### PR TITLE
Replace count documents with find one #91

### DIFF
--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -194,8 +194,9 @@ class CatalogueCategoryRepo:
         logger.info("Checking if catalogue category with ID '%s' has children elements", catalogue_category_id)
         # Check if it has catalogue categories
         query = {"parent_id": catalogue_category_id}
-        count = self._catalogue_categories_collection.count_documents(query)
+        catalogue_category = self._catalogue_categories_collection.find_one(query)
+
         # Check if it has catalogue items
         query = {"catalogue_category_id": catalogue_category_id}
-        count = count + self._catalogue_items_collection.count_documents(query)
-        return count > 0
+        catalogue_item = self._catalogue_items_collection.find_one(query)
+        return catalogue_category or catalogue_item

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -192,11 +192,8 @@ class CatalogueCategoryRepo:
         :return: True if the catalogue category has children elements, False otherwise.
         """
         logger.info("Checking if catalogue category with ID '%s' has children elements", catalogue_category_id)
-        # Check if it has catalogue categories
-        query = {"parent_id": catalogue_category_id}
-        catalogue_category = self._catalogue_categories_collection.find_one(query)
-
-        # Check if it has catalogue items
-        query = {"catalogue_category_id": catalogue_category_id}
-        catalogue_item = self._catalogue_items_collection.find_one(query)
-        return (catalogue_category is not None) or (catalogue_item is not None)
+        
+        return (
+            self._catalogue_categories_collection.find_one({"parent_id": catalogue_category_id}) is not None
+            or self._catalogue_items_collection.find_one({"parent_id": catalogue_category_id}) is not None
+        )

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -192,8 +192,8 @@ class CatalogueCategoryRepo:
         :return: True if the catalogue category has children elements, False otherwise.
         """
         logger.info("Checking if catalogue category with ID '%s' has children elements", catalogue_category_id)
-        
+
         return (
             self._catalogue_categories_collection.find_one({"parent_id": catalogue_category_id}) is not None
-            or self._catalogue_items_collection.find_one({"parent_id": catalogue_category_id}) is not None
+            or self._catalogue_items_collection.find_one({"catalogue_category_id": catalogue_category_id}) is not None
         )

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -199,4 +199,4 @@ class CatalogueCategoryRepo:
         # Check if it has catalogue items
         query = {"catalogue_category_id": catalogue_category_id}
         catalogue_item = self._catalogue_items_collection.find_one(query)
-        return catalogue_category or catalogue_item
+        return (catalogue_category is not None) or (catalogue_item is not None)

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -178,8 +178,7 @@ class CatalogueCategoryRepo:
         if parent_id:
             parent_id = CustomObjectId(parent_id)
 
-        count = self._catalogue_categories_collection.count_documents({"parent_id": parent_id, "code": code})
-        return count > 0
+        return self._catalogue_categories_collection.find_one({"parent_id": parent_id, "code": code}) is not None
 
     def has_child_elements(self, catalogue_category_id: CustomObjectId) -> bool:
         """

--- a/inventory_management_system_api/repositories/manufacturer.py
+++ b/inventory_management_system_api/repositories/manufacturer.py
@@ -142,5 +142,5 @@ class ManufacturerRepo:
         :return: Returns True if 1 or more documents have the manufacturer ID, false if none do
         """
         manufacturer_id = CustomObjectId(manufacturer_id)
-        count = self._catalogue_item_collection.count_documents({"manufacturer_id": manufacturer_id})
-        return count > 0
+        catalogue_item = self._catalogue_item_collection.find_one({"manufacturer_id": manufacturer_id})
+        return catalogue_item

--- a/inventory_management_system_api/repositories/manufacturer.py
+++ b/inventory_management_system_api/repositories/manufacturer.py
@@ -143,4 +143,4 @@ class ManufacturerRepo:
         """
         manufacturer_id = CustomObjectId(manufacturer_id)
         catalogue_item = self._catalogue_item_collection.find_one({"manufacturer_id": manufacturer_id})
-        return catalogue_item
+        return catalogue_item is not None

--- a/inventory_management_system_api/repositories/manufacturer.py
+++ b/inventory_management_system_api/repositories/manufacturer.py
@@ -142,5 +142,4 @@ class ManufacturerRepo:
         :return: Returns True if 1 or more documents have the manufacturer ID, false if none do
         """
         manufacturer_id = CustomObjectId(manufacturer_id)
-        catalogue_item = self._catalogue_item_collection.find_one({"manufacturer_id": manufacturer_id})
-        return catalogue_item is not None
+        return self._catalogue_item_collection.find_one({"manufacturer_id": manufacturer_id}) is not None

--- a/inventory_management_system_api/repositories/manufacturer.py
+++ b/inventory_management_system_api/repositories/manufacturer.py
@@ -132,8 +132,7 @@ class ManufacturerRepo:
         :return `True` if duplicate manufacturer, `False` otherwise
         """
         logger.info("Checking if manufacturer with code '%s' already exists", code)
-        count = self._manufacturers_collection.count_documents({"code": code})
-        return count > 0
+        return self._manufacturers_collection.find_one({"code": code}) is not None
 
     def _is_manufacturer_in_catalogue_item(self, manufacturer_id: str) -> bool:
         """Checks to see if any of the documents in the database have a specific manufactuer id

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -178,6 +178,5 @@ class SystemRepo:
         """
         logger.info("Checking if system with ID '%s' has child elements", str(system_id))
         # Check if it has System's
-        query = {"parent_id": system_id}
-        count = self._systems_collection.count_documents(query)
-        return count > 0
+        system = self._systems_collection.find_one({"parent_id": system_id})
+        return system

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -166,8 +166,7 @@ class SystemRepo:
         if parent_id:
             parent_id = CustomObjectId(parent_id)
 
-        count = self._systems_collection.count_documents({"parent_id": parent_id, "code": code})
-        return count > 0
+        return self._systems_collection.find_one({"parent_id": parent_id, "code": code}) is not None
 
     def _has_child_elements(self, system_id: CustomObjectId) -> bool:
         """

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -179,4 +179,4 @@ class SystemRepo:
         logger.info("Checking if system with ID '%s' has child elements", str(system_id))
         # Check if it has System's
         system = self._systems_collection.find_one({"parent_id": system_id})
-        return system
+        return system is not None

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -97,21 +97,6 @@ class RepositoryTestHelpers:
     """
 
     @staticmethod
-    def mock_count_documents(collection_mock: Mock, count: int) -> None:
-        """
-        Mock the `count_documents` method of the MongoDB database collection mock to return a specific count value.
-
-        :param collection_mock: Mocked MongoDB database collection instance.
-        :param count: The count value to be returned by the `count_documents` method.
-        """
-        if collection_mock.count_documents.side_effect is None:
-            collection_mock.count_documents.side_effect = [count]
-        else:
-            counts = list(collection_mock.count_documents.side_effect)
-            counts.append(count)
-            collection_mock.count_documents.side_effect = counts
-
-    @staticmethod
     def mock_delete_one(collection_mock: Mock, deleted_count: int) -> None:
         """
         Mock the `delete_one` method of the MongoDB database collection mock to return a `DeleteResult` object. The

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -386,12 +386,8 @@ def test_delete(test_helpers, database_mock, catalogue_category_repository):
     test_helpers.mock_delete_one(database_mock.catalogue_categories, 1)
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
-    test_helpers.mock_find_one(
-        database_mock.catalogue_categories, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
     catalogue_category_repository.delete(catalogue_category_id)
 
@@ -422,9 +418,7 @@ def test_delete_with_children_catalogue_categories(test_helpers, database_mock, 
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     with pytest.raises(ChildrenElementsExistError) as exc:
         catalogue_category_repository.delete(catalogue_category_id)
@@ -442,9 +436,8 @@ def test_delete_with_children_catalogue_items(test_helpers, database_mock, catal
     catalogue_category_id = str(ObjectId())
 
     # Mock `find_one` to return no child catalogue category document
-    test_helpers.mock_find_one(
-        database_mock.catalogue_categories, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
+    # pylint: disable=duplicate-code
     # Mock `find_one` to return the child catalogue item document
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
@@ -454,7 +447,7 @@ def test_delete_with_children_catalogue_items(test_helpers, database_mock, catal
             **FULL_CATALOGUE_ITEM_A_INFO,
         },
     )
-
+    # pylint: enable=duplicate-code
     with pytest.raises(ChildrenElementsExistError) as exc:
         catalogue_category_repository.delete(catalogue_category_id)
     assert str(exc.value) == (
@@ -485,12 +478,8 @@ def test_delete_with_nonexistent_id(test_helpers, database_mock, catalogue_categ
     test_helpers.mock_delete_one(database_mock.catalogue_categories, 0)
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
-    test_helpers.mock_find_one(
-        database_mock.catalogue_categories, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
     with pytest.raises(MissingRecordError) as exc:
         catalogue_category_repository.delete(catalogue_category_id)
@@ -989,12 +978,8 @@ def test_has_child_elements_with_no_child_categories(test_helpers, database_mock
     Test has_child_elements returns false when there are no child categories
     """
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
-    test_helpers.mock_find_one(
-        database_mock.catalogue_categories, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
     result = catalogue_category_repository.has_child_elements(ObjectId())
 
@@ -1021,9 +1006,7 @@ def test_has_child_elements_with_child_categories(test_helpers, database_mock, c
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     result = catalogue_category_repository.has_child_elements(catalogue_category_id)
 
@@ -1039,9 +1022,8 @@ def test_has_child_elements_with_child_items(test_helpers, database_mock, catalo
     catalogue_category_id = str(ObjectId())
 
     # Mock `find_one` to return no child catalogue category document
-    test_helpers.mock_find_one(
-        database_mock.catalogue_categories, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
+    # pylint: disable=duplicate-code
     # Mock `find_one` to return the child catalogue item document
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
@@ -1051,7 +1033,7 @@ def test_has_child_elements_with_child_items(test_helpers, database_mock, catalo
             **FULL_CATALOGUE_ITEM_A_INFO,
         },
     )
-
+    # pylint: enable=duplicate-code
     result = catalogue_category_repository.has_child_elements(catalogue_category_id)
 
     assert result

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -238,8 +238,9 @@ def test_create_with_parent_id(test_helpers, database_mock, catalogue_category_r
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
-            "_id": CustomObjectId(catalogue_category.parent_id),
             **CATALOGUE_CATEGORY_INFO,
+            "_id": CustomObjectId(catalogue_category.parent_id),
+            
         },
     )
     # Mock `count_documents` to return 0 (no duplicate catalogue category found within the parent catalogue category)
@@ -349,8 +350,8 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, c
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
-            "_id": CustomObjectId(catalogue_category.parent_id),
             **CATALOGUE_CATEGORY_INFO,
+            "_id": CustomObjectId(catalogue_category.parent_id),
         },
     )
     # Mock `count_documents` to return 1 (duplicate catalogue category found within the parent catalogue category)
@@ -409,9 +410,10 @@ def test_delete_with_children_catalogue_categories(test_helpers, database_mock, 
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
+            **CATALOGUE_CATEGORY_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "parent_id": catalogue_category_id,
-            **CATALOGUE_CATEGORY_INFO,
+            
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)
@@ -785,11 +787,11 @@ def test_update(test_helpers, database_mock, catalogue_category_repository):
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
+            **CATALOGUE_CATEGORY_INFO,
             "_id": CustomObjectId(catalogue_category.id),
             "is_leaf": catalogue_category.is_leaf,
             "parent_id": catalogue_category.parent_id,
             "catalogue_item_properties": catalogue_category.catalogue_item_properties,
-            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock `count_documents` to return 0 (no duplicate catalogue category found within the parent catalogue category)
@@ -903,11 +905,11 @@ def test_update_duplicate_name_within_parent(test_helpers, database_mock, catalo
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
+            **CATALOGUE_CATEGORY_INFO,
             "_id": CustomObjectId(catalogue_category_id),
             "is_leaf": update_catalogue_category.is_leaf,
             "parent_id": update_catalogue_category.parent_id,
             "catalogue_item_properties": update_catalogue_category.catalogue_item_properties,
-            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock `count_documents` to return 1 (duplicate catalogue category found within the parent catalogue category)
@@ -992,9 +994,9 @@ def test_has_child_elements_with_child_categories(test_helpers, database_mock, c
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
+            **CATALOGUE_CATEGORY_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "parent_id": catalogue_category_id,
-            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -363,7 +363,8 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, c
         database_mock.catalogue_categories,
         {
             **CATALOGUE_CATEGORY_INFO,
-            "_id": CustomObjectId(catalogue_category.parent_id),
+            "_id": ObjectId(),
+            "parent_id": CustomObjectId(catalogue_category.parent_id),
         },
     )
 
@@ -927,7 +928,7 @@ def test_update_duplicate_name_within_parent(test_helpers, database_mock, catalo
         database_mock.catalogue_categories,
         {
             **CATALOGUE_CATEGORY_INFO,
-            "_id": CustomObjectId(catalogue_category_id),
+            "_id": ObjectId(),
         },
     )
 
@@ -983,7 +984,7 @@ def test_update_duplicate_name_within_new_parent(test_helpers, database_mock, ca
         database_mock.catalogue_categories,
         {
             **CATALOGUE_CATEGORY_INFO,
-            "_id": CustomObjectId(catalogue_category_id),
+            "_id": ObjectId(),
         },
     )
 

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -441,9 +441,10 @@ def test_delete_with_children_catalogue_items(test_helpers, database_mock, catal
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
         {
+            **FULL_CATALOGUE_ITEM_A_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "catalogue_category_id": CustomObjectId(catalogue_category_id),
-            **FULL_CATALOGUE_ITEM_A_INFO,
+            
         },
     )
     # pylint: enable=duplicate-code
@@ -1022,9 +1023,9 @@ def test_has_child_elements_with_child_items(test_helpers, database_mock, catalo
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
         {
+            **FULL_CATALOGUE_ITEM_A_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "catalogue_category_id": CustomObjectId(catalogue_category_id),
-            **FULL_CATALOGUE_ITEM_A_INFO,
         },
     )
     # pylint: enable=duplicate-code

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -385,7 +385,7 @@ def test_delete(test_helpers, database_mock, catalogue_category_repository):
     # Mock `delete_one` to return that one document has been deleted
     test_helpers.mock_delete_one(database_mock.catalogue_categories, 1)
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue category document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
     test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
@@ -474,7 +474,7 @@ def test_delete_with_nonexistent_id(test_helpers, database_mock, catalogue_categ
     # Mock `delete_one` to return that no document has been deleted
     test_helpers.mock_delete_one(database_mock.catalogue_categories, 0)
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue category document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
     test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
@@ -972,7 +972,7 @@ def test_has_child_elements_with_no_child_categories(test_helpers, database_mock
     """
     Test has_child_elements returns false when there are no child categories
     """
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue category document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
     test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
@@ -1009,8 +1009,6 @@ def test_has_child_elements_with_child_items(test_helpers, database_mock, catalo
     """
     Test has_child_elements returns true when there are child categories
     """
-
-    # Mock count_documents to return 1 (child element found)
     catalogue_category_id = str(ObjectId())
 
     # Mock `find_one` to return no child catalogue category document

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -22,6 +22,13 @@ from inventory_management_system_api.models.catalogue_category import (
     CatalogueItemProperty,
 )
 
+CATALOGUE_CATEGORY_INFO = {
+            "name": "Category A",
+            "code": "category-a",
+            "is_leaf": False,
+            "parent_id": None,
+            "catalogue_item_properties": [],
+        }
 
 def test_create(test_helpers, database_mock, catalogue_category_repository):
     """
@@ -231,11 +238,7 @@ def test_create_with_parent_id(test_helpers, database_mock, catalogue_category_r
         database_mock.catalogue_categories,
         {
             "_id": CustomObjectId(catalogue_category.parent_id),
-            "name": "Category A",
-            "code": "category-a",
-            "is_leaf": False,
-            "parent_id": None,
-            "catalogue_item_properties": [],
+            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock `count_documents` to return 0 (no duplicate catalogue category found within the parent catalogue category)
@@ -346,11 +349,7 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, c
         database_mock.catalogue_categories,
         {
             "_id": CustomObjectId(catalogue_category.parent_id),
-            "name": "Category A",
-            "code": "category-a",
-            "is_leaf": False,
-            "parent_id": None,
-            "catalogue_item_properties": [],
+            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock `count_documents` to return 1 (duplicate catalogue category found within the parent catalogue category)
@@ -410,11 +409,8 @@ def test_delete_with_children_catalogue_categories(test_helpers, database_mock, 
         database_mock.catalogue_categories,
         {
             "_id": CustomObjectId(str(ObjectId())),
-            "name": "Category A",
-            "code": "category-a",
-            "is_leaf": False,
             "parent_id": catalogue_category_id,
-            "catalogue_item_properties": [],
+            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)
@@ -789,11 +785,10 @@ def test_update(test_helpers, database_mock, catalogue_category_repository):
         database_mock.catalogue_categories,
         {
             "_id": CustomObjectId(catalogue_category.id),
-            "name": "Category A",
-            "code": "category-a",
             "is_leaf": catalogue_category.is_leaf,
             "parent_id": catalogue_category.parent_id,
             "catalogue_item_properties": catalogue_category.catalogue_item_properties,
+            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock `count_documents` to return 0 (no duplicate catalogue category found within the parent catalogue category)
@@ -908,11 +903,10 @@ def test_update_duplicate_name_within_parent(test_helpers, database_mock, catalo
         database_mock.catalogue_categories,
         {
             "_id": CustomObjectId(catalogue_category_id),
-            "name": "Category A",
-            "code": "category-a",
             "is_leaf": update_catalogue_category.is_leaf,
             "parent_id": update_catalogue_category.parent_id,
             "catalogue_item_properties": update_catalogue_category.catalogue_item_properties,
+            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock `count_documents` to return 1 (duplicate catalogue category found within the parent catalogue category)
@@ -998,11 +992,8 @@ def test_has_child_elements_with_child_categories(test_helpers, database_mock, c
         database_mock.catalogue_categories,
         {
             "_id": CustomObjectId(str(ObjectId())),
-            "name": "Category A",
-            "code": "category-a",
-            "is_leaf": False,
             "parent_id": catalogue_category_id,
-            "catalogue_item_properties": [],
+            **CATALOGUE_CATEGORY_INFO,
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -23,12 +23,13 @@ from inventory_management_system_api.models.catalogue_category import (
 )
 
 CATALOGUE_CATEGORY_INFO = {
-            "name": "Category A",
-            "code": "category-a",
-            "is_leaf": False,
-            "parent_id": None,
-            "catalogue_item_properties": [],
-        }
+    "name": "Category A",
+    "code": "category-a",
+    "is_leaf": False,
+    "parent_id": None,
+    "catalogue_item_properties": [],
+}
+
 
 def test_create(test_helpers, database_mock, catalogue_category_repository):
     """

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -240,7 +240,6 @@ def test_create_with_parent_id(test_helpers, database_mock, catalogue_category_r
         {
             **CATALOGUE_CATEGORY_INFO,
             "_id": CustomObjectId(catalogue_category.parent_id),
-            
         },
     )
     # Mock `count_documents` to return 0 (no duplicate catalogue category found within the parent catalogue category)
@@ -413,7 +412,6 @@ def test_delete_with_children_catalogue_categories(test_helpers, database_mock, 
             **CATALOGUE_CATEGORY_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "parent_id": catalogue_category_id,
-            
         },
     )
     # Mock find_one to return 0 (children catalogue items not found)
@@ -444,7 +442,6 @@ def test_delete_with_children_catalogue_items(test_helpers, database_mock, catal
             **FULL_CATALOGUE_ITEM_A_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "catalogue_category_id": CustomObjectId(catalogue_category_id),
-            
         },
     )
     # pylint: enable=duplicate-code

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -65,8 +65,6 @@ def test_create(test_helpers, database_mock, catalogue_item_repository):
     )
     # pylint: enable=duplicate-code
 
-    # Mock `count_documents` to return 0 (no duplicate catalogue item found within the catalogue category)
-    test_helpers.mock_count_documents(database_mock.catalogue_items, 0)
     # Mock `insert_one` to return an object for the inserted catalogue item document
     test_helpers.mock_insert_one(database_mock.catalogue_items, CustomObjectId(catalogue_item.id))
     # Mock `find_one` to return the inserted catalogue item document

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -64,30 +64,34 @@ def test_create(test_helpers, database_mock, catalogue_item_repository):
     """
     # pylint: disable=duplicate-code
     catalogue_item = CatalogueItemOut(
+        **FULL_CATALOGUE_ITEM_A_INFO,
         id=str(ObjectId()),
         catalogue_category_id=str(ObjectId()),
         manufacturer_id=str(ObjectId()),
-        **FULL_CATALOGUE_ITEM_A_INFO,
     )
     # pylint: enable=duplicate-code
 
     # Mock `insert_one` to return an object for the inserted catalogue item document
     test_helpers.mock_insert_one(database_mock.catalogue_items, CustomObjectId(catalogue_item.id))
+
     # Mock `find_one` to return the inserted catalogue item document
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
         {
+            **FULL_CATALOGUE_ITEM_A_INFO,
             "_id": CustomObjectId(catalogue_item.id),
             "catalogue_category_id": CustomObjectId(catalogue_item.catalogue_category_id),
             "manufacturer_id": CustomObjectId(catalogue_item.manufacturer_id),
-            **FULL_CATALOGUE_ITEM_A_INFO,
         },
     )
 
+    # Mock `find_one` to return no duplicate catalogue items found
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
+
     catalogue_item_in = CatalogueItemIn(
+        **FULL_CATALOGUE_ITEM_A_INFO,
         catalogue_category_id=catalogue_item.catalogue_category_id,
         manufacturer_id=catalogue_item.manufacturer_id,
-        **FULL_CATALOGUE_ITEM_A_INFO,
     )
     created_catalogue_item = catalogue_item_repository.create(catalogue_item_in)
 

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -366,7 +366,7 @@ def test_update_with_duplicate_name(test_helpers, database_mock, manufacturer_re
 
     test_helpers.mock_count_documents(database_mock.manufacturers, 1)
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue item document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     with pytest.raises(DuplicateRecordError) as exc:
@@ -406,7 +406,7 @@ def test_partial_update_address(test_helpers, database_mock, manufacturer_reposi
         },
     )
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue item document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     test_helpers.mock_update_one(database_mock.manufacturers)
@@ -462,7 +462,7 @@ def test_delete(test_helpers, database_mock, manufacturer_repository):
 
     test_helpers.mock_delete_one(database_mock.manufacturers, 1)
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue item document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     manufacturer_repository.delete(manufacturer_id)
@@ -484,7 +484,7 @@ def test_delete_with_a_nonexistent_id(test_helpers, database_mock, manufacturer_
     manufacturer_id = str(ObjectId())
 
     test_helpers.mock_delete_one(database_mock.manufacturers, 0)
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child catalogue item document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     with pytest.raises(MissingRecordError) as exc:

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -531,9 +531,9 @@ def test_delete_manufacturer_that_is_part_of_a_catalogue_item(test_helpers, data
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
         {
+            **FULL_CATALOGUE_ITEM_A_INFO,
             "_id": CustomObjectId(str(ObjectId())),
             "catalogue_category_id": CustomObjectId(catalogue_category_id),
-            **FULL_CATALOGUE_ITEM_A_INFO,
         },
     )
     # pylint: enable=duplicate-code

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the `ManufacturerRepo` repository.
 """
-
+from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
 import pytest
 from bson import ObjectId
 
@@ -14,7 +14,7 @@ from inventory_management_system_api.core.exceptions import (
 )
 from inventory_management_system_api.models.manufacturer import ManufacturerIn, ManufacturerOut
 from inventory_management_system_api.schemas.manufacturer import AddressSchema
-from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
+
 
 
 def test_create_manufacturer(test_helpers, database_mock, manufacturer_repository):
@@ -253,9 +253,7 @@ def test_update(test_helpers, database_mock, manufacturer_repository):
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     # Mock count documents to return no duplicate manufactures
     test_helpers.mock_count_documents(database_mock.manufacturers, 0)
@@ -369,14 +367,12 @@ def test_update_with_duplicate_name(test_helpers, database_mock, manufacturer_re
             "telephone": "0348343897",
         },
     )
-    
+
     test_helpers.mock_count_documents(database_mock.manufacturers, 1)
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
-    
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
+
     with pytest.raises(DuplicateRecordError) as exc:
         manufacturer_repository.update(manufacturer_id, updated_manufacturer)
 
@@ -415,9 +411,7 @@ def test_partial_update_address(test_helpers, database_mock, manufacturer_reposi
     )
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     test_helpers.mock_update_one(database_mock.manufacturers)
 
@@ -471,11 +465,9 @@ def test_delete(test_helpers, database_mock, manufacturer_repository):
     manufacturer_id = str(ObjectId())
 
     test_helpers.mock_delete_one(database_mock.manufacturers, 1)
-    
+
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     manufacturer_repository.delete(manufacturer_id)
 
@@ -497,10 +489,8 @@ def test_delete_with_a_nonexistent_id(test_helpers, database_mock, manufacturer_
 
     test_helpers.mock_delete_one(database_mock.manufacturers, 0)
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items, None
-    )
-    
+    test_helpers.mock_find_one(database_mock.catalogue_items, None)
+
     with pytest.raises(MissingRecordError) as exc:
         manufacturer_repository.delete(manufacturer_id)
     assert str(exc.value) == f"No manufacturer found with ID: {manufacturer_id}"
@@ -513,6 +503,7 @@ def test_delete_manufacturer_that_is_part_of_a_catalogue_item(test_helpers, data
 
     catalogue_category_id = str(ObjectId())
 
+    # pylint: disable=duplicate-code
     # Mock `find_one` to return the child catalogue item document
     test_helpers.mock_find_one(
         database_mock.catalogue_items,
@@ -522,7 +513,7 @@ def test_delete_manufacturer_that_is_part_of_a_catalogue_item(test_helpers, data
             **FULL_CATALOGUE_ITEM_A_INFO,
         },
     )
-
+    # pylint: enable=duplicate-code
     with pytest.raises(PartOfCatalogueItemError) as exc:
         manufacturer_repository.delete(manufacturer_id)
     assert str(exc.value) == f"The manufacturer with id {str(manufacturer_id)} is a part of a Catalogue Item"

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -252,9 +252,6 @@ def test_update(test_helpers, database_mock, manufacturer_repository):
     )
     # pylint: enable=duplicate-code
 
-    # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(database_mock.catalogue_items, None)
-
     # Mock count documents to return no duplicate manufactures
     test_helpers.mock_count_documents(database_mock.manufacturers, 0)
 

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -16,7 +16,6 @@ from inventory_management_system_api.models.manufacturer import ManufacturerIn, 
 from inventory_management_system_api.schemas.manufacturer import AddressSchema
 
 
-
 def test_create_manufacturer(test_helpers, database_mock, manufacturer_repository):
     """
     Test creating a manufacturer.

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the `ManufacturerRepo` repository.
 """
+from unittest.mock import call
 from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
 import pytest
 from bson import ObjectId
@@ -65,7 +66,12 @@ def test_create_manufacturer(test_helpers, database_mock, manufacturer_repositor
 
     database_mock.manufacturers.insert_one.assert_called_once_with(manufacturer_in.model_dump())
     # pylint: enable=duplicate-code
-    database_mock.manufacturers.find_one.assert_called_with({"_id": CustomObjectId(manufacturer.id)})
+    database_mock.manufacturers.find_one.assert_has_calls(
+        [
+            call({"code": manufacturer.code}),
+            call({"_id": CustomObjectId(manufacturer.id)}),
+        ]
+    )
     assert created_manufacturer == manufacturer
 
 
@@ -95,7 +101,7 @@ def test_create_manufacturer_duplicate(test_helpers, database_mock, manufacturer
     test_helpers.mock_find_one(
         database_mock.manufacturers,
         {
-            "_id": CustomObjectId(manufacturer.id),
+            "_id": ObjectId(),
             "code": manufacturer.code,
             "name": manufacturer.name,
             "url": manufacturer.url,
@@ -359,7 +365,7 @@ def test_update_with_duplicate_name(test_helpers, database_mock, manufacturer_re
     test_helpers.mock_find_one(
         database_mock.manufacturers,
         {
-            "_id": CustomObjectId(manufacturer_id),
+            "_id": ObjectId(),
             "code": "manufacturer-b",
             "name": "Manufacturer B",
             "url": "http://example.com",

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -448,9 +448,7 @@ def test_delete(test_helpers, database_mock, system_repository):
     test_helpers.mock_delete_one(database_mock.systems, 1)
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.systems, None
-    )
+    test_helpers.mock_find_one(database_mock.systems, None)
 
     system_repository.delete(system_id)
 
@@ -471,12 +469,12 @@ def test_delete_with_child_systems(test_helpers, database_mock, system_repositor
     # Mock count_documents to return 1 (children elements found)
     # Mock `find_one` to return 0 (children elements not found)
     test_helpers.mock_find_one(
-        database_mock.systems, 
+        database_mock.systems,
         {
-        "id": str(ObjectId()),
-        **SYSTEM_A_INFO,
-        "parent_id": system_id,
-    }
+            "id": str(ObjectId()),
+            **SYSTEM_A_INFO,
+            "parent_id": system_id,
+        },
     )
 
     with pytest.raises(ChildrenElementsExistError) as exc:
@@ -512,9 +510,7 @@ def test_delete_with_non_existent_id(test_helpers, database_mock, system_reposit
     test_helpers.mock_delete_one(database_mock.systems, 0)
 
     # Mock `find_one` to return 0 (children elements not found)
-    test_helpers.mock_find_one(
-        database_mock.systems, None
-    )
+    test_helpers.mock_find_one(database_mock.systems, None)
 
     with pytest.raises(MissingRecordError) as exc:
         system_repository.delete(system_id)

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -447,7 +447,7 @@ def test_delete(test_helpers, database_mock, system_repository):
     # Mock `delete_one` to return that one document has been deleted
     test_helpers.mock_delete_one(database_mock.systems, 1)
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child system document
     test_helpers.mock_find_one(database_mock.systems, None)
 
     system_repository.delete(system_id)
@@ -467,7 +467,7 @@ def test_delete_with_child_systems(test_helpers, database_mock, system_repositor
     test_helpers.mock_delete_one(database_mock.systems, 1)
 
     # Mock count_documents to return 1 (children elements found)
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no child system document
     test_helpers.mock_find_one(
         database_mock.systems,
         {
@@ -509,7 +509,7 @@ def test_delete_with_non_existent_id(test_helpers, database_mock, system_reposit
     # Mock `delete_one` to return that no document has been deleted
     test_helpers.mock_delete_one(database_mock.systems, 0)
 
-    # Mock `find_one` to return 0 (children elements not found)
+    # Mock `find_one` to return no system document
     test_helpers.mock_find_one(database_mock.systems, None)
 
     with pytest.raises(MissingRecordError) as exc:

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -83,8 +83,8 @@ def test_create(test_helpers, database_mock, system_repository):
     system = SystemOut(id=str(ObjectId()), **system_info)
     # pylint: enable=duplicate-code
 
-    # Mock `count_documents` to return 0 (no duplicate system found within the parent system)
-    test_helpers.mock_count_documents(database_mock.systems, 0)
+    # Mock `find_one` to return no duplicate systen found in parent system
+    test_helpers.mock_find_one(database_mock.systems, None)
     # Mock `insert_one` to return an object for the inserted system document
     test_helpers.mock_insert_one(database_mock.systems, CustomObjectId(system.id))
     # Mock `find_one` to return the inserted system document
@@ -120,8 +120,8 @@ def test_create_with_parent_id(test_helpers, database_mock, system_repository):
         {"_id": CustomObjectId(system.parent_id), "parent_id": None, **SYSTEM_A_INFO},
     )
     # pylint: enable=duplicate-code
-    # Mock `count_documents` to return 0 (no duplicate system found within the parent system)
-    test_helpers.mock_count_documents(database_mock.systems, 0)
+    # Mock `find_one` to return no duplicate systen found in parent system
+    test_helpers.mock_find_one(database_mock.systems, None)
     # Mock `insert_one` to return an object for the inserted system document
     test_helpers.mock_insert_one(database_mock.systems, CustomObjectId(system.id))
     # Mock `find_one` to return the inserted system document
@@ -136,7 +136,11 @@ def test_create_with_parent_id(test_helpers, database_mock, system_repository):
         {**system_info, "parent_id": CustomObjectId(system.parent_id)},
     )
     database_mock.systems.find_one.assert_has_calls(
-        [call({"_id": CustomObjectId(system.parent_id)}), call({"_id": CustomObjectId(system.id)})]
+        [
+            call({"_id": CustomObjectId(system.parent_id)}),
+            call({"parent_id": CustomObjectId(system.parent_id), "code": system.code}),
+            call({"_id": CustomObjectId(system.id)}),
+        ]
     )
     assert created_system == system
 
@@ -189,8 +193,14 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, s
             **SYSTEM_A_INFO,
         },
     )
-    # Mock `count_documents` to return 1 (duplicate system found within the parent system)
-    test_helpers.mock_count_documents(database_mock.systems, 1)
+    # Mock `find_one` to return duplicate systen found in parent system
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {
+            "_id": CustomObjectId(system.parent_id),
+            **SYSTEM_A_INFO,
+        },
+    )
 
     with pytest.raises(DuplicateRecordError) as exc:
         system_repository.create(SystemIn(**system_info))
@@ -346,14 +356,20 @@ def test_update(test_helpers, database_mock, system_repository):
     """
     system = SystemOut(id=str(ObjectId()), **SYSTEM_A_INFO)
 
-    # Mock `find_one` to return the updated System document
-    test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(system.id), **SYSTEM_A_INFO})
-    # Mock `count_documents` to return 0 (no duplicate System found within the parent System)
-    test_helpers.mock_count_documents(database_mock.systems, 0)
+    # Mock `find_one` to return a System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {
+            **SYSTEM_A_INFO,
+            "_id": CustomObjectId(system.id),
+        },
+    )
+
     # Mock `update_one` to return an object for the updated System document
     test_helpers.mock_update_one(database_mock.systems)
+
     # Mock `find_one` to return the updated System document
-    test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(system.id), **SYSTEM_A_INFO})
+    test_helpers.mock_find_one(database_mock.systems, {**SYSTEM_A_INFO, "_id": CustomObjectId(system.id)})
 
     system_in = SystemIn(**SYSTEM_A_INFO)
     updated_system = system_repository.update(system.id, system_in)
@@ -425,15 +441,14 @@ def test_update_duplicate_name_within_parent(test_helpers, database_mock, system
 
     # Mock `find_one` to return a parent System document
     test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(system_id), **SYSTEM_B_INFO})
-    # Mock `count_documents` to return 1 (duplicate System found within the parent System)
-    test_helpers.mock_count_documents(database_mock.systems, 1)
+    # Mock `find_one` to return duplicate systen found in parent system
+    test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(system_id), **SYSTEM_B_INFO})
 
     with pytest.raises(DuplicateRecordError) as exc:
         system_repository.update(system_id, system)
     assert str(exc.value) == "Duplicate System found within the parent System"
 
     database_mock.systems.update_one.assert_not_called()
-    database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(system_id)})
 
 
 def test_delete(test_helpers, database_mock, system_repository):

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -197,8 +197,8 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, s
     test_helpers.mock_find_one(
         database_mock.systems,
         {
-            "_id": CustomObjectId(system.parent_id),
             **SYSTEM_A_INFO,
+            "_id": CustomObjectId(system.parent_id),
         },
     )
 
@@ -442,7 +442,13 @@ def test_update_duplicate_name_within_parent(test_helpers, database_mock, system
     # Mock `find_one` to return a parent System document
     test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(system_id), **SYSTEM_B_INFO})
     # Mock `find_one` to return duplicate systen found in parent system
-    test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(system_id), **SYSTEM_B_INFO})
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {
+            **SYSTEM_B_INFO,
+            "_id": CustomObjectId(system_id),
+        },
+    )
 
     with pytest.raises(DuplicateRecordError) as exc:
         system_repository.update(system_id, system)
@@ -486,8 +492,8 @@ def test_delete_with_child_systems(test_helpers, database_mock, system_repositor
     test_helpers.mock_find_one(
         database_mock.systems,
         {
-            "id": str(ObjectId()),
             **SYSTEM_A_INFO,
+            "id": str(ObjectId()),
             "parent_id": system_id,
         },
     )

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -198,7 +198,7 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, s
         database_mock.systems,
         {
             **SYSTEM_A_INFO,
-            "_id": CustomObjectId(system.parent_id),
+            "_id": ObjectId(),
         },
     )
 
@@ -370,6 +370,9 @@ def test_update(test_helpers, database_mock, system_repository):
 
     # Mock `find_one` to return the updated System document
     test_helpers.mock_find_one(database_mock.systems, {**SYSTEM_A_INFO, "_id": CustomObjectId(system.id)})
+
+    # Mock `find_one` to not return a parent System document
+    test_helpers.mock_find_one(database_mock.systems, None)
 
     system_in = SystemIn(**SYSTEM_A_INFO)
     updated_system = system_repository.update(system.id, system_in)

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -447,8 +447,10 @@ def test_delete(test_helpers, database_mock, system_repository):
     # Mock `delete_one` to return that one document has been deleted
     test_helpers.mock_delete_one(database_mock.systems, 1)
 
-    # Mock count_documents to return 0 (children elements not found)
-    test_helpers.mock_count_documents(database_mock.systems, 0)
+    # Mock `find_one` to return 0 (children elements not found)
+    test_helpers.mock_find_one(
+        database_mock.systems, None
+    )
 
     system_repository.delete(system_id)
 
@@ -467,7 +469,15 @@ def test_delete_with_child_systems(test_helpers, database_mock, system_repositor
     test_helpers.mock_delete_one(database_mock.systems, 1)
 
     # Mock count_documents to return 1 (children elements found)
-    test_helpers.mock_count_documents(database_mock.systems, 1)
+    # Mock `find_one` to return 0 (children elements not found)
+    test_helpers.mock_find_one(
+        database_mock.systems, 
+        {
+        "id": str(ObjectId()),
+        **SYSTEM_A_INFO,
+        "parent_id": system_id,
+    }
+    )
 
     with pytest.raises(ChildrenElementsExistError) as exc:
         system_repository.delete(system_id)
@@ -501,8 +511,10 @@ def test_delete_with_non_existent_id(test_helpers, database_mock, system_reposit
     # Mock `delete_one` to return that no document has been deleted
     test_helpers.mock_delete_one(database_mock.systems, 0)
 
-    # Mock count_documents to return 0 (children elements not found)
-    test_helpers.mock_count_documents(database_mock.systems, 0)
+    # Mock `find_one` to return 0 (children elements not found)
+    test_helpers.mock_find_one(
+        database_mock.systems, None
+    )
 
     with pytest.raises(MissingRecordError) as exc:
         system_repository.delete(system_id)

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -19,7 +19,7 @@ from inventory_management_system_api.models.catalogue_category import (
 )
 from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueCategoryPatchRequestSchema,
-    CatalogueCategoryPostRequestSchema
+    CatalogueCategoryPostRequestSchema,
 )
 
 


### PR DESCRIPTION
## Description
Refactored logic to use `find_one` for checking for children elements. This was done for catalogue categories, systems and manufacturers. 
(note this has been done for catalogue items in #147)

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #91