### PR TITLE
Duplicate catalogue item properties #123

### DIFF
--- a/inventory_management_system_api/core/exceptions.py
+++ b/inventory_management_system_api/core/exceptions.py
@@ -20,10 +20,13 @@ class NonLeafCategoryError(Exception):
     Catalogue item is attempted to be added to a non-leaf catalogue category.
     """
 
+
 class DuplicatePropertyName(Exception):
     """
     Catalogue item is attempted to be created with duplicate property names
     """
+
+
 class InvalidCatalogueItemPropertyTypeError(Exception):
     """
     The type of the provided value does not match the expected type of the catalogue item property.

--- a/inventory_management_system_api/core/exceptions.py
+++ b/inventory_management_system_api/core/exceptions.py
@@ -20,7 +20,10 @@ class NonLeafCategoryError(Exception):
     Catalogue item is attempted to be added to a non-leaf catalogue category.
     """
 
-
+class DuplicatePropertyName(Exception):
+    """
+    Catalogue item is attempted to be created with duplicate property names
+    """
 class InvalidCatalogueItemPropertyTypeError(Exception):
     """
     The type of the provided value does not match the expected type of the catalogue item property.

--- a/inventory_management_system_api/core/exceptions.py
+++ b/inventory_management_system_api/core/exceptions.py
@@ -21,9 +21,9 @@ class NonLeafCategoryError(Exception):
     """
 
 
-class DuplicatePropertyName(Exception):
+class DuplicateCatalogueItemPropertyNameError(Exception):
     """
-    Catalogue item is attempted to be created with duplicate property names
+    Catalogue category is attempted to be created with duplicate catalogue item property names.
     """
 
 

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -169,6 +169,10 @@ def partial_update_catalogue_category(
         message = "Adding a catalogue category to a leaf parent catalogue category is not allowed"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except DuplicatePropertyName as exc:
+        message = "Duplicate property names are not allowed"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
 
 
 @router.delete(

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from inventory_management_system_api.core.exceptions import (
     ChildrenElementsExistError,
     DatabaseIntegrityError,
-    DuplicatePropertyName,
+    DuplicateCatalogueItemPropertyNameError,
     DuplicateRecordError,
     InvalidObjectIdError,
     LeafCategoryError,
@@ -122,10 +122,9 @@ def create_catalogue_category(
         message = "Adding a catalogue category to a leaf parent catalogue category is not allowed"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
-    except DuplicatePropertyName as exc:
-        message = "Duplicate property names are not allowed"
-        logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except DuplicateCatalogueItemPropertyNameError as exc:
+        logger.exception(str(exc))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
 
 
 @router.patch(
@@ -169,10 +168,9 @@ def partial_update_catalogue_category(
         message = "Adding a catalogue category to a leaf parent catalogue category is not allowed"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
-    except DuplicatePropertyName as exc:
-        message = "Duplicate property names are not allowed"
-        logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except DuplicateCatalogueItemPropertyNameError as exc:
+        logger.exception(str(exc))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
 
 
 @router.delete(

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 from inventory_management_system_api.core.exceptions import (
     ChildrenElementsExistError,
     DatabaseIntegrityError,
+    DuplicatePropertyName,
     DuplicateRecordError,
     InvalidObjectIdError,
     LeafCategoryError,
@@ -119,6 +120,10 @@ def create_catalogue_category(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except LeafCategoryError as exc:
         message = "Adding a catalogue category to a leaf parent catalogue category is not allowed"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except DuplicatePropertyName as exc:
+        message = "Duplicate property names are not allowed"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
 

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -8,6 +8,7 @@ from typing import List, Annotated, Optional
 from fastapi import APIRouter, status, Depends, HTTPException, Path, Query
 
 from inventory_management_system_api.core.exceptions import (
+    DuplicatePropertyName,
     MissingRecordError,
     InvalidObjectIdError,
     NonLeafCategoryError,

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -8,7 +8,6 @@ from typing import List, Annotated, Optional
 from fastapi import APIRouter, status, Depends, HTTPException, Path, Query
 
 from inventory_management_system_api.core.exceptions import (
-    DuplicatePropertyName,
     MissingRecordError,
     InvalidObjectIdError,
     NonLeafCategoryError,

--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -162,8 +162,8 @@ class CatalogueCategoryService:
         seen_catalogue_item_property_names = set()
         for catalogue_item_property in catalogue_item_properties:
             catalogue_item_property_name = catalogue_item_property.name
-            if catalogue_item_property_name.lower() in seen_catalogue_item_property_names:
+            if catalogue_item_property_name.lower().strip() in seen_catalogue_item_property_names:
                 raise DuplicateCatalogueItemPropertyNameError(
-                    f"Duplicate catalogue item property name: {catalogue_item_property_name}"
+                    f"Duplicate catalogue item property name: {catalogue_item_property_name.strip()}"
                 )
-            seen_catalogue_item_property_names.add(catalogue_item_property_name.lower())
+            seen_catalogue_item_property_names.add(catalogue_item_property_name.lower().strip())

--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -153,15 +153,17 @@ class CatalogueCategoryService:
     def _check_duplicate_catalogue_item_property_names(
         self, catalogue_item_properties: List[CatalogueItemPropertySchema]
     ) -> None:
-             """
-             Go through all the catalogue item properties to check for any duplicate names.
-             :param catalogue_item_properties: The supplied catalogue item properties
-             :raises DuplicateCatalogueItemPropertyName: If a duplicate catalogue item property name is found.
-             """
-             logger.info("Checking for duplicate catalogue item property names")
-             seen_catalogue_item_property_names = set()
-             for catalogue_item_property in catalogue_item_properties:
-                 catalogue_item_property_name = catalogue_item_property.name
-                 if catalogue_item_property_name.lower() in seen_catalogue_item_property_names:
-                     raise DuplicateCatalogueItemPropertyNameError(f"Duplicate catalogue item property name: {catalogue_item_property_name}")
-                 seen_catalogue_item_property_names.add(catalogue_item_property_name.lower())
+        """
+        Go through all the catalogue item properties to check for any duplicate names.
+        :param catalogue_item_properties: The supplied catalogue item properties
+        :raises DuplicateCatalogueItemPropertyName: If a duplicate catalogue item property name is found.
+        """
+        logger.info("Checking for duplicate catalogue item property names")
+        seen_catalogue_item_property_names = set()
+        for catalogue_item_property in catalogue_item_properties:
+            catalogue_item_property_name = catalogue_item_property.name
+            if catalogue_item_property_name.lower() in seen_catalogue_item_property_names:
+                raise DuplicateCatalogueItemPropertyNameError(
+                    f"Duplicate catalogue item property name: {catalogue_item_property_name}"
+                )
+            seen_catalogue_item_property_names.add(catalogue_item_property_name.lower())

--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -58,9 +58,9 @@ class CatalogueCategoryService:
         if parent_catalogue_category and parent_catalogue_category.is_leaf:
             raise LeafCategoryError("Cannot add catalogue category to a leaf parent catalogue category")
 
-
-        logger.info(catalogue_category.catalogue_item_properties)
-        if self.check_duplicate_property_names(catalogue_category.catalogue_item_properties if catalogue_category.catalogue_item_properties else [], 'post'):
+        if self.check_duplicate_property_names(
+            catalogue_category.catalogue_item_properties if catalogue_category.catalogue_item_properties else [], "post"
+        ):
             raise DuplicatePropertyName("Cannot add catalogue category with duplicate catalogue item property names")
 
         code = utils.generate_code(catalogue_category.name, "catalogue category")
@@ -138,9 +138,14 @@ class CatalogueCategoryService:
             if parent_catalogue_category and parent_catalogue_category.is_leaf:
                 raise LeafCategoryError("Cannot add catalogue category to a leaf parent catalogue category")
 
-        if "catalogue_item_properties" in update_data and catalogue_category.catalogue_item_properties != stored_catalogue_category.catalogue_item_properties:
-            if self.check_duplicate_property_names(update_data["catalogue_item_properties"], 'patch'):
-                raise DuplicatePropertyName("Cannot edit a catalogue category to have duplicate catalogue item property names")
+        if (
+            "catalogue_item_properties" in update_data
+            and catalogue_category.catalogue_item_properties != stored_catalogue_category.catalogue_item_properties
+        ):
+            if self.check_duplicate_property_names(update_data["catalogue_item_properties"], "patch"):
+                raise DuplicatePropertyName(
+                    "Cannot edit a catalogue category to have duplicate catalogue item property names"
+                )
         # If any of these, need to ensure the category has no children
         if any(key in update_data for key in CATALOGUE_CATEGORY_WITH_CHILDREN_NON_EDITABLE_FIELDS):
             if self._catalogue_category_repository.has_child_elements(CustomObjectId(catalogue_category_id)):
@@ -152,31 +157,29 @@ class CatalogueCategoryService:
             catalogue_category_id, CatalogueCategoryIn(**{**stored_catalogue_category.model_dump(), **update_data})
         )
 
-    def check_duplicate_property_names(self,
-        properties: List[CatalogueItemPropertySchema], request: str
-) -> bool:
+    def check_duplicate_property_names(self, properties: List[CatalogueItemPropertySchema], request: str) -> bool:
         """
         Go through all the properties to check for any duplicate property names
 
         :param properties: The supplied properties when creating or editing a catalogue category
+        :param request: Which request is being processed as the list of properties supplied have
+                        different types/format
         :return: Returns true if any duplicate property names have been found
         """
 
-        logger.info('Checking for duplicate property names')
+        logger.info("Checking for duplicate property names")
 
         list_of_names = []
 
-        if request == 'post':
+        if request == "post":
             for dictionary in properties:
                 list_of_names.append(dictionary.name.lower())
 
-        if request == 'patch':
-
-            for dict in properties:
-                for key, value in dict.items():
-                    if key == 'name':
+        if request == "patch":
+            for dictionary in properties:
+                for key, value in dictionary.items():
+                    if key == "name":
                         list_of_names.append(value.lower())
-        
         duplicate_names = set()
         unique_names = set()
 

--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -60,7 +60,7 @@ class CatalogueCategoryService:
 
 
         logger.info(catalogue_category.catalogue_item_properties)
-        if self.check_duplicate_property_names(catalogue_category.catalogue_item_properties):
+        if self.check_duplicate_property_names(catalogue_category.catalogue_item_properties if catalogue_category.catalogue_item_properties else []):
             raise DuplicatePropertyName("Cannot add catalogue category with duplicate catalogue item property names")
 
         code = utils.generate_code(catalogue_category.name, "catalogue category")

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -222,6 +222,22 @@ def test_create_catalogue_category_with_invalid_catalogue_item_property_type(tes
     assert response.status_code == 422
     assert response.json()["detail"][0]["msg"] == "Input should be 'string', 'number' or 'boolean'"
 
+def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(test_client):
+    """
+    Test creating a catalogue category with duplicate catalogue item property names.
+    """
+    catalogue_category = {
+        **CATALOGUE_CATEGORY_POST_C,
+        "catalogue_item_properties": [
+            {"name": "Duplicate", "type": "number", "unit": "mm", "mandatory": False},
+            {"name": "Duplicate", "type": "boolean", "mandatory": True}
+        ],
+    }
+
+    response = test_client.post("/v1/catalogue-categories", json=catalogue_category)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Duplicate property names are not allowed"
 
 def test_create_catalogue_category_with_disallowed_unit_value_for_boolean_catalogue_item_property(test_client):
     """

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -237,8 +237,8 @@ def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(
 
     response = test_client.post("/v1/catalogue-categories", json=catalogue_category)
 
-    assert response.status_code == 409
-    assert response.json()["detail"] == "Duplicate property names are not allowed"
+    assert response.status_code == 422
+    assert response.json()["detail"] == (f"Duplicate catalogue item property name: {catalogue_category['catalogue_item_properties'][0]['name']}")
 
 
 def test_create_catalogue_category_with_disallowed_unit_value_for_boolean_catalogue_item_property(test_client):
@@ -1049,5 +1049,5 @@ def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_cl
 
     response = test_client.patch(f"/v1/catalogue-categories/{catalogue_category_id}", json=catalogue_category_patch)
 
-    assert response.status_code == 409
-    assert response.json()["detail"] == "Duplicate property names are not allowed"
+    assert response.status_code == 422
+    assert response.json()["detail"] == (f"Duplicate catalogue item property name: {catalogue_category_patch['catalogue_item_properties'][0]['name']}")

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -1029,3 +1029,20 @@ def test_partial_update_catalogue_category_non_existent_id(test_client):
 
     assert response.status_code == 404
     assert response.json()["detail"] == "A catalogue category with such ID was not found"
+
+def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_client):
+    """
+    Test updating a catalogue category to have duplicate catalogue item property names
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_C)
+    catalogue_category__id = response.json()["id"]
+
+    catalogue_category_patch = {"catalogue_item_properties": [
+        {"name": "Duplicate", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Duplicate", "type": "boolean", "unit": None, "mandatory": True},
+    ]}
+
+    response = test_client.patch(f"/v1/catalogue-categories/{catalogue_category__id}", json=catalogue_category_patch)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Duplicate property names are not allowed"

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -1038,7 +1038,7 @@ def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_cl
     Test updating a catalogue category to have duplicate catalogue item property names
     """
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_C)
-    catalogue_category__id = response.json()["id"]
+    catalogue_category_id = response.json()["id"]
 
     catalogue_category_patch = {
         "catalogue_item_properties": [
@@ -1047,7 +1047,7 @@ def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_cl
         ]
     }
 
-    response = test_client.patch(f"/v1/catalogue-categories/{catalogue_category__id}", json=catalogue_category_patch)
+    response = test_client.patch(f"/v1/catalogue-categories/{catalogue_category_id}", json=catalogue_category_patch)
 
     assert response.status_code == 409
     assert response.json()["detail"] == "Duplicate property names are not allowed"

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -222,6 +222,7 @@ def test_create_catalogue_category_with_invalid_catalogue_item_property_type(tes
     assert response.status_code == 422
     assert response.json()["detail"][0]["msg"] == "Input should be 'string', 'number' or 'boolean'"
 
+
 def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(test_client):
     """
     Test creating a catalogue category with duplicate catalogue item property names.
@@ -230,7 +231,7 @@ def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(
         **CATALOGUE_CATEGORY_POST_C,
         "catalogue_item_properties": [
             {"name": "Duplicate", "type": "number", "unit": "mm", "mandatory": False},
-            {"name": "Duplicate", "type": "boolean", "mandatory": True}
+            {"name": "Duplicate", "type": "boolean", "mandatory": True},
         ],
     }
 
@@ -238,6 +239,7 @@ def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(
 
     assert response.status_code == 409
     assert response.json()["detail"] == "Duplicate property names are not allowed"
+
 
 def test_create_catalogue_category_with_disallowed_unit_value_for_boolean_catalogue_item_property(test_client):
     """
@@ -1030,6 +1032,7 @@ def test_partial_update_catalogue_category_non_existent_id(test_client):
     assert response.status_code == 404
     assert response.json()["detail"] == "A catalogue category with such ID was not found"
 
+
 def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_client):
     """
     Test updating a catalogue category to have duplicate catalogue item property names
@@ -1037,10 +1040,12 @@ def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_cl
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_C)
     catalogue_category__id = response.json()["id"]
 
-    catalogue_category_patch = {"catalogue_item_properties": [
-        {"name": "Duplicate", "type": "number", "unit": "mm", "mandatory": False},
-        {"name": "Duplicate", "type": "boolean", "unit": None, "mandatory": True},
-    ]}
+    catalogue_category_patch = {
+        "catalogue_item_properties": [
+            {"name": "Duplicate", "type": "number", "unit": "mm", "mandatory": False},
+            {"name": "Duplicate", "type": "boolean", "unit": None, "mandatory": True},
+        ]
+    }
 
     response = test_client.patch(f"/v1/catalogue-categories/{catalogue_category__id}", json=catalogue_category_patch)
 

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -238,7 +238,9 @@ def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(
     response = test_client.post("/v1/catalogue-categories", json=catalogue_category)
 
     assert response.status_code == 422
-    assert response.json()["detail"] == (f"Duplicate catalogue item property name: {catalogue_category['catalogue_item_properties'][0]['name']}")
+    assert response.json()["detail"] == (
+        f"Duplicate catalogue item property name: {catalogue_category['catalogue_item_properties'][0]['name']}"
+    )
 
 
 def test_create_catalogue_category_with_disallowed_unit_value_for_boolean_catalogue_item_property(test_client):
@@ -1050,4 +1052,6 @@ def test_partial_update_catalogue_items_to_have_duplicate_property_names(test_cl
     response = test_client.patch(f"/v1/catalogue-categories/{catalogue_category_id}", json=catalogue_category_patch)
 
     assert response.status_code == 422
-    assert response.json()["detail"] == (f"Duplicate catalogue item property name: {catalogue_category_patch['catalogue_item_properties'][0]['name']}")
+    assert response.json()["detail"] == (
+        f"Duplicate catalogue item property name: {catalogue_category_patch['catalogue_item_properties'][0]['name']}"
+    )

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -717,9 +717,6 @@ def test_update_change_catalogue_item_properties_when_has_children(
     )
     # pylint: enable=duplicate-code
 
-    # Mock so child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = True
-
     # Mock `get` to return a catalogue category
     # pylint: disable=duplicate-code
     test_helpers.mock_get(
@@ -749,4 +746,56 @@ def test_update_change_catalogue_item_properties_when_has_children(
     assert (
         str(exc.value)
         == f"Catalogue category with ID {str(catalogue_category.id)} has child elements and cannot be updated"
+    )
+
+def test_update_change_catalogue_item_properties_to_have_duplicate_names(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+    """
+    Test that checks that trying to update catalogue item properties so that the names are duplicated is not allowed
+
+    Verify the `update` method properly handles the catalogue category to be updated
+    """
+    # pylint: disable=duplicate-code
+    catalogue_category = CatalogueCategoryOut(
+        id=str(ObjectId()),
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[
+            CatalogueItemProperty(name="Duplicate", type="number", unit="mm", mandatory=False),
+            CatalogueItemProperty(name="Duplicate", type="boolean", mandatory=True),
+        ],
+    )
+    # pylint: enable=duplicate-code
+
+    
+
+    # Mock `get` to return a catalogue category
+    # pylint: disable=duplicate-code
+    test_helpers.mock_get(
+        catalogue_category_repository_mock,
+        CatalogueCategoryOut(
+            id=catalogue_category.id,
+            name=catalogue_category.name,
+            code=catalogue_category.code,
+            is_leaf=catalogue_category.is_leaf,
+            parent_id=catalogue_category.parent_id,
+            catalogue_item_properties=[catalogue_category.catalogue_item_properties[1]],
+        ),
+    )
+    # pylint: enable=duplicate-code
+    # Mock `update` to return the updated catalogue category
+    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+    with pytest.raises(DuplicatePropertyName) as exc:
+        catalogue_category_service.update(
+            catalogue_category.id,
+            CatalogueCategoryPatchRequestSchema(
+                catalogue_item_properties=[prop.model_dump() for prop in catalogue_category.catalogue_item_properties]
+            ),
+        )
+
+    catalogue_category_repository_mock.update.assert_not_called()
+    assert (
+        str(exc.value) == "Cannot edit a catalogue category to have duplicate catalogue item property names"
     )

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -270,7 +270,9 @@ def test_create_with_duplicate_property_names(
             )
         )
         # pylint: enable=duplicate-code
-    assert str(exc.value) == "Cannot add catalogue category with duplicate catalogue item property names"
+    assert str(exc.value) == (
+        f"Cannot have duplicate catalogue item property name: {catalogue_category_catalogue_item_properties[0].name}"
+    )
 
 
 def test_delete(catalogue_category_repository_mock, catalogue_category_service):
@@ -800,4 +802,6 @@ def test_update_properties_to_have_duplicate_names(
         )
 
     catalogue_category_repository_mock.update.assert_not_called()
-    assert str(exc.value) == "Cannot edit a catalogue category to have duplicate catalogue item property names"
+    assert str(exc.value) == (
+        f"Cannot have duplicate catalogue item property name: {catalogue_category.catalogue_item_properties[0].name}"
+    )

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -218,7 +218,10 @@ def test_create_with_leaf_parent_catalogue_category(
         )
     assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
 
-def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+
+def test_create_with_duplicate_property_names(
+    test_helpers, catalogue_category_repository_mock, catalogue_category_service
+):
     """
     Test trying to create a catalogue category with duplicate catalogue item property names
     """
@@ -260,12 +263,12 @@ def test_create_catalogue_category_with_duplicate_catalogue_item_property_names(
     with pytest.raises(DuplicatePropertyName) as exc:
         # pylint: disable=duplicate-code
         catalogue_category_service.create(
-        CatalogueCategoryPostRequestSchema(
-            name=catalogue_category.name,
-            is_leaf=catalogue_category.is_leaf,
-            catalogue_item_properties=catalogue_category_catalogue_item_properties,
+            CatalogueCategoryPostRequestSchema(
+                name=catalogue_category.name,
+                is_leaf=catalogue_category.is_leaf,
+                catalogue_item_properties=catalogue_category_catalogue_item_properties,
+            )
         )
-    )
         # pylint: enable=duplicate-code
     assert str(exc.value) == "Cannot add catalogue category with duplicate catalogue item property names"
 
@@ -748,7 +751,10 @@ def test_update_change_catalogue_item_properties_when_has_children(
         == f"Catalogue category with ID {str(catalogue_category.id)} has child elements and cannot be updated"
     )
 
-def test_update_change_catalogue_item_properties_to_have_duplicate_names(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+
+def test_update_properties_to_have_duplicate_names(
+    test_helpers, catalogue_category_repository_mock, catalogue_category_service
+):
     """
     Test that checks that trying to update catalogue item properties so that the names are duplicated is not allowed
 
@@ -767,8 +773,6 @@ def test_update_change_catalogue_item_properties_to_have_duplicate_names(test_he
         ],
     )
     # pylint: enable=duplicate-code
-
-    
 
     # Mock `get` to return a catalogue category
     # pylint: disable=duplicate-code
@@ -796,6 +800,4 @@ def test_update_change_catalogue_item_properties_to_have_duplicate_names(test_he
         )
 
     catalogue_category_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value) == "Cannot edit a catalogue category to have duplicate catalogue item property names"
-    )
+    assert str(exc.value) == "Cannot edit a catalogue category to have duplicate catalogue item property names"

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -219,8 +219,7 @@ def test_create_with_leaf_parent_catalogue_category(
     assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
 
 
-def test_create_with_duplicate_property_names(
-    test_helpers, catalogue_category_repository_mock, catalogue_category_service
+def test_create_with_duplicate_property_names(catalogue_category_service
 ):
     """
     Test trying to create a catalogue category with duplicate catalogue item property names
@@ -239,27 +238,6 @@ def test_create_with_duplicate_property_names(
     )
     # pylint: enable=duplicate-code
 
-    # # Mock `get` to return the parent catalogue category
-    # # pylint: disable=duplicate-code
-    # test_helpers.mock_get(
-    #     catalogue_category_repository_mock,
-    #     CatalogueCategoryOut(
-    #         id=catalogue_category.parent_id,
-    #         name="Category A",
-    #         code="category-a",
-    #         is_leaf=False,
-    #         parent_id=None,
-    #         catalogue_item_properties=[],
-    #     ),
-    # )
-    # # pylint: enable=duplicate-code
-
-    # the same catalogue item properties but mapped to the schema so that they are accepted
-    # catalogue_category_catalogue_item_properties = [
-    #     CatalogueItemPropertySchema(name="Property A", type="number", unit="mm", mandatory=False),
-    #     CatalogueItemPropertySchema(name="Property A", type="boolean", mandatory=True),
-    # ]
-
     with pytest.raises(DuplicateCatalogueItemPropertyNameError) as exc:
         # pylint: disable=duplicate-code
         catalogue_category_service.create(
@@ -271,7 +249,7 @@ def test_create_with_duplicate_property_names(
         )
         # pylint: enable=duplicate-code
     assert str(exc.value) == (
-        f"Cannot have duplicate catalogue item property name: {catalogue_category.catalogue_item_properties[0].name}"
+        f"Duplicate catalogue item property name: {catalogue_category.catalogue_item_properties[0].name}"
     )
 
 
@@ -803,5 +781,5 @@ def test_update_properties_to_have_duplicate_names(
 
     catalogue_category_repository_mock.update.assert_not_called()
     assert str(exc.value) == (
-        f"Cannot have duplicate catalogue item property name: {catalogue_category.catalogue_item_properties[0].name}"
+        f"Duplicate catalogue item property name: {catalogue_category.catalogue_item_properties[0].name}"
     )

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -19,8 +19,7 @@ from inventory_management_system_api.models.catalogue_category import (
 )
 from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueCategoryPatchRequestSchema,
-    CatalogueCategoryPostRequestSchema,
-    CatalogueItemPropertySchema,
+    CatalogueCategoryPostRequestSchema
 )
 
 
@@ -219,8 +218,7 @@ def test_create_with_leaf_parent_catalogue_category(
     assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
 
 
-def test_create_with_duplicate_property_names(catalogue_category_service
-):
+def test_create_with_duplicate_property_names(catalogue_category_service):
     """
     Test trying to create a catalogue category with duplicate catalogue item property names
     """


### PR DESCRIPTION
## Description
Added logic to the creation and updating of catalogue categories to make sure that duplicate catalogue item property names are not possible. The logic also ensures that not case specific names (e.g. Property A and property a) are also seen as duplicates

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] check creating a catalogue category with duplicate catalogue item property names
- [ ] check editing a catalogue category to have duplicate catalogue item property names

## Agile board tracking

closes #123
