### PR TITLE
Add items

### DIFF
--- a/inventory_management_system_api/core/database.py
+++ b/inventory_management_system_api/core/database.py
@@ -8,7 +8,8 @@ from inventory_management_system_api.core.config import config
 
 db_config = config.database
 mongodb_client = MongoClient(
-    f"{db_config.protocol}://{db_config.username}:{db_config.password}@{db_config.hostname}:{db_config.port}"
+    f"{db_config.protocol}://{db_config.username}:{db_config.password}@{db_config.hostname}:{db_config.port}",
+    tz_aware=True,
 )
 
 

--- a/inventory_management_system_api/main.py
+++ b/inventory_management_system_api/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 
 from inventory_management_system_api.core.config import config
 from inventory_management_system_api.core.logger_setup import setup_logger
-from inventory_management_system_api.routers.v1 import catalogue_category, catalogue_item, system, manufacturer
+from inventory_management_system_api.routers.v1 import catalogue_category, catalogue_item, system, manufacturer, item
 
 app = FastAPI(title=config.api.title, description=config.api.description)
 
@@ -64,6 +64,7 @@ app.add_middleware(
 
 app.include_router(catalogue_category.router)
 app.include_router(catalogue_item.router)
+app.include_router(item.router)
 app.include_router(manufacturer.router)
 app.include_router(system.router)
 

--- a/inventory_management_system_api/models/item.py
+++ b/inventory_management_system_api/models/item.py
@@ -1,0 +1,55 @@
+"""
+Module for defining the database models for representing items.
+"""
+from typing import Optional, List, Any
+
+from pydantic import BaseModel, Field, ConfigDict, field_validator, AwareDatetime
+
+from inventory_management_system_api.models.catalogue_item import Property
+from inventory_management_system_api.models.custom_object_id_data_types import CustomObjectIdField, StringObjectIdField
+
+
+class ItemIn(BaseModel):
+    """
+    Input database model for an item.
+    """
+
+    catalogue_item_id: CustomObjectIdField
+    system_id: Optional[CustomObjectIdField] = None
+    purchase_order_number: Optional[str] = None
+    is_defective: bool
+    usage_status: int
+    warranty_end_date: Optional[AwareDatetime] = None
+    asset_number: Optional[str] = None
+    serial_number: Optional[str] = None
+    delivered_date: Optional[AwareDatetime] = None
+    notes: Optional[str] = None
+    catalogue_item_override_properties: List[Property] = []
+
+    @field_validator("catalogue_item_override_properties", mode="before")
+    @classmethod
+    def validate_catalogue_item_override_properties(cls, catalogue_item_override_properties: Any) -> Any:
+        """
+        Validator for the `catalogue_item_override_properties` field that runs after field assignment but before type
+        validation.
+
+        If the value is `None`, it replaces it with an empty list allowing for items without override properties to be
+        created.
+
+        :param catalogue_item_override_properties: The list of override properties.
+        :return: The list of override properties or an empty list.
+        """
+        if catalogue_item_override_properties is None:
+            catalogue_item_override_properties = []
+        return catalogue_item_override_properties
+
+
+class ItemOut(ItemIn):
+    """
+    Output database model for an item.
+    """
+
+    id: StringObjectIdField = Field(alias="_id")
+    catalogue_item_id: StringObjectIdField
+    system_id: Optional[StringObjectIdField] = None
+    model_config = ConfigDict(populate_by_name=True)

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -8,6 +8,8 @@ from pymongo.collection import Collection
 from pymongo.database import Database
 
 from inventory_management_system_api.core.database import get_database
+from inventory_management_system_api.core.exceptions import MissingRecordError
+from inventory_management_system_api.models.item import ItemIn, ItemOut
 
 logger = logging.getLogger()
 
@@ -25,3 +27,21 @@ class ItemRepo:
         """
         self._database = database
         self._items_collection: Collection = self._database.items
+        self._systems_collection: Collection = self._database.systems
+
+    def create(self, item: ItemIn) -> ItemOut:
+        """
+        Create a new item in a MongoDB database.
+
+        :param item: The item to be created.
+        :return: The created item.
+        """
+        if item.system_id and not self._systems_collection.find_one({"_id": item.system_id}):
+            raise MissingRecordError(f"No system found with ID: {item.system_id}")
+
+        logger.info("Inserting the new item into the database")
+        result = self._items_collection.insert_one(item.model_dump())
+
+        # pylint: disable=fixme
+        # TODO - Use the `get` repo method when implemented to get the item
+        return ItemOut(**self._items_collection.find_one({"_id": result.inserted_id}))

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -1,0 +1,27 @@
+"""
+Module for providing a repository for managing items in a MongoDB database.
+"""
+import logging
+
+from fastapi import Depends
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+from inventory_management_system_api.core.database import get_database
+
+logger = logging.getLogger()
+
+
+class ItemRepo:
+    """
+    Repository for managing items in a MongoDB database.
+    """
+
+    def __init__(self, database: Database = Depends(get_database)) -> None:
+        """
+        Initialize the `ItemRepo` with a MongoDB database instance.
+
+        :param database: The database to use.
+        """
+        self._database = database
+        self._items_collection: Collection = self._database.items

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -3,8 +3,48 @@ Module for providing an API router which defines routes for managing items using
 """
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status, HTTPException, Depends
+
+from inventory_management_system_api.core.exceptions import (
+    InvalidObjectIdError,
+    MissingRecordError,
+    DatabaseIntegrityError,
+    InvalidCatalogueItemPropertyTypeError,
+)
+from inventory_management_system_api.schemas.item import ItemPostRequestSchema, ItemSchema
+from inventory_management_system_api.services.item import ItemService
 
 logger = logging.getLogger()
 
 router = APIRouter(prefix="/v1/items", tags=["items"])
+
+
+@router.post(
+    path="/",
+    summary="Create a new item",
+    response_description="The created item",
+    status_code=status.HTTP_201_CREATED,
+)
+def create_item(item: ItemPostRequestSchema, item_service: ItemService = Depends()) -> ItemSchema:
+    # pylint: disable=missing-function-docstring
+    logger.info("Creating a new item")
+    logger.debug("Item data: %s", item)
+    try:
+        item = item_service.create(item)
+        return ItemSchema(**item.model_dump())
+    except InvalidCatalogueItemPropertyTypeError as exc:
+        logger.exception(str(exc))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except (MissingRecordError, InvalidObjectIdError) as exc:
+        if item.system_id and item.system_id in str(exc) or "system" in str(exc).lower():
+            message = "The specified system ID does not exist"
+            logger.exception(message)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
+
+        message = "The specified catalogue item ID does not exist"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
+    except DatabaseIntegrityError as exc:
+        message = "Unable to create item"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -1,0 +1,10 @@
+"""
+Module for providing an API router which defines routes for managing items using the `ItemService` service.
+"""
+import logging
+
+from fastapi import APIRouter
+
+logger = logging.getLogger()
+
+router = APIRouter(prefix="/v1/items", tags=["items"])

--- a/inventory_management_system_api/schemas/item.py
+++ b/inventory_management_system_api/schemas/item.py
@@ -1,0 +1,53 @@
+"""
+Module for defining the API schema models for representing items.
+"""
+from enum import Enum
+from typing import Optional, List
+
+from pydantic import BaseModel, Field, AwareDatetime
+
+from inventory_management_system_api.schemas.catalogue_item import PropertyPostRequestSchema, PropertySchema
+
+
+class ItemUsageStatus(int, Enum):
+    """
+    Enumeration for item usage statuses.
+    """
+
+    NEW = 0
+    IN_USE = 1
+    USED = 2
+    SCRAPPED = 3
+
+
+class ItemPostRequestSchema(BaseModel):
+    """
+    Schema model for an item creation request.
+    """
+
+    catalogue_item_id: str = Field(description="The ID of the corresponding catalogue item for this item")
+    system_id: Optional[str] = Field(default=None, description="The ID of the system that the item belongs to")
+    purchase_order_number: Optional[str] = Field(default=None, description="The purchase order number of the item")
+    is_defective: bool = Field(description="Whether the item is defective or not")
+    usage_status: ItemUsageStatus = Field(
+        description="The usage status of the item. 0 means new, 1 means in use, 2 means used, and 3 means scrapped."
+    )
+    warranty_end_date: Optional[AwareDatetime] = Field(default=None, description="The warranty end date of the item")
+    asset_number: Optional[str] = Field(default=None, description="The asset number of the item")
+    serial_number: Optional[str] = Field(default=None, description="The serial number of the item")
+    delivered_date: Optional[AwareDatetime] = Field(default=None, description="The date the item was delivered")
+    notes: Optional[str] = Field(default=None, description="Any notes about the item")
+    catalogue_item_override_properties: Optional[List[PropertyPostRequestSchema]] = Field(
+        default=None, description="The overriden catalogue item properties specific to this item"
+    )
+
+
+class ItemSchema(ItemPostRequestSchema):
+    """
+    Schema model for an item response.
+    """
+
+    id: str = Field(description="The ID of the item")
+    catalogue_item_override_properties: List[PropertySchema] = Field(
+        description="The overriden catalogue item properties specific to this item"
+    )

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -3,27 +3,20 @@ Module for providing a service for managing catalogue items using the `Catalogue
 repositories.
 """
 import logging
-from numbers import Number
-from typing import Optional, List, Dict, Union
+from typing import Optional, List
 
 from fastapi import Depends
 
-from inventory_management_system_api.core.exceptions import (
-    MissingRecordError,
-    NonLeafCategoryError,
-    InvalidCatalogueItemPropertyTypeError,
-    MissingMandatoryCatalogueItemProperty,
-)
-from inventory_management_system_api.models.catalogue_category import CatalogueItemProperty
+from inventory_management_system_api.core.exceptions import MissingRecordError, NonLeafCategoryError
 from inventory_management_system_api.models.catalogue_item import CatalogueItemOut, CatalogueItemIn
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
-from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyType
 from inventory_management_system_api.schemas.catalogue_item import (
     CatalogueItemPostRequestSchema,
     CatalogueItemPatchRequestSchema,
     PropertyPostRequestSchema,
 )
+from inventory_management_system_api.services import utils
 
 logger = logging.getLogger()
 
@@ -76,7 +69,7 @@ class CatalogueItemService:
 
         defined_properties = catalogue_category.catalogue_item_properties
         supplied_properties = catalogue_item.properties if catalogue_item.properties else []
-        supplied_properties = self._process_catalogue_item_properties(defined_properties, supplied_properties)
+        supplied_properties = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
 
         return self._catalogue_item_repository.create(
             CatalogueItemIn(
@@ -174,157 +167,9 @@ class CatalogueItemService:
 
             defined_properties = catalogue_category.catalogue_item_properties
             supplied_properties = catalogue_item.properties
-            update_data["properties"] = self._process_catalogue_item_properties(defined_properties, supplied_properties)
+            update_data["properties"] = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
 
         return self._catalogue_item_repository.update(
             catalogue_item_id,
             CatalogueItemIn(**{**stored_catalogue_item.model_dump(), **update_data}),
         )
-
-    def _process_catalogue_item_properties(
-        self, defined_properties: List[CatalogueItemProperty], supplied_properties: List[PropertyPostRequestSchema]
-    ) -> List[Dict]:
-        """
-        Process and validate supplied catalogue item properties based on defined catalogue item properties. It checks
-        for missing mandatory catalogue item properties, files the matching catalogue item properties, adds the property
-        units, and finally validates the property values.
-
-        The `supplied_properties_dict` dictionary may get modified as part of the processing and validation.
-
-        :param defined_properties: The list of defined catalogue item property objects.
-        :param supplied_properties: The list of supplied catalogue item property objects.
-        :return: A list of processed and validated supplied catalogue item properties.
-        """
-        # Convert properties to dictionaries for easier lookups
-        defined_properties_dict = self._create_catalogue_item_properties_dict(defined_properties)
-        supplied_properties_dict = self._create_catalogue_item_properties_dict(supplied_properties)
-
-        # Some mandatory catalogue item properties may not have been supplied
-        self._check_missing_mandatory_catalogue_item_properties(defined_properties_dict, supplied_properties_dict)
-        # Catalogue item properties that have not been defined may have been supplied
-        supplied_properties_dict = self._filter_matching_catalogue_item_properties(
-            defined_properties_dict, supplied_properties_dict
-        )
-        # Supplied catalogue item properties do not have units as we can't trust they would be correct
-        self._add_catalogue_item_property_units(defined_properties_dict, supplied_properties_dict)
-        # The values of the supplied catalogue item properties may not be of the expected types
-        self._validate_catalogue_item_property_values(defined_properties_dict, supplied_properties_dict)
-
-        return list(supplied_properties_dict.values())
-
-    def _create_catalogue_item_properties_dict(
-        self, catalogue_item_properties: Union[List[CatalogueItemProperty], List[PropertyPostRequestSchema]]
-    ) -> Dict[str, Dict]:
-        """
-        Convert a list of catalogue item property objects into a dictionary where the keys are the catalogue item
-        property names and the values are the catalogue item property dictionaries.
-
-        :param catalogue_item_properties: The list of catalogue item property objects.
-        :return: A dictionary where the keys are the catalogue item property names and the values are the catalogue item
-            property dictionaries.
-        """
-        return {
-            catalogue_item_property.name: catalogue_item_property.model_dump()
-            for catalogue_item_property in catalogue_item_properties
-        }
-
-    def _add_catalogue_item_property_units(
-        self,
-        defined_properties: Dict[str, Dict],
-        supplied_properties: Dict[str, Dict],
-    ) -> None:
-        """
-        Add the units to the supplied properties.
-
-        The supplied properties only contain a name and value so the units from the defined properties in the database
-        are added to the supplied properties. This means that this method modifies the `supplied_properties` dictionary.
-
-        :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
-            database.
-        :param supplied_properties: The supplied catalogue item properties.
-        """
-        logger.info("Adding the units to the supplied properties")
-        for supplied_property_name, supplied_property in supplied_properties.items():
-            supplied_property["unit"] = defined_properties[supplied_property_name]["unit"]
-
-    def _validate_catalogue_item_property_values(
-        self,
-        defined_properties: Dict[str, Dict],
-        supplied_properties: Dict[str, Dict],
-    ) -> None:
-        """
-        Validate the values of the supplied properties against the expected property types. Raise an error if the type
-        of the supplied value does not match the expected type.
-
-        :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
-            database.
-        :param supplied_properties: The supplied catalogue item properties.
-        :raises InvalidCatalogueItemPropertyTypeError: If the type of the supplied value does not match the expected
-            type.
-        """
-        logger.info("Validating the values of the supplied properties against the expected property types")
-        for supplied_property_name, supplied_property in supplied_properties.items():
-            expected_property_type = defined_properties[supplied_property_name]["type"]
-            supplied_property_value = supplied_property["value"]
-
-            if expected_property_type == CatalogueItemPropertyType.STRING and not isinstance(
-                supplied_property_value, str
-            ):
-                raise InvalidCatalogueItemPropertyTypeError(
-                    f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: string."
-                )
-            if expected_property_type == CatalogueItemPropertyType.NUMBER and not isinstance(
-                supplied_property_value, Number
-            ):
-                raise InvalidCatalogueItemPropertyTypeError(
-                    f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: number."
-                )
-            if expected_property_type == CatalogueItemPropertyType.BOOLEAN and not isinstance(
-                supplied_property_value, bool
-            ):
-                raise InvalidCatalogueItemPropertyTypeError(
-                    f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: "
-                    f"boolean."
-                )
-
-    def _check_missing_mandatory_catalogue_item_properties(
-        self,
-        defined_properties: Dict[str, Dict],
-        supplied_properties: Dict[str, Dict],
-    ) -> None:
-        """
-        Check for mandatory catalogue item properties that are missing/ have not been supplied. Raise an error as soon
-        as a mandatory property is found to be missing.
-
-        :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
-            database.
-        :param supplied_properties: The supplied catalogue item properties.
-        :raises MissingMandatoryCatalogueItemProperty: If a mandatory catalogue item property is missing/ not supplied.
-        """
-        logger.info("Checking for missing mandatory catalogue item properties")
-        for defined_property_name, defined_property in defined_properties.items():
-            if defined_property["mandatory"] and defined_property_name not in supplied_properties:
-                raise MissingMandatoryCatalogueItemProperty(
-                    f"Missing mandatory catalogue item property: '{defined_property_name}'"
-                )
-
-    def _filter_matching_catalogue_item_properties(
-        self,
-        defined_properties: Dict[str, Dict],
-        supplied_properties: Dict[str, Dict],
-    ) -> Dict[str, Dict]:
-        """
-        Filter through the supplied properties and extract the ones matching the defined properties.
-
-        :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
-            database.
-        :param supplied_properties: The supplied catalogue item properties.
-        :return: The supplied properties that are matching the defined properties.
-        """
-        logger.info("Extracting the supplied properties that are matching the defined properties")
-        matching_properties = {}
-        for supplied_property_name, supplied_property in supplied_properties.items():
-            if supplied_property_name in defined_properties:
-                matching_properties[supplied_property_name] = supplied_property
-
-        return matching_properties

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -1,0 +1,24 @@
+"""
+Module for providing a service for managing items using the `ItemRepo` repository.
+"""
+
+import logging
+
+from fastapi import Depends
+
+from inventory_management_system_api.repositories.item import ItemRepo
+
+logger = logging.getLogger()
+
+
+class ItemService:
+    """
+    Service for managing items.
+    """
+
+    def __init__(self, item_repository: ItemRepo = Depends(ItemRepo)) -> None:
+        """
+        Initialise the `ItemService` with an `ItemRepo` repo.
+
+        :param item_repository: The `ItemRepo` repository to use."""
+        self._item_repository = item_repository

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -1,12 +1,23 @@
 """
-Module for providing a service for managing items using the `ItemRepo` repository.
+Module for providing a service for managing items using the `ItemRepo`, `CatalogueCategoryRepo`, and `CatalogueItemRepo`
+repositories.
 """
 
 import logging
 
 from fastapi import Depends
 
+from inventory_management_system_api.core.exceptions import (
+    MissingRecordError,
+    DatabaseIntegrityError,
+    InvalidObjectIdError,
+)
+from inventory_management_system_api.models.item import ItemOut, ItemIn
+from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
+from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
+from inventory_management_system_api.schemas.item import ItemPostRequestSchema
+from inventory_management_system_api.services import utils
 
 logger = logging.getLogger()
 
@@ -16,9 +27,55 @@ class ItemService:
     Service for managing items.
     """
 
-    def __init__(self, item_repository: ItemRepo = Depends(ItemRepo)) -> None:
+    def __init__(
+        self,
+        item_repository: ItemRepo = Depends(ItemRepo),
+        catalogue_category_repository: CatalogueCategoryRepo = Depends(CatalogueCategoryRepo),
+        catalogue_item_repository: CatalogueItemRepo = Depends(CatalogueItemRepo),
+    ) -> None:
         """
-        Initialise the `ItemService` with an `ItemRepo` repo.
+        Initialise the `ItemService` with an `ItemRepo`, `CatalogueCategoryRepo`, and `CatalogueItemRepo` repos.
 
-        :param item_repository: The `ItemRepo` repository to use."""
+        :param item_repository: The `ItemRepo` repository to use.
+        :param catalogue_category_repository: The `CatalogueCategoryRepo` repository to use.
+        :param catalogue_item_repository: The `CatalogueItemRepo` repository to use.
+        """
         self._item_repository = item_repository
+        self._catalogue_category_repository = catalogue_category_repository
+        self._catalogue_item_repository = catalogue_item_repository
+
+    def create(self, item: ItemPostRequestSchema) -> ItemOut:
+        """
+        Create a new item.
+
+        :param item: The item to be created.
+        :return: The created item.
+        :raises MissingRecordError: If the catalogue item does not exist.
+        """
+        catalogue_item_id = item.catalogue_item_id
+        catalogue_item = self._catalogue_item_repository.get(catalogue_item_id)
+        if not catalogue_item:
+            raise MissingRecordError(f"No catalogue item found with ID: {catalogue_item_id}")
+
+        try:
+            catalogue_category_id = catalogue_item.catalogue_category_id
+            catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
+            if not catalogue_category:
+                raise DatabaseIntegrityError(f"No catalogue category found with ID: {catalogue_category_id}")
+        except InvalidObjectIdError as exc:
+            raise DatabaseIntegrityError(str(exc)) from exc
+
+        defined_properties = catalogue_category.catalogue_item_properties
+        supplied_properties = item.catalogue_item_override_properties if item.catalogue_item_override_properties else []
+        supplied_properties = utils.process_catalogue_item_properties(
+            defined_properties, supplied_properties, skip_missing_mandatory_check=True
+        )
+
+        return self._item_repository.create(
+            ItemIn(
+                **{
+                    **item.model_dump(),
+                    "catalogue_item_override_properties": supplied_properties,
+                }
+            )
+        )

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -4,6 +4,16 @@ Collection of some utility functions used by services
 
 import logging
 import re
+from numbers import Number
+from typing import Dict, Union, List
+
+from inventory_management_system_api.core.exceptions import (
+    MissingMandatoryCatalogueItemProperty,
+    InvalidCatalogueItemPropertyTypeError,
+)
+from inventory_management_system_api.models.catalogue_category import CatalogueItemProperty
+from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyType
+from inventory_management_system_api.schemas.catalogue_item import PropertyPostRequestSchema
 
 logger = logging.getLogger()
 
@@ -23,3 +33,156 @@ def generate_code(name: str, entity_type: str) -> str:
     logger.info("Generating code for the %s based on its name", entity_type)
     name = name.lower().strip()
     return re.sub(r"\s+", "-", name)
+
+
+def process_catalogue_item_properties(
+    defined_properties: List[CatalogueItemProperty],
+    supplied_properties: List[PropertyPostRequestSchema],
+    skip_missing_mandatory_check: bool = False,
+) -> List[Dict]:
+    """
+    Process and validate supplied catalogue item properties based on defined catalogue item properties. It checks
+    for missing mandatory catalogue item properties unless otherwise instructed, filters the matching catalogue item
+    properties, adds the property units, and finally validates the property values.
+
+    The `supplied_properties_dict` dictionary may get modified as part of the processing and validation.
+
+    :param defined_properties: The list of defined catalogue item property objects.
+    :param supplied_properties: The list of supplied catalogue item property objects.
+    :param skip_missing_mandatory_check: Whether to skip the check for missing mandatory catalogue item properties.
+        Default is `False`.
+    :return: A list of processed and validated supplied catalogue item properties.
+    """
+    # Convert properties to dictionaries for easier lookups
+    defined_properties_dict = _create_catalogue_item_properties_dict(defined_properties)
+    supplied_properties_dict = _create_catalogue_item_properties_dict(supplied_properties)
+
+    if not skip_missing_mandatory_check:
+        # Some mandatory catalogue item properties may not have been supplied
+        _check_missing_mandatory_catalogue_item_properties(defined_properties_dict, supplied_properties_dict)
+    # Catalogue item properties that have not been defined may have been supplied
+    supplied_properties_dict = _filter_matching_catalogue_item_properties(
+        defined_properties_dict, supplied_properties_dict
+    )
+    # Supplied catalogue item properties do not have units as we can't trust they would be correct
+    _add_catalogue_item_property_units(defined_properties_dict, supplied_properties_dict)
+    # The values of the supplied catalogue item properties may not be of the expected types
+    _validate_catalogue_item_property_values(defined_properties_dict, supplied_properties_dict)
+
+    return list(supplied_properties_dict.values())
+
+
+def _create_catalogue_item_properties_dict(
+    catalogue_item_properties: Union[List[CatalogueItemProperty], List[PropertyPostRequestSchema]]
+) -> Dict[str, Dict]:
+    """
+    Convert a list of catalogue item property objects into a dictionary where the keys are the catalogue item
+    property names and the values are the catalogue item property dictionaries.
+
+    :param catalogue_item_properties: The list of catalogue item property objects.
+    :return: A dictionary where the keys are the catalogue item property names and the values are the catalogue item
+        property dictionaries.
+    """
+    return {
+        catalogue_item_property.name: catalogue_item_property.model_dump()
+        for catalogue_item_property in catalogue_item_properties
+    }
+
+
+def _add_catalogue_item_property_units(
+    defined_properties: Dict[str, Dict],
+    supplied_properties: Dict[str, Dict],
+) -> None:
+    """
+    Add the units to the supplied properties.
+
+    The supplied properties only contain a name and value so the units from the defined properties in the database
+    are added to the supplied properties. This means that this method modifies the `supplied_properties` dictionary.
+
+    :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
+        database.
+    :param supplied_properties: The supplied catalogue item properties.
+    """
+    logger.info("Adding the units to the supplied properties")
+    for supplied_property_name, supplied_property in supplied_properties.items():
+        supplied_property["unit"] = defined_properties[supplied_property_name]["unit"]
+
+
+def _validate_catalogue_item_property_values(
+    defined_properties: Dict[str, Dict],
+    supplied_properties: Dict[str, Dict],
+) -> None:
+    """
+    Validate the values of the supplied properties against the expected property types. Raise an error if the type
+    of the supplied value does not match the expected type.
+
+    :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
+        database.
+    :param supplied_properties: The supplied catalogue item properties.
+    :raises InvalidCatalogueItemPropertyTypeError: If the type of the supplied value does not match the expected
+        type.
+    """
+    logger.info("Validating the values of the supplied properties against the expected property types")
+    for supplied_property_name, supplied_property in supplied_properties.items():
+        expected_property_type = defined_properties[supplied_property_name]["type"]
+        supplied_property_value = supplied_property["value"]
+
+        if expected_property_type == CatalogueItemPropertyType.STRING and not isinstance(supplied_property_value, str):
+            raise InvalidCatalogueItemPropertyTypeError(
+                f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: string."
+            )
+        if expected_property_type == CatalogueItemPropertyType.NUMBER and not isinstance(
+            supplied_property_value, Number
+        ):
+            raise InvalidCatalogueItemPropertyTypeError(
+                f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: number."
+            )
+        if expected_property_type == CatalogueItemPropertyType.BOOLEAN and not isinstance(
+            supplied_property_value, bool
+        ):
+            raise InvalidCatalogueItemPropertyTypeError(
+                f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: "
+                f"boolean."
+            )
+
+
+def _check_missing_mandatory_catalogue_item_properties(
+    defined_properties: Dict[str, Dict],
+    supplied_properties: Dict[str, Dict],
+) -> None:
+    """
+    Check for mandatory catalogue item properties that are missing/ have not been supplied. Raise an error as soon
+    as a mandatory property is found to be missing.
+
+    :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
+        database.
+    :param supplied_properties: The supplied catalogue item properties.
+    :raises MissingMandatoryCatalogueItemProperty: If a mandatory catalogue item property is missing/ not supplied.
+    """
+    logger.info("Checking for missing mandatory catalogue item properties")
+    for defined_property_name, defined_property in defined_properties.items():
+        if defined_property["mandatory"] and defined_property_name not in supplied_properties:
+            raise MissingMandatoryCatalogueItemProperty(
+                f"Missing mandatory catalogue item property: '{defined_property_name}'"
+            )
+
+
+def _filter_matching_catalogue_item_properties(
+    defined_properties: Dict[str, Dict],
+    supplied_properties: Dict[str, Dict],
+) -> Dict[str, Dict]:
+    """
+    Filter through the supplied properties and extract the ones matching the defined properties.
+
+    :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
+        database.
+    :param supplied_properties: The supplied catalogue item properties.
+    :return: The supplied properties that are matching the defined properties.
+    """
+    logger.info("Extracting the supplied properties that are matching the defined properties")
+    matching_properties = {}
+    for supplied_property_name, supplied_property in supplied_properties.items():
+        if supplied_property_name in defined_properties:
+            matching_properties[supplied_property_name] = supplied_property
+
+    return matching_properties

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -27,5 +27,6 @@ def fixture_cleanup_database_collections():
     yield
     database.catalogue_categories.delete_many({})
     database.catalogue_items.delete_many({})
+    database.items.delete_many({})
     database.manufacturers.delete_many({})
     database.systems.delete_many({})

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY
 
 from bson import ObjectId
 
-
+# pylint: disable=duplicate-code
 CATALOGUE_CATEGORY_POST_A = {
     "name": "Category A",
     "is_leaf": True,
@@ -15,6 +15,7 @@ CATALOGUE_CATEGORY_POST_A = {
         {"name": "Property C", "type": "string", "unit": "cm", "mandatory": True},
     ],
 }
+# pylint: enable=duplicate-code
 
 CATALOGUE_CATEGORY_POST_B = {
     "name": "Category B",

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -1,0 +1,246 @@
+"""
+End-to-End tests for the catalogue item router.
+"""
+from unittest.mock import ANY
+
+from bson import ObjectId
+
+# pylint: disable=duplicate-code
+CATALOGUE_CATEGORY_POST_A = {
+    "name": "Category A",
+    "is_leaf": True,
+    "catalogue_item_properties": [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "boolean", "mandatory": True},
+        {"name": "Property C", "type": "string", "unit": "cm", "mandatory": True},
+    ],
+}
+
+CATALOGUE_ITEM_POST_A = {
+    "manufacturer": {
+        "name": "Manufacturer A",
+        "address": "1 Address, City, Country, Postcode",
+        "url": "https://www.manufacturer-a.co.uk/",
+    },
+    "name": "Catalogue Item A",
+    "description": "This is Catalogue Item A",
+    "cost_gbp": 129.99,
+    "days_to_replace": 2.0,
+    "drawing_link": "https://drawing-link.com/",
+    "item_model_number": "abc123",
+    "is_obsolete": False,
+    "properties": [
+        {"name": "Property A", "value": 20},
+        {"name": "Property B", "value": False},
+        {"name": "Property C", "value": "20x15x10"},
+    ],
+}
+
+SYSTEM_POST_A = {
+    "name": "System A",
+    "description": "System description",
+    "location": "Test location",
+    "owner": "Me",
+    "importance": "low",
+}
+# pylint: enable=duplicate-code
+
+ITEM_POST = {
+    "is_defective": False,
+    "usage_status": 0,
+    "warranty_end_date": "2015-11-15T23:59:59Z",
+    "serial_number": "xyz123",
+    "delivered_date": "2012-12-05T12:00:00Z",
+    "notes": "Test notes",
+    "catalogue_item_override_properties": [{"name": "Property A", "value": 21}],
+}
+
+ITEM_POST_EXPECTED = {
+    **ITEM_POST,
+    "id": ANY,
+    "purchase_order_number": None,
+    "asset_number": None,
+    "catalogue_item_override_properties": [{"name": "Property A", "value": 21, "unit": "mm"}],
+}
+
+
+def test_create_item(test_client):
+    """
+    Test creating an item.
+    """
+    response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
+    system_id = response.json()["id"]
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 201
+
+    item = response.json()
+
+    assert item == {**ITEM_POST_EXPECTED, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
+
+
+def test_create_item_with_invalid_catalogue_item_id(test_client):
+    """
+    Test creating an item with an invalid catalogue item ID.
+    """
+    item_post = {**ITEM_POST, "catalogue_item_id": "invalid", "system_id": str(ObjectId())}
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "The specified catalogue item ID does not exist"
+
+
+def test_create_item_with_non_existent_catalogue_item_id(test_client):
+    """
+    Test creating an item with a non-existent catalogue item ID.
+    """
+    item_post = {**ITEM_POST, "catalogue_item_id": str(ObjectId()), "system_id": str(ObjectId())}
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "The specified catalogue item ID does not exist"
+
+
+def test_create_item_with_invalid_system_id(test_client):
+    """
+    Test creating an item with an invalid system ID.
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    item_post = {**ITEM_POST, "catalogue_item_id": response.json()["id"], "system_id": "invalid"}
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "The specified system ID does not exist"
+
+
+def test_create_item_with_non_existent_system_id(test_client):
+    """
+    Test creating an item with a non-existent system ID.
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    item_post = {**ITEM_POST, "catalogue_item_id": response.json()["id"], "system_id": str(ObjectId())}
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "The specified system ID does not exist"
+
+
+def test_create_item_without_catalogue_item_override_properties(test_client):
+    """
+    Testing creating an item without catalogue item override properties.
+    """
+    response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
+    system_id = response.json()["id"]
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    item_post = {
+        **ITEM_POST,
+        "catalogue_item_id": catalogue_item_id,
+        "system_id": system_id,
+        "catalogue_item_override_properties": [],
+    }
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 201
+
+    item = response.json()
+
+    assert item == {
+        **ITEM_POST_EXPECTED,
+        "catalogue_item_id": catalogue_item_id,
+        "system_id": system_id,
+        "catalogue_item_override_properties": [],
+    }
+
+
+def test_create_item_with_invalid_value_type_for_string_property(test_client):
+    """
+    Test creating an item with invalid value type for a string catalogue item property.
+    """
+    response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
+    system_id = response.json()["id"]
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    item_post = {
+        **ITEM_POST,
+        "catalogue_item_id": catalogue_item_id,
+        "system_id": system_id,
+        "catalogue_item_override_properties": [{"name": "Property C", "value": True}],
+    }
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == "Invalid value type for catalogue item property 'Property C'. Expected type: string."
+    )
+
+
+def test_create_item_with_invalid_value_type_for_number_property(test_client):
+    """
+    Test creating an item with invalid value type for a number catalogue item property.
+    """
+    response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
+    system_id = response.json()["id"]
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    item_post = {
+        **ITEM_POST,
+        "catalogue_item_id": catalogue_item_id,
+        "system_id": system_id,
+        "catalogue_item_override_properties": [{"name": "Property A", "value": "20"}],
+    }
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == "Invalid value type for catalogue item property 'Property A'. Expected type: number."
+    )
+
+
+def test_create_item_with_invalid_value_type_for_boolean_property(test_client):
+    """
+    Test creating an item with invalid value type for a boolean catalogue item property.
+    """
+    response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
+    system_id = response.json()["id"]
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_item_post = {**CATALOGUE_ITEM_POST_A, "catalogue_category_id": response.json()["id"]}
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    item_post = {
+        **ITEM_POST,
+        "catalogue_item_id": catalogue_item_id,
+        "system_id": system_id,
+        "catalogue_item_override_properties": [{"name": "Property B", "value": "False"}],
+    }
+    response = test_client.post("/v1/items", json=item_post)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == "Invalid value type for catalogue item property 'Property B'. Expected type: boolean."
+    )

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -13,6 +13,7 @@ from pymongo.results import DeleteResult, InsertOneResult, UpdateResult
 
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
+from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
 from inventory_management_system_api.repositories.system import SystemRepo
 
@@ -28,6 +29,7 @@ def fixture_database_mock() -> Mock:
     database_mock = Mock(Database)
     database_mock.catalogue_categories = Mock(Collection)
     database_mock.catalogue_items = Mock(Collection)
+    database_mock.items = Mock(Collection)
     database_mock.manufacturers = Mock(Collection)
     database_mock.systems = Mock(Collection)
     return database_mock
@@ -53,6 +55,17 @@ def fixture_catalogue_item_repository(database_mock: Mock) -> CatalogueItemRepo:
     :return: `CatalogueItemRepo` instance with the mocked dependency.
     """
     return CatalogueItemRepo(database_mock)
+
+
+@pytest.fixture(name="item_repository")
+def fixture_item_repository(database_mock: Mock) -> ItemRepo:
+    """
+    Fixture to create a `ItemRepo` instance with a mocked Database dependency.
+
+    :param database_mock: Mocked MongoDB database instance.
+    :return: `ItemRepo` instance with the mocked dependency.
+    """
+    return ItemRepo(database_mock)
 
 
 @pytest.fixture(name="manufacturer_repository")

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for the `ItemRepo` repository.
+"""
+import pytest
+from bson import ObjectId
+
+from inventory_management_system_api.core.custom_object_id import CustomObjectId
+from inventory_management_system_api.core.exceptions import MissingRecordError
+from inventory_management_system_api.models.item import ItemOut, ItemIn
+
+# pylint: disable=duplicate-code
+FULL_SYSTEM_A_INFO = {
+    "parent_id": None,
+    "name": "System A",
+    "description": "System description",
+    "location": "Test location",
+    "owner": "Me",
+    "importance": "low",
+    "code": "system-a",
+}
+
+ITEM_INFO = {
+    "is_defective": False,
+    "usage_status": 0,
+    "warranty_end_date": "2015-11-15T23:59:59Z",
+    "serial_number": "xyz123",
+    "delivered_date": "2012-12-05T12:00:00Z",
+    "notes": "Test notes",
+    "catalogue_item_override_properties": [{"name": "Property A", "value": 21}],
+}
+
+FULL_ITEM_INFO = {
+    **ITEM_INFO,
+    "purchase_order_number": None,
+    "asset_number": None,
+    "catalogue_item_override_properties": [{"name": "Property A", "value": 21, "unit": "mm"}],
+}
+# pylint: enable=duplicate-code
+
+
+def test_create(test_helpers, database_mock, item_repository):
+    """
+    Test creating an item.
+    """
+    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+
+    # Mock `find_one` to return a system
+    test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(item.system_id), **FULL_SYSTEM_A_INFO})
+    # Mock `insert_one` to return an object for the inserted item document
+    test_helpers.mock_insert_one(database_mock.items, CustomObjectId(item.id))
+    # Mock `find_one` to return the inserted item document
+    test_helpers.mock_find_one(
+        database_mock.items,
+        {
+            "_id": CustomObjectId(item.id),
+            "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
+            "system_id": CustomObjectId(item.system_id),
+            **FULL_ITEM_INFO,
+        },
+    )
+
+    item_in = ItemIn(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **FULL_ITEM_INFO)
+    created_item = item_repository.create(item_in)
+
+    database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(item.system_id)})
+    database_mock.items.insert_one.assert_called_once_with(item_in.model_dump())
+    assert created_item == item
+
+
+def test_create_with_non_existent_system_id(test_helpers, database_mock, item_repository):
+    """
+    Test creating an item with a non-existent system ID.
+    """
+    system_id = str(ObjectId())
+
+    # Mock `find_one` to return a system
+    test_helpers.mock_find_one(database_mock.systems, None)
+
+    with pytest.raises(MissingRecordError) as exc:
+        item_repository.create(ItemIn(catalogue_item_id=str(ObjectId()), system_id=system_id, **FULL_ITEM_INFO))
+
+    database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(system_id)})
+    database_mock.items.insert_one.assert_not_called()
+    assert str(exc.value) == f"No system found with ID: {system_id}"

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -9,12 +9,14 @@ import pytest
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
 from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
+from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
 from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService
+from inventory_management_system_api.services.item import ItemService
 from inventory_management_system_api.services.manufacturer import ManufacturerService
 from inventory_management_system_api.services.system import SystemService
 
@@ -37,6 +39,16 @@ def fixture_catalogue_item_repository_mock() -> Mock:
     :return: Mocked CatalogueItemRepo instance.
     """
     return Mock(CatalogueItemRepo)
+
+
+@pytest.fixture(name="item_repository_mock")
+def fixture_item_repository_mock() -> Mock:
+    """
+    Fixture to create a mock of the `ItemRepo` dependency.
+
+    :return: Mocked ItemRepo instance.
+    """
+    return Mock(ItemRepo)
 
 
 @pytest.fixture(name="manufacturer_repository_mock")
@@ -83,6 +95,22 @@ def fixture_catalogue_item_service(
     :return: `CatalogueItemService` instance with the mocked dependency.
     """
     return CatalogueItemService(catalogue_item_repository_mock, catalogue_category_repository_mock)
+
+
+@pytest.fixture(name="item_service")
+def fixture_item_service(
+    item_repository_mock: Mock, catalogue_category_repository_mock: Mock, catalogue_item_repository_mock: Mock
+) -> ItemService:
+    """
+    Fixture to create an `ItemService` instance with mocked `ItemRepo`, `CatalogueItemRepo`, and
+    `CatalogueCategoryRepo` dependencies.
+
+    :param item_repository_mock: Mocked `ItemRepo` instance.
+    :param catalogue_category_repository_mock: Mocked `CatalogueCategoryRepo` instance.
+    :param catalogue_item_repository_mock: Mocked `CatalogueItemRepo` instance.
+    :return: `ItemService` instance with the mocked dependencies.
+    """
+    return ItemService(item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock)
 
 
 @pytest.fixture(name="manufacturer_service")

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for the `ItemService` service.
+"""
+import pytest
+from bson import ObjectId
+
+from inventory_management_system_api.core.exceptions import MissingRecordError, DatabaseIntegrityError
+from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
+from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
+from inventory_management_system_api.models.item import ItemOut, ItemIn
+from inventory_management_system_api.schemas.item import ItemPostRequestSchema
+
+FULL_CATALOGUE_CATEGORY_A_INFO = {
+    "name": "Category A",
+    "code": "category-a",
+    "is_leaf": True,
+    "parent_id": None,
+    "catalogue_item_properties": [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True},
+        {"name": "Property C", "type": "string", "unit": "cm", "mandatory": True},
+    ],
+}
+
+# pylint: disable=duplicate-code
+FULL_CATALOGUE_ITEM_A_INFO = {
+    "manufacturer": {
+        "name": "Manufacturer A",
+        "address": "1 Address, City, Country, Postcode",
+        "url": "https://www.manufacturer-a.co.uk/",
+    },
+    "name": "Catalogue Item A",
+    "description": "This is Catalogue Item A",
+    "cost_gbp": 129.99,
+    "cost_to_rework_gbp": None,
+    "days_to_replace": 2.0,
+    "days_to_rework": None,
+    "drawing_link": "https://drawing-link.com/",
+    "drawing_number": None,
+    "item_model_number": "abc123",
+    "is_obsolete": False,
+    "obsolete_reason": None,
+    "obsolete_replacement_catalogue_item_id": None,
+    "properties": [
+        {"name": "Property A", "value": 20, "unit": "mm"},
+        {"name": "Property B", "value": False, "unit": None},
+        {"name": "Property C", "value": "20x15x10", "unit": "cm"},
+    ],
+}
+
+ITEM_INFO = {
+    "is_defective": False,
+    "usage_status": 0,
+    "warranty_end_date": "2015-11-15T23:59:59Z",
+    "serial_number": "xyz123",
+    "delivered_date": "2012-12-05T12:00:00Z",
+    "notes": "Test notes",
+    "catalogue_item_override_properties": [{"name": "Property A", "value": 21}],
+}
+
+FULL_ITEM_INFO = {
+    **ITEM_INFO,
+    "purchase_order_number": None,
+    "asset_number": None,
+    "catalogue_item_override_properties": [{"name": "Property A", "value": 21, "unit": "mm"}],
+}
+# pylint: enable=duplicate-code
+
+
+def test_create(
+    test_helpers, item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock, item_service
+):
+    """
+    Test creating an item.
+    """
+    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+
+    catalogue_category_id = str(ObjectId())
+    # Mock `get` to return a catalogue item
+    test_helpers.mock_get(
+        catalogue_item_repository_mock,
+        CatalogueItemOut(
+            id=item.catalogue_item_id, catalogue_category_id=catalogue_category_id, **FULL_CATALOGUE_ITEM_A_INFO
+        ),
+    )
+    # Mock `get` to return a catalogue category
+    test_helpers.mock_get(
+        catalogue_category_repository_mock,
+        CatalogueCategoryOut(id=catalogue_category_id, **FULL_CATALOGUE_CATEGORY_A_INFO),
+    )
+    # Mock `create` to return the created item
+    test_helpers.mock_create(item_repository_mock, item)
+
+    created_item = item_service.create(
+        ItemPostRequestSchema(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **ITEM_INFO)
+    )
+
+    catalogue_item_repository_mock.get.assert_called_once_with(item.catalogue_item_id)
+    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
+    item_repository_mock.create.assert_called_once_with(
+        ItemIn(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **FULL_ITEM_INFO)
+    )
+    assert created_item == item
+
+
+def test_create_with_non_existent_catalogue_item_id(
+    test_helpers, item_repository_mock, catalogue_item_repository_mock, item_service
+):
+    """
+    Test creating an item with a non-existent catalogue item ID.
+    """
+    catalogue_item_id = str(ObjectId)
+
+    # Mock `get` to not return a catalogue item
+    test_helpers.mock_get(catalogue_item_repository_mock, None)
+
+    with pytest.raises(MissingRecordError) as exc:
+        item_service.create(
+            ItemPostRequestSchema(catalogue_item_id=catalogue_item_id, system_id=str(ObjectId), **ITEM_INFO)
+        )
+    catalogue_item_repository_mock.get.assert_called_once_with(catalogue_item_id)
+    item_repository_mock.create.assert_not_called()
+    assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
+
+
+def test_create_with_non_existent_catalogue_category_id_in_catalogue_item(
+    test_helpers, item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock, item_service
+):
+    """
+    Test creating an item with a non-existent catalogue category ID in a catalogue item.
+    """
+    catalogue_item_id = str(ObjectId)
+    catalogue_category_id = str(ObjectId)
+
+    # Mock `get` to return a catalogue item
+    test_helpers.mock_get(
+        catalogue_item_repository_mock,
+        CatalogueItemOut(
+            id=catalogue_item_id, catalogue_category_id=catalogue_category_id, **FULL_CATALOGUE_ITEM_A_INFO
+        ),
+    )
+    # Mock `get` to not return a catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, None)
+
+    with pytest.raises(DatabaseIntegrityError) as exc:
+        item_service.create(
+            ItemPostRequestSchema(catalogue_item_id=catalogue_item_id, system_id=str(ObjectId), **ITEM_INFO)
+        )
+    catalogue_item_repository_mock.get.assert_called_once_with(catalogue_item_id)
+    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
+    item_repository_mock.create.assert_not_called()
+    assert str(exc.value) == f"No catalogue category found with ID: {catalogue_item_id}"
+
+
+def test_create_without_catalogue_item_override_properties(
+    test_helpers, item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock, item_service
+):
+    """
+    Testing creating an item without catalogue item override properties.
+    """
+    item = ItemOut(
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+        **{**FULL_ITEM_INFO, "catalogue_item_override_properties": []},
+    )
+
+    catalogue_category_id = str(ObjectId())
+    # Mock `get` to return a catalogue item
+    test_helpers.mock_get(
+        catalogue_item_repository_mock,
+        CatalogueItemOut(
+            id=item.catalogue_item_id, catalogue_category_id=catalogue_category_id, **FULL_CATALOGUE_ITEM_A_INFO
+        ),
+    )
+    # Mock `get` to return a catalogue category
+    test_helpers.mock_get(
+        catalogue_category_repository_mock,
+        CatalogueCategoryOut(id=catalogue_category_id, **FULL_CATALOGUE_CATEGORY_A_INFO),
+    )
+    # Mock `create` to return the created item
+    test_helpers.mock_create(item_repository_mock, item)
+
+    created_item = item_service.create(
+        ItemPostRequestSchema(
+            catalogue_item_id=item.catalogue_item_id,
+            system_id=item.system_id,
+            **{**ITEM_INFO, "catalogue_item_override_properties": []},
+        )
+    )
+
+    catalogue_item_repository_mock.get.assert_called_once_with(item.catalogue_item_id)
+    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
+    item_repository_mock.create.assert_called_once_with(
+        ItemIn(
+            catalogue_item_id=item.catalogue_item_id,
+            system_id=item.system_id,
+            **{**FULL_ITEM_INFO, "catalogue_item_override_properties": []},
+        )
+    )
+    assert created_item == item


### PR DESCRIPTION
## Description
This PR creates an items endpoint (accessible at `/v1/items`) to which `POST` requests can be sent to create new items. The endpoint allows for the catalogue item properties to be overridden at this level through the `catalogue_item_override_properties` field. This does not override the actual catalogue item properties in the corresponding catalogue item itself but keeps them separate. Each catalogue item overrides property object requires a `name`, which is the name of the property as defined in the category, and a `value` for it.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Test creating an item
- [ ] Test creating an item without catalogue item override properties
- [ ] Test creating an item with an invalid catalogue item ID
- [ ] Test creating an item with a non-existent catalogue item ID
- [ ] Test creating an item with an invalid catalogue category ID in a catalogue item
- [ ] Test creating an item with a non-existent catalogue category ID in a catalogue item
- [ ] Test creating an item with an invalid system item ID
- [ ] Test creating an item with a non-existent system item ID
- [ ] Test creating an item with invalid value types for the catalogue item override properties

## Agile board tracking
closes #11 