### PR TITLE
edit item #13

### DIFF
--- a/inventory_management_system_api/core/exceptions.py
+++ b/inventory_management_system_api/core/exceptions.py
@@ -74,3 +74,9 @@ class DatabaseIntegrityError(DatabaseError):
     """
     Exception raised when something is found in the database that shouldn't have been
     """
+
+
+class InvalidActionError(DatabaseError):
+    """
+    Exception raised when trying to update an item's catalogue item ID
+    """

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -90,3 +90,18 @@ class ItemRepo:
 
         items = self._items_collection.find(query)
         return [ItemOut(**item) for item in items]
+
+
+    def update(self, item_id: str, item: ItemIn) -> ItemOut:
+        """
+        Update an item by its ID in a MongoDB database.
+
+        :param item_id: The ID of the item to update.
+        :param item: The item containing the update data.
+        :return: The updated item.
+        """
+        item_id = CustomObjectId(item_id)
+        logger.info("Updating item with ID: %s in the database", item_id)
+        self._items_collection.update_one({"_id": item_id}, {"$set": item.model_dump()})
+        item = self.get(str(item_id))
+        return item

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -91,7 +91,6 @@ class ItemRepo:
         items = self._items_collection.find(query)
         return [ItemOut(**item) for item in items]
 
-
     def update(self, item_id: str, item: ItemIn) -> ItemOut:
         """
         Update an item by its ID in a MongoDB database.

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -127,7 +127,7 @@ def get_item(
 def partial_update_item(
     item: ItemPatchRequestSchema,
     item_id: Annotated[str, Path(description="The ID of the item to update")],
-    item_service: Annotated[ItemService, Depends()],
+    item_service: Annotated[ItemService, Depends(ItemService)],
 ) -> ItemSchema:
     # pylint: disable=missing-function-docstring
     logger.info("Partially updating item with ID: %s", item_id)
@@ -151,3 +151,7 @@ def partial_update_item(
         message = "An item with such ID was not found"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+    except DatabaseIntegrityError as exc:
+        message = "Unable to update item"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -7,7 +7,7 @@ from typing import Annotated, List, Optional
 from fastapi import APIRouter, Query, status, HTTPException, Depends, Path
 
 from inventory_management_system_api.core.exceptions import (
-    ChildElementsExistError,
+    InvalidActionError,
     InvalidObjectIdError,
     MissingMandatoryCatalogueItemProperty,
     MissingRecordError,
@@ -151,7 +151,7 @@ def partial_update_item(
         message = "Unable to update item"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
-    except ChildElementsExistError as exc:
+    except InvalidActionError as exc:
         message = "Cannot change the catalogue item of an item"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -99,7 +99,11 @@ def get_item(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
 
 
-@router.patch(path="/{item_id}", summary="Update an item partially by ID", response_description="Item updated successfully",)
+@router.patch(
+    path="/{item_id}",
+    summary="Update an item partially by ID",
+    response_description="Item updated successfully",
+)
 def partial_update_item(
     item: ItemPatchRequestSchema,
     item_id: Annotated[str, Path(description="The ID of the item to update")],
@@ -115,19 +119,15 @@ def partial_update_item(
         logger.exception(str(exc))
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     except (MissingRecordError, InvalidObjectIdError) as exc:
-        if (
-            item.catalogue_item_id and item.catalogue_item_id in str(exc) or "catalogue item" in str(exc).lower()
-        ):
+        if item.catalogue_item_id and item.catalogue_item_id in str(exc) or "catalogue item" in str(exc).lower():
             message = "The specified catalogue item ID does not exist"
             logger.exception(message)
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
-        if(
-            item.system_id and item.system_id in str(exc) or "system" in str(exc).lower()
-        ):
+        if item.system_id and item.system_id in str(exc) or "system" in str(exc).lower():
             message = "The specified system ID does not exist"
             logger.exception(message)
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
-        
+
         message = "An item with such ID was not found"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -122,11 +122,11 @@ def partial_update_item(
         if item.catalogue_item_id and item.catalogue_item_id in str(exc) or "catalogue item" in str(exc).lower():
             message = "The specified catalogue item ID does not exist"
             logger.exception(message)
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
         if item.system_id and item.system_id in str(exc) or "system" in str(exc).lower():
             message = "The specified system ID does not exist"
             logger.exception(message)
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
 
         message = "An item with such ID was not found"
         logger.exception(message)

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -7,7 +7,7 @@ from typing import Annotated, List, Optional
 from fastapi import APIRouter, Query, status, HTTPException, Depends, Path
 
 from inventory_management_system_api.core.exceptions import (
-    ChildrenElementsExistError,
+    ChildElementsExistError,
     InvalidObjectIdError,
     MissingMandatoryCatalogueItemProperty,
     MissingRecordError,
@@ -151,7 +151,7 @@ def partial_update_item(
         message = "Unable to update item"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
-    except ChildrenElementsExistError as exc:
+    except ChildElementsExistError as exc:
         message = "Cannot change the catalogue item of an item"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc

--- a/inventory_management_system_api/schemas/item.py
+++ b/inventory_management_system_api/schemas/item.py
@@ -57,6 +57,11 @@ class ItemPatchRequestSchema(ItemPostRequestSchema):
         default=None,
         description="The usage status of the item. 0 means new, 1 means in use, 2 means used, and 3 means scrapped.",
     )
+    properties: Optional[List[PropertyPostRequestSchema]] = Field(
+        default=None,
+        description="The properties specific to this item. Any properties not declared will be overwritten by " 
+                    "the inherited catalogue item properties",
+    )
 
 
 class ItemSchema(ItemPostRequestSchema):

--- a/inventory_management_system_api/schemas/item.py
+++ b/inventory_management_system_api/schemas/item.py
@@ -59,7 +59,7 @@ class ItemPatchRequestSchema(ItemPostRequestSchema):
     )
     properties: Optional[List[PropertyPostRequestSchema]] = Field(
         default=None,
-        description="The properties specific to this item. Any properties not declared will be overwritten by " 
+        description="The properties specific to this item. Any properties not declared will be overwritten by "
                     "the inherited catalogue item properties",
     )
 

--- a/inventory_management_system_api/schemas/item.py
+++ b/inventory_management_system_api/schemas/item.py
@@ -60,7 +60,7 @@ class ItemPatchRequestSchema(ItemPostRequestSchema):
     properties: Optional[List[PropertyPostRequestSchema]] = Field(
         default=None,
         description="The properties specific to this item. Any properties not declared will be overwritten by "
-                    "the inherited catalogue item properties",
+        "the inherited catalogue item properties",
     )
 
 

--- a/inventory_management_system_api/schemas/item.py
+++ b/inventory_management_system_api/schemas/item.py
@@ -43,15 +43,21 @@ class ItemPostRequestSchema(BaseModel):
         "properties found in the catalogue item will be inherited if not explicitly provided.",
     )
 
+
 class ItemPatchRequestSchema(ItemPostRequestSchema):
     """
     Schema model for an item update request.
     """
-    catalogue_item_id: Optional[str] = Field(default=None, description="The ID of the corresponding catalogue item for this item")
+
+    catalogue_item_id: Optional[str] = Field(
+        default=None, description="The ID of the corresponding catalogue item for this item"
+    )
     is_defective: Optional[bool] = Field(default=None, description="Whether the item is defective or not")
     usage_status: Optional[ItemUsageStatus] = Field(
-        default=None, description="The usage status of the item. 0 means new, 1 means in use, 2 means used, and 3 means scrapped."
+        default=None,
+        description="The usage status of the item. 0 means new, 1 means in use, 2 means used, and 3 means scrapped.",
     )
+
 
 class ItemSchema(ItemPostRequestSchema):
     """

--- a/inventory_management_system_api/schemas/item.py
+++ b/inventory_management_system_api/schemas/item.py
@@ -43,6 +43,15 @@ class ItemPostRequestSchema(BaseModel):
         "properties found in the catalogue item will be inherited if not explicitly provided.",
     )
 
+class ItemPatchRequestSchema(ItemPostRequestSchema):
+    """
+    Schema model for an item update request.
+    """
+    catalogue_item_id: Optional[str] = Field(default=None, description="The ID of the corresponding catalogue item for this item")
+    is_defective: Optional[bool] = Field(default=None, description="Whether the item is defective or not")
+    usage_status: Optional[ItemUsageStatus] = Field(
+        default=None, description="The usage status of the item. 0 means new, 1 means in use, 2 means used, and 3 means scrapped."
+    )
 
 class ItemSchema(ItemPostRequestSchema):
     """

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from fastapi import Depends
 
 from inventory_management_system_api.core.exceptions import (
-    ChildElementsExistError,
+    InvalidActionError,
     MissingRecordError,
     DatabaseIntegrityError,
     InvalidObjectIdError,
@@ -145,7 +145,7 @@ class ItemService:
             raise MissingRecordError(f"No item found with ID: {item_id}")
 
         if "catalogue_item_id" in update_data and item.catalogue_item_id != stored_item.catalogue_item_id:
-            raise ChildElementsExistError("Cannot change the catalogue item the item belongs to")
+            raise InvalidActionError("Cannot change the catalogue item the item belongs to")
 
         if "system_id" in update_data and item.system_id != stored_item.system_id:
             system = self._system_repository.get(item.system_id)

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -130,6 +130,8 @@ class ItemService:
         The method checks if the item exists in the database and raises a `MissingRecordError` if it does
         not. If the catalogue item ID or system ID is being updated, it checks if a catalogue item
         and/or system ID with such ID exists and raises a `MissingRecordError` if it does not.
+        When updatimg properties, existing properties must all be supplied, or they will be overwritten
+        by the catalogue item properties.
 
         :param item_id: The ID of the item to update.
         :param item: The item containing the fields that need to be updated.
@@ -155,6 +157,10 @@ class ItemService:
             system = self._system_repository.get(item.system_id)
             if not system:
                 raise MissingRecordError(f"No system found with ID: {item.system_id}")
+
+        # If catalogue item ID not supplied then it will be fetched, and its parent catalogue category.
+        # the defined (at a catalogue category level) and supplied properties will be used to find
+        # missing supplied properties. They will then be processed and validated.
 
         if "properties" in update_data:
             if not catalogue_item:

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -146,7 +146,7 @@ class ItemService:
                 item.properties = [PropertyPostRequestSchema(**prop.model_dump()) for prop in stored_item.properties]
                 update_data = item.model_dump(exclude_unset=True)
 
-        system = None
+        #system = None
         if (
             "system_id" in update_data
             and item.system_id != stored_item.system_id
@@ -174,6 +174,17 @@ class ItemService:
 
             defined_properties = catalogue_category.catalogue_item_properties
             supplied_properties = item.properties
+            missing_supplied_properties = self._find_missing_supplied_properties(
+            catalogue_item.properties, supplied_properties
+            )
+            # Inherit the missing properties from the corresponding catalogue item. Create `PropertyPostRequestSchema`
+            # objects for the inherited properties and add them to the `supplied_properties` list before proceeding with
+            # processing and validation.
+            supplied_properties.extend(
+                [PropertyPostRequestSchema(**prop.model_dump()) for prop in missing_supplied_properties]
+            )
+
+
             update_data["properties"] = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
 
         return self._item_repository.update(

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -36,7 +36,7 @@ class ItemService:
         item_repository: ItemRepo = Depends(ItemRepo),
         catalogue_category_repository: CatalogueCategoryRepo = Depends(CatalogueCategoryRepo),
         catalogue_item_repository: CatalogueItemRepo = Depends(CatalogueItemRepo),
-        system_repository: SystemRepo = Depends(SystemRepo)
+        system_repository: SystemRepo = Depends(SystemRepo),
     ) -> None:
         """
         Initialise the `ItemService` with an `ItemRepo`, `CatalogueCategoryRepo`, and `CatalogueItemRepo` repos.
@@ -119,48 +119,39 @@ class ItemService:
         """
         Update an item by its ID.
 
-        The method checks if the item exists in the database and raises a `MissingRecordError` if it does 
-        not. If the catalogue item ID or system ID is being updated, it checks if a catalogue item  and/or system ID with such ID exists and
-        raises a `MissingRecordError` if it does not.
+        The method checks if the item exists in the database and raises a `MissingRecordError` if it does
+        not. If the catalogue item ID or system ID is being updated, it checks if a catalogue item 
+        and/or system ID with such ID exists and raises a `MissingRecordError` if it does not.
 
         :param item_id: The ID of the item to update.
         :param item: The item containing the fields that need to be updated.
-        :return: The updated item. 
+        :return: The updated item.
         """
         update_data = item.model_dump(exclude_unset=True)
 
         stored_item = self.get(item_id)
         if not stored_item:
             raise MissingRecordError(f"No item found with ID: {item_id}")
-        
+
         catalogue_item = None
-        if (
-            "catalogue_item_id" in update_data
-            and item.catalogue_item_id != stored_item.catalogue_item_id
-        ):
+        if "catalogue_item_id" in update_data and item.catalogue_item_id != stored_item.catalogue_item_id:
             catalogue_item = self._catalogue_item_repository.get(item.catalogue_item_id)
             if not catalogue_item:
                 raise MissingRecordError(f"No catalogue item found with ID: {item.catalogue_item_id}")
-            
+
             if "properties" not in update_data:
                 item.properties = [PropertyPostRequestSchema(**prop.model_dump()) for prop in stored_item.properties]
                 update_data = item.model_dump(exclude_unset=True)
 
-        #system = None
-        if (
-            "system_id" in update_data
-            and item.system_id != stored_item.system_id
-        ):
+        # system = None
+        if "system_id" in update_data and item.system_id != stored_item.system_id:
             system = self._system_repository.get(item.system_id)
             if not system:
                 raise MissingRecordError(f"No system found with ID: {item.system_id}")
-        
 
         if "properties" in update_data:
             if not catalogue_item:
-                catalogue_item = self._catalogue_item_repository.get(
-                    stored_item.catalogue_item_id
-                )
+                catalogue_item = self._catalogue_item_repository.get(stored_item.catalogue_item_id)
 
             try:
                 catalogue_category_id = catalogue_item.catalogue_category_id
@@ -170,12 +161,10 @@ class ItemService:
             except InvalidObjectIdError as exc:
                 raise DatabaseIntegrityError(str(exc)) from exc
 
-        
-
             defined_properties = catalogue_category.catalogue_item_properties
             supplied_properties = item.properties
             missing_supplied_properties = self._find_missing_supplied_properties(
-            catalogue_item.properties, supplied_properties
+                catalogue_item.properties, supplied_properties
             )
             # Inherit the missing properties from the corresponding catalogue item. Create `PropertyPostRequestSchema`
             # objects for the inherited properties and add them to the `supplied_properties` list before proceeding with
@@ -184,15 +173,9 @@ class ItemService:
                 [PropertyPostRequestSchema(**prop.model_dump()) for prop in missing_supplied_properties]
             )
 
-
             update_data["properties"] = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
 
-        return self._item_repository.update(
-            item_id, 
-            ItemIn(**{**stored_item.model_dump(), **update_data})
-        )
-        
-        
+        return self._item_repository.update(item_id, ItemIn(**{**stored_item.model_dump(), **update_data}))
 
     def _find_missing_supplied_properties(
         self, catalogue_item_properties: List[Property], supplied_properties: List[PropertyPostRequestSchema]

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -143,7 +143,6 @@ class ItemService:
                 item.properties = [PropertyPostRequestSchema(**prop.model_dump()) for prop in stored_item.properties]
                 update_data = item.model_dump(exclude_unset=True)
 
-        # system = None
         if "system_id" in update_data and item.system_id != stored_item.system_id:
             system = self._system_repository.get(item.system_id)
             if not system:

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -120,7 +120,7 @@ class ItemService:
         Update an item by its ID.
 
         The method checks if the item exists in the database and raises a `MissingRecordError` if it does
-        not. If the catalogue item ID or system ID is being updated, it checks if a catalogue item 
+        not. If the catalogue item ID or system ID is being updated, it checks if a catalogue item
         and/or system ID with such ID exists and raises a `MissingRecordError` if it does not.
 
         :param item_id: The ID of the item to update.

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from fastapi import Depends
 
 from inventory_management_system_api.core.exceptions import (
-    ChildrenElementsExistError,
+    ChildElementsExistError,
     MissingRecordError,
     DatabaseIntegrityError,
     InvalidObjectIdError,
@@ -145,7 +145,7 @@ class ItemService:
             raise MissingRecordError(f"No item found with ID: {item_id}")
 
         if "catalogue_item_id" in update_data and item.catalogue_item_id != stored_item.catalogue_item_id:
-            raise ChildrenElementsExistError("Cannot change the catalogue item the item belongs to")
+            raise ChildElementsExistError("Cannot change the catalogue item the item belongs to")
 
         if "system_id" in update_data and item.system_id != stored_item.system_id:
             system = self._system_repository.get(item.system_id)

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -142,9 +142,9 @@ class ItemService:
             if not catalogue_item:
                 raise MissingRecordError(f"No catalogue item found with ID: {item.catalogue_item_id}")
             
-            # if "properties" not in update_data:
-            #     item.properties = [PropertyPostRequestSchema(**prop.model_dump()) for prop in stored_item.properties]
-            #     update_data = item.model_dump(exclude_unset=True)
+            if "properties" not in update_data:
+                item.properties = [PropertyPostRequestSchema(**prop.model_dump()) for prop in stored_item.properties]
+                update_data = item.model_dump(exclude_unset=True)
 
         system = None
         if (
@@ -156,25 +156,25 @@ class ItemService:
                 raise MissingRecordError(f"No system found with ID: {item.system_id}")
         
 
-        # if "properties" in update_data:
-        #     if not catalogue_item:
-        #         catalogue_item = self._catalogue_item_repository.get(
-        #             stored_item.catalogue_item_id
-        #         )
+        if "properties" in update_data:
+            if not catalogue_item:
+                catalogue_item = self._catalogue_item_repository.get(
+                    stored_item.catalogue_item_id
+                )
 
-        #     try:
-        #         catalogue_category_id = catalogue_item.catalogue_category_id
-        #         catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
-        #         if not catalogue_category:
-        #             raise DatabaseIntegrityError(f"No catalogue category found with ID: {catalogue_category_id}")
-        #     except InvalidObjectIdError as exc:
-        #         raise DatabaseIntegrityError(str(exc)) from exc
+            try:
+                catalogue_category_id = catalogue_item.catalogue_category_id
+                catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
+                if not catalogue_category:
+                    raise DatabaseIntegrityError(f"No catalogue category found with ID: {catalogue_category_id}")
+            except InvalidObjectIdError as exc:
+                raise DatabaseIntegrityError(str(exc)) from exc
 
         
 
-        #     defined_properties = catalogue_category.catalogue_item_properties
-        #     supplied_properties = item.properties
-        #     update_data["properties"] = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
+            defined_properties = catalogue_category.catalogue_item_properties
+            supplied_properties = item.properties
+            update_data["properties"] = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
 
         return self._item_repository.update(
             item_id, 

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -18,8 +18,9 @@ from inventory_management_system_api.models.item import ItemOut, ItemIn
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
+from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.schemas.catalogue_item import PropertyPostRequestSchema
-from inventory_management_system_api.schemas.item import ItemPostRequestSchema
+from inventory_management_system_api.schemas.item import ItemPatchRequestSchema, ItemPostRequestSchema
 from inventory_management_system_api.services import utils
 
 logger = logging.getLogger()
@@ -35,6 +36,7 @@ class ItemService:
         item_repository: ItemRepo = Depends(ItemRepo),
         catalogue_category_repository: CatalogueCategoryRepo = Depends(CatalogueCategoryRepo),
         catalogue_item_repository: CatalogueItemRepo = Depends(CatalogueItemRepo),
+        system_repository: SystemRepo = Depends(SystemRepo)
     ) -> None:
         """
         Initialise the `ItemService` with an `ItemRepo`, `CatalogueCategoryRepo`, and `CatalogueItemRepo` repos.
@@ -46,6 +48,7 @@ class ItemService:
         self._item_repository = item_repository
         self._catalogue_category_repository = catalogue_category_repository
         self._catalogue_item_repository = catalogue_item_repository
+        self._system_repository = system_repository
 
     def create(self, item: ItemPostRequestSchema) -> ItemOut:
         """
@@ -110,8 +113,75 @@ class ItemService:
         :param item_id: The ID of the item to retrieve
         :return: The retrieved item, or `None` if not found
         """
-
         return self._item_repository.get(item_id)
+
+    def update(self, item_id: str, item: ItemPatchRequestSchema) -> ItemOut:
+        """
+        Update an item by its ID.
+
+        The method checks if the item exists in the database and raises a `MissingRecordError` if it does 
+        not. If the catalogue item ID or system ID is being updated, it checks if a catalogue item  and/or system ID with such ID exists and
+        raises a `MissingRecordError` if it does not.
+
+        :param item_id: The ID of the item to update.
+        :param item: The item containing the fields that need to be updated.
+        :return: The updated item. 
+        """
+        update_data = item.model_dump(exclude_unset=True)
+
+        stored_item = self.get(item_id)
+        if not stored_item:
+            raise MissingRecordError(f"No item found with ID: {item_id}")
+        
+        catalogue_item = None
+        if (
+            "catalogue_item_id" in update_data
+            and item.catalogue_item_id != stored_item.catalogue_item_id
+        ):
+            catalogue_item = self._catalogue_item_repository.get(item.catalogue_item_id)
+            if not catalogue_item:
+                raise MissingRecordError(f"No catalogue item found with ID: {item.catalogue_item_id}")
+            
+            # if "properties" not in update_data:
+            #     item.properties = [PropertyPostRequestSchema(**prop.model_dump()) for prop in stored_item.properties]
+            #     update_data = item.model_dump(exclude_unset=True)
+
+        system = None
+        if (
+            "system_id" in update_data
+            and item.system_id != stored_item.system_id
+        ):
+            system = self._system_repository.get(item.system_id)
+            if not system:
+                raise MissingRecordError(f"No system found with ID: {item.system_id}")
+        
+
+        # if "properties" in update_data:
+        #     if not catalogue_item:
+        #         catalogue_item = self._catalogue_item_repository.get(
+        #             stored_item.catalogue_item_id
+        #         )
+
+        #     try:
+        #         catalogue_category_id = catalogue_item.catalogue_category_id
+        #         catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
+        #         if not catalogue_category:
+        #             raise DatabaseIntegrityError(f"No catalogue category found with ID: {catalogue_category_id}")
+        #     except InvalidObjectIdError as exc:
+        #         raise DatabaseIntegrityError(str(exc)) from exc
+
+        
+
+        #     defined_properties = catalogue_category.catalogue_item_properties
+        #     supplied_properties = item.properties
+        #     update_data["properties"] = utils.process_catalogue_item_properties(defined_properties, supplied_properties)
+
+        return self._item_repository.update(
+            item_id, 
+            ItemIn(**{**stored_item.model_dump(), **update_data})
+        )
+        
+        
 
     def _find_missing_supplied_properties(
         self, catalogue_item_properties: List[Property], supplied_properties: List[PropertyPostRequestSchema]

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -2,7 +2,6 @@
 End-to-End tests for the catalogue item router.
 """
 from unittest.mock import ANY
-from test.e2e.test_system import SYSTEM_POST_B
 from bson import ObjectId
 
 
@@ -48,6 +47,14 @@ MANUFACTURER_POST = {
 
 SYSTEM_POST_A = {
     "name": "System A",
+    "description": "System description",
+    "location": "Test location",
+    "owner": "Me",
+    "importance": "low",
+}
+
+SYSTEM_POST_B = {
+    "name": "System B",
     "description": "System description",
     "location": "Test location",
     "owner": "Me",

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -2,10 +2,10 @@
 End-to-End tests for the catalogue item router.
 """
 from unittest.mock import ANY
-
+from test.e2e.test_system import SYSTEM_POST_B
 from bson import ObjectId
 
-from test.e2e.test_system import SYSTEM_POST_B
+
 
 # pylint: disable=duplicate-code
 CATALOGUE_CATEGORY_POST_A = {
@@ -552,6 +552,7 @@ def test_get_item_with_invalid_id(test_client):
     assert response.status_code == 404
     assert response.json()["detail"] == "An item with such ID was not found"
 
+
 def test_partial_update_item(test_client):
     """
     Test changing 'usage_status' and 'is_defective' in an item
@@ -584,12 +585,8 @@ def test_partial_update_item(test_client):
 
     item = response.json()
 
-    assert item == {
-        **ITEM_POST_EXPECTED,
-        **item_patch,
-        "catalogue_item_id": catalogue_item_id, 
-        "system_id": system_id
-    }
+    assert item == {**ITEM_POST_EXPECTED, **item_patch, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
+
 
 def test_partial_update_item_invalid_id(test_client):
     """
@@ -602,6 +599,7 @@ def test_partial_update_item_invalid_id(test_client):
     assert response.status_code == 404
     assert response.json()["detail"] == "An item with such ID was not found"
 
+
 def test_partial_update_item_nonexistent_id(test_client):
     """
     Test updating an item with a nonexistent ID.
@@ -612,6 +610,7 @@ def test_partial_update_item_nonexistent_id(test_client):
 
     assert response.status_code == 404
     assert response.json()["detail"] == "An item with such ID was not found"
+
 
 def test_partial_update_change_catalogue_item_id(test_client):
     """
@@ -640,9 +639,7 @@ def test_partial_update_change_catalogue_item_id(test_client):
 
     item_id = response.json()["id"]
 
-    item_patch = {
-        "catalogue_item_id": catalogue_item_id_b
-    }
+    item_patch = {"catalogue_item_id": catalogue_item_id_b}
 
     response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
 
@@ -653,9 +650,10 @@ def test_partial_update_change_catalogue_item_id(test_client):
     assert item == {
         **ITEM_POST_EXPECTED,
         **item_patch,
-        "catalogue_item_id": catalogue_item_id_b, 
-        "system_id": system_id
+        "catalogue_item_id": catalogue_item_id_b,
+        "system_id": system_id,
     }
+
 
 def test_partial_update_change_system_id(test_client):
     """
@@ -685,9 +683,7 @@ def test_partial_update_change_system_id(test_client):
 
     item_id = response.json()["id"]
 
-    item_patch = {
-        "system_id": system_id_b
-    }
+    item_patch = {"system_id": system_id_b}
 
     response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
 
@@ -698,9 +694,10 @@ def test_partial_update_change_system_id(test_client):
     assert item == {
         **ITEM_POST_EXPECTED,
         **item_patch,
-        "catalogue_item_id": catalogue_item_id, 
-        "system_id": system_id_b
+        "catalogue_item_id": catalogue_item_id,
+        "system_id": system_id_b,
     }
+
 
 def test_partial_update_item_change_value_for_string_property_invalid_type(test_client):
     """
@@ -725,12 +722,8 @@ def test_partial_update_item_change_value_for_string_property_invalid_type(test_
     response = test_client.post("/v1/items", json=item_post)
 
     item_id = response.json()["id"]
-    
-    item_patch = {
-        "properties": [
-            {"name": "Property C", "value": 21}
-        ]
-    }
+
+    item_patch = {"properties": [{"name": "Property C", "value": 21}]}
 
     response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
 
@@ -739,6 +732,7 @@ def test_partial_update_item_change_value_for_string_property_invalid_type(test_
         response.json()["detail"]
         == "Invalid value type for catalogue item property 'Property C'. Expected type: string."
     )
+
 
 def test_partial_update_item_change_value_for_number_property_invalid_type(test_client):
     """
@@ -763,12 +757,8 @@ def test_partial_update_item_change_value_for_number_property_invalid_type(test_
     response = test_client.post("/v1/items", json=item_post)
 
     item_id = response.json()["id"]
-    
-    item_patch = {
-        "properties": [
-            {"name": "Property A", "value": "21"}
-        ]
-    }
+
+    item_patch = {"properties": [{"name": "Property A", "value": "21"}]}
 
     response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
 
@@ -777,6 +767,7 @@ def test_partial_update_item_change_value_for_number_property_invalid_type(test_
         response.json()["detail"]
         == "Invalid value type for catalogue item property 'Property A'. Expected type: number."
     )
+
 
 def test_partial_update_item_change_value_for_boolean_property_invalid_type(test_client):
     """
@@ -801,12 +792,8 @@ def test_partial_update_item_change_value_for_boolean_property_invalid_type(test
     response = test_client.post("/v1/items", json=item_post)
 
     item_id = response.json()["id"]
-    
-    item_patch = {
-        "properties": [
-            {"name": "Property B", "value": 21}
-        ]
-    }
+
+    item_patch = {"properties": [{"name": "Property B", "value": 21}]}
 
     response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
 
@@ -815,4 +802,3 @@ def test_partial_update_item_change_value_for_boolean_property_invalid_type(test
         response.json()["detail"]
         == "Invalid value type for catalogue item property 'Property B'. Expected type: boolean."
     )
-

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -6,7 +6,6 @@ from test.e2e.test_system import SYSTEM_POST_B
 from bson import ObjectId
 
 
-
 # pylint: disable=duplicate-code
 CATALOGUE_CATEGORY_POST_A = {
     "name": "Category A",

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -691,7 +691,6 @@ def test_partial_update_try_change_catalogue_item_id(test_client):
     response = test_client.post("/v1/items", json=item_post)
 
     item_patch = {"catalogue_item_id": str(ObjectId())}
-
     response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 422
@@ -710,9 +709,11 @@ def test_partial_update_change_system_id(test_client):
 
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
     catalogue_category_id = response.json()["id"]
+
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER_POST)
-    # pylint: disable=duplicate-code
     manufacturer_id = response.json()["id"]
+
+    # pylint: disable=duplicate-code
     catalogue_item_post = {
         **CATALOGUE_ITEM_POST_A,
         "catalogue_category_id": catalogue_category_id,
@@ -720,15 +721,13 @@ def test_partial_update_change_system_id(test_client):
     }
     response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
     catalogue_item_id = response.json()["id"]
+
     # pylint: enable=duplicate-code
     item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id, "system_id": system_id_a}
     response = test_client.post("/v1/items", json=item_post)
 
-    item_id = response.json()["id"]
-
     item_patch = {"system_id": system_id_b}
-
-    response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
+    response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 200
 
@@ -749,9 +748,11 @@ def test_partial_update_change_nonexistent_system_id(test_client):
 
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
     catalogue_category_id = response.json()["id"]
+
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER_POST)
-    # pylint: disable=duplicate-code
     manufacturer_id = response.json()["id"]
+
+    # pylint: disable=duplicate-code
     catalogue_item_post = {
         **CATALOGUE_ITEM_POST_A,
         "catalogue_category_id": catalogue_category_id,
@@ -759,15 +760,13 @@ def test_partial_update_change_nonexistent_system_id(test_client):
     }
     response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
     catalogue_item_id = response.json()["id"]
+
     # pylint: enable=duplicate-code
     item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
     response = test_client.post("/v1/items", json=item_post)
 
-    item_id = response.json()["id"]
-
     item_patch = {"system_id": str(ObjectId())}
-
-    response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
+    response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 422
     assert response.json()["detail"] == "The specified system ID does not exist"
@@ -804,7 +803,6 @@ def test_partial_update_property_values(test_client):
             {"name": "Property C", "value": "20x15x10", "unit": "cm"},
         ],
     }
-
     response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 200
@@ -841,7 +839,6 @@ def test_partial_update_not_all_supplied_properties(test_client):
     item_patch = {
         "properties": [{"name": "Property A", "value": 15, "unit": "mm"}],
     }
-
     response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 200
@@ -862,11 +859,14 @@ def test_partial_update_item_change_value_for_string_property_invalid_type(test_
     """
     response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
     system_id = response.json()["id"]
+
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
     catalogue_category_id = response.json()["id"]
+
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER_POST)
-    # pylint: disable=duplicate-code
     manufacturer_id = response.json()["id"]
+
+    # pylint: disable=duplicate-code
     catalogue_item_post = {
         **CATALOGUE_ITEM_POST_A,
         "catalogue_category_id": catalogue_category_id,
@@ -874,15 +874,13 @@ def test_partial_update_item_change_value_for_string_property_invalid_type(test_
     }
     response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
     catalogue_item_id = response.json()["id"]
+
     # pylint: enable=duplicate-code
     item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
     response = test_client.post("/v1/items", json=item_post)
 
-    item_id = response.json()["id"]
-
     item_patch = {"properties": [{"name": "Property C", "value": 21}]}
-
-    response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
+    response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 422
     assert (
@@ -897,11 +895,14 @@ def test_partial_update_item_change_value_for_number_property_invalid_type(test_
     """
     response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
     system_id = response.json()["id"]
+
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
     catalogue_category_id = response.json()["id"]
+
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER_POST)
-    # pylint: disable=duplicate-code
     manufacturer_id = response.json()["id"]
+
+    # pylint: disable=duplicate-code
     catalogue_item_post = {
         **CATALOGUE_ITEM_POST_A,
         "catalogue_category_id": catalogue_category_id,
@@ -909,15 +910,13 @@ def test_partial_update_item_change_value_for_number_property_invalid_type(test_
     }
     response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
     catalogue_item_id = response.json()["id"]
+
     # pylint: enable=duplicate-code
     item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
     response = test_client.post("/v1/items", json=item_post)
 
-    item_id = response.json()["id"]
-
     item_patch = {"properties": [{"name": "Property A", "value": "21"}]}
-
-    response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
+    response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 422
     assert (
@@ -932,11 +931,14 @@ def test_partial_update_item_change_value_for_boolean_property_invalid_type(test
     """
     response = test_client.post("/v1/systems", json=SYSTEM_POST_A)
     system_id = response.json()["id"]
+
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
     catalogue_category_id = response.json()["id"]
+
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER_POST)
-    # pylint: disable=duplicate-code
     manufacturer_id = response.json()["id"]
+
+    # pylint: disable=duplicate-code
     catalogue_item_post = {
         **CATALOGUE_ITEM_POST_A,
         "catalogue_category_id": catalogue_category_id,
@@ -944,15 +946,13 @@ def test_partial_update_item_change_value_for_boolean_property_invalid_type(test
     }
     response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
     catalogue_item_id = response.json()["id"]
+
     # pylint: enable=duplicate-code
     item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id, "system_id": system_id}
     response = test_client.post("/v1/items", json=item_post)
 
-    item_id = response.json()["id"]
-
     item_patch = {"properties": [{"name": "Property B", "value": 21}]}
-
-    response = test_client.patch(f"/v1/items/{item_id}", json=item_patch)
+    response = test_client.patch(f"/v1/items/{response.json()['id']}", json=item_patch)
 
     assert response.status_code == 422
     assert (

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -38,24 +38,41 @@ def test_create(test_helpers, database_mock, item_repository):
     """
     Test creating an item.
     """
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `find_one` to return a system
-    test_helpers.mock_find_one(database_mock.systems, {"_id": CustomObjectId(item.system_id), **FULL_SYSTEM_A_INFO})
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {
+            **FULL_SYSTEM_A_INFO,
+            "_id": CustomObjectId(item.system_id),
+        },
+    )
     # Mock `insert_one` to return an object for the inserted item document
     test_helpers.mock_insert_one(database_mock.items, CustomObjectId(item.id))
     # Mock `find_one` to return the inserted item document
     test_helpers.mock_find_one(
         database_mock.items,
         {
+            **FULL_ITEM_INFO,
             "_id": CustomObjectId(item.id),
             "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
             "system_id": CustomObjectId(item.system_id),
-            **FULL_ITEM_INFO,
         },
     )
 
-    item_in = ItemIn(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **FULL_ITEM_INFO)
+    item_in = ItemIn(
+        **FULL_ITEM_INFO,
+        catalogue_item_id=item.catalogue_item_id,
+        system_id=item.system_id,
+    )
     created_item = item_repository.create(item_in)
 
     database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(item.system_id)})
@@ -73,7 +90,13 @@ def test_create_with_non_existent_system_id(test_helpers, database_mock, item_re
     test_helpers.mock_find_one(database_mock.systems, None)
 
     with pytest.raises(MissingRecordError) as exc:
-        item_repository.create(ItemIn(catalogue_item_id=str(ObjectId()), system_id=system_id, **FULL_ITEM_INFO))
+        item_repository.create(
+            ItemIn(
+                **FULL_ITEM_INFO,
+                catalogue_item_id=str(ObjectId()),
+                system_id=system_id,
+            )
+        )
 
     database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(system_id)})
     database_mock.items.insert_one.assert_not_called()
@@ -131,26 +154,30 @@ def test_list(test_helpers, database_mock, item_repository):
     Verify that the `list` method properly handles the retrieval of items
     """
     item_a = ItemOut(
+        **FULL_ITEM_INFO,
         id=str(ObjectId()),
         catalogue_item_id=str(ObjectId()),
-        **FULL_ITEM_INFO,
     )
 
-    item_b = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), **FULL_ITEM_INFO)
+    item_b = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+    )
 
     # Mock `find` to return a list of item documents
     test_helpers.mock_find(
         database_mock.items,
         [
             {
+                **FULL_ITEM_INFO,
                 "_id": CustomObjectId(item_a.id),
                 "catalogue_item_id": CustomObjectId(item_a.catalogue_item_id),
-                **FULL_ITEM_INFO,
             },
             {
+                **FULL_ITEM_INFO,
                 "_id": CustomObjectId(item_b.id),
                 "catalogue_item_id": CustomObjectId(item_b.catalogue_item_id),
-                **FULL_ITEM_INFO,
             },
         ],
     )
@@ -168,18 +195,24 @@ def test_list_with_system_id_filter(test_helpers, database_mock, item_repository
     Verify that the `list` method properly handles the retrieval of items based on
     the provided system ID filter
     """
-
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of item documents
     test_helpers.mock_find(
         database_mock.items,
         [
             {
+                **FULL_ITEM_INFO,
                 "_id": CustomObjectId(item.id),
                 "system_id": CustomObjectId(item.system_id),
                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                **FULL_ITEM_INFO,
             }
         ],
     )
@@ -198,16 +231,20 @@ def test_list_with_system_id_as_null(test_helpers, database_mock, item_repositor
     the provided system ID filter
     """
 
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), **FULL_ITEM_INFO)
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+    )
 
     # Mock `find` to return a list of item documents
     test_helpers.mock_find(
         database_mock.items,
         [
             {
+                **FULL_ITEM_INFO,
                 "_id": CustomObjectId(item.id),
                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                **FULL_ITEM_INFO,
             }
         ],
     )
@@ -255,17 +292,24 @@ def test_list_with_catalogue_item_id_filter(test_helpers, database_mock, item_re
     Verify that the `list` method properly handles the retrieval of items based on
     the provided catalogue item ID filter
     """
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of item documents
     test_helpers.mock_find(
         database_mock.items,
         [
             {
+                **FULL_ITEM_INFO,
                 "_id": CustomObjectId(item.id),
                 "system_id": CustomObjectId(item.system_id),
                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                **FULL_ITEM_INFO,
             }
         ],
     )
@@ -312,17 +356,24 @@ def test_list_with_both_system_catalogue_item_id_filters(test_helpers, database_
 
     Verify that the `list` methof properly handles the retrieval of items with the provided ID filters
     """
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of item documents
     test_helpers.mock_find(
         database_mock.items,
         [
             {
+                **FULL_ITEM_INFO,
                 "_id": CustomObjectId(item.id),
                 "system_id": CustomObjectId(item.system_id),
                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                **FULL_ITEM_INFO,
             }
         ],
     )
@@ -364,7 +415,14 @@ def test_list_two_filters_no_matching_results(test_helpers, database_mock, item_
     Verify the `list` method properly handles the retrieval of items based on the provided
     system and catalogue item ID filters
     """
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of item documents
     test_helpers.mock_find(
@@ -403,16 +461,23 @@ def test_get(test_helpers, database_mock, item_repository):
 
     Verify that the `get` method properly handles the retrieval of an item by ID.
     """
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `find_one` to return the inserted item document
     test_helpers.mock_find_one(
         database_mock.items,
         {
+            **FULL_ITEM_INFO,
             "_id": CustomObjectId(item.id),
             "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
             "system_id": CustomObjectId(item.system_id),
-            **FULL_ITEM_INFO,
         },
     )
 
@@ -456,7 +521,14 @@ def test_update(test_helpers, database_mock, item_repository):
 
     Verify that the `update` method properly handles the item to be updated.
     """
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # pylint: disable=duplicate-code
+    item = ItemOut(
+        **FULL_ITEM_INFO,
+        id=str(ObjectId()),
+        catalogue_item_id=str(ObjectId()),
+        system_id=str(ObjectId()),
+    )
+    # pylint: enable=duplicate-code
 
     # Mock `update_one` to return an object for the updated item document
     test_helpers.mock_update_one(database_mock.items)

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -405,6 +405,7 @@ def test_get_with_nonexistent_id(test_helpers, database_mock, item_repository):
     assert retrieved_item is None
     database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item_id)})
 
+
 def test_update(test_helpers, database_mock, item_repository):
     """
     Test updating an item.
@@ -422,28 +423,25 @@ def test_update(test_helpers, database_mock, item_repository):
             **FULL_ITEM_INFO,
             "_id": CustomObjectId(item.id),
             "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-            "system_id": CustomObjectId(item.system_id)
-        }
+            "system_id": CustomObjectId(item.system_id),
+        },
     )
 
-    item_in = ItemIn(
-        **FULL_ITEM_INFO,
-        catalogue_item_id=item.catalogue_item_id,
-        system_id=item.system_id
-    )
+    item_in = ItemIn(**FULL_ITEM_INFO, catalogue_item_id=item.catalogue_item_id, system_id=item.system_id)
     updated_item = item_repository.update(item.id, item_in)
 
     database_mock.items.update_one.assert_called_once_with(
         {"_id": CustomObjectId(item.id)},
         {
             "$set": {
-                "catalogue_item_id":  CustomObjectId(item.catalogue_item_id),
+                "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
                 **item_in.model_dump(),
             }
-        }
+        },
     )
     database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item.id)})
     assert updated_item == item
+
 
 def test_update_with_invalid_id(item_repository):
     """

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -8,6 +8,8 @@ import pytest
 
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
 from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
+from inventory_management_system_api.models.item import ItemOut
+from inventory_management_system_api.models.system import SystemOut
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
@@ -101,7 +103,7 @@ def fixture_catalogue_item_service(
 
 @pytest.fixture(name="item_service")
 def fixture_item_service(
-    item_repository_mock: Mock, catalogue_category_repository_mock: Mock, catalogue_item_repository_mock: Mock
+    item_repository_mock: Mock, catalogue_category_repository_mock: Mock, catalogue_item_repository_mock: Mock, system_repository_mock: Mock
 ) -> ItemService:
     """
     Fixture to create an `ItemService` instance with mocked `ItemRepo`, `CatalogueItemRepo`, and
@@ -112,7 +114,7 @@ def fixture_item_service(
     :param catalogue_item_repository_mock: Mocked `CatalogueItemRepo` instance.
     :return: `ItemService` instance with the mocked dependencies.
     """
-    return ItemService(item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock)
+    return ItemService(item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock, system_repository_mock)
 
 
 @pytest.fixture(name="manufacturer_service")
@@ -147,7 +149,7 @@ class ServiceTestHelpers:
     """
 
     @staticmethod
-    def mock_create(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut]) -> None:
+    def mock_create(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut]) -> None:
         """
         Mock the `create` method of the repository mock to return a repository object.
 
@@ -157,7 +159,7 @@ class ServiceTestHelpers:
         repository_mock.create.return_value = repo_obj
 
     @staticmethod
-    def mock_get(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, None]) -> None:
+    def mock_get(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut, None]) -> None:
         """
         Mock the `get` method of the repository mock to return a specific repository object.
 
@@ -184,7 +186,7 @@ class ServiceTestHelpers:
             repository_mock.get_breadcrumbs.side_effect = [breadcrumbs_obj]
 
     @staticmethod
-    def mock_list(repository_mock: Mock, repo_objs: List[Union[CatalogueCategoryOut, CatalogueItemOut]]) -> None:
+    def mock_list(repository_mock: Mock, repo_objs: List[Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut,]]) -> None:
         """
         Mock the `list` method of the repository mock to return a specific list of repository objects.
         objects.
@@ -195,7 +197,7 @@ class ServiceTestHelpers:
         repository_mock.list.return_value = repo_objs
 
     @staticmethod
-    def mock_update(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut]) -> None:
+    def mock_update(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut,]) -> None:
         """
         Mock the `update` method of the repository mock to return a repository object.
 

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -103,7 +103,10 @@ def fixture_catalogue_item_service(
 
 @pytest.fixture(name="item_service")
 def fixture_item_service(
-    item_repository_mock: Mock, catalogue_category_repository_mock: Mock, catalogue_item_repository_mock: Mock, system_repository_mock: Mock
+    item_repository_mock: Mock,
+    catalogue_category_repository_mock: Mock,
+    catalogue_item_repository_mock: Mock,
+    system_repository_mock: Mock,
 ) -> ItemService:
     """
     Fixture to create an `ItemService` instance with mocked `ItemRepo`, `CatalogueItemRepo`, and
@@ -114,7 +117,9 @@ def fixture_item_service(
     :param catalogue_item_repository_mock: Mocked `CatalogueItemRepo` instance.
     :return: `ItemService` instance with the mocked dependencies.
     """
-    return ItemService(item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock, system_repository_mock)
+    return ItemService(
+        item_repository_mock, catalogue_category_repository_mock, catalogue_item_repository_mock, system_repository_mock
+    )
 
 
 @pytest.fixture(name="manufacturer_service")
@@ -149,7 +154,9 @@ class ServiceTestHelpers:
     """
 
     @staticmethod
-    def mock_create(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut]) -> None:
+    def mock_create(
+        repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut]
+    ) -> None:
         """
         Mock the `create` method of the repository mock to return a repository object.
 
@@ -159,7 +166,9 @@ class ServiceTestHelpers:
         repository_mock.create.return_value = repo_obj
 
     @staticmethod
-    def mock_get(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut, None]) -> None:
+    def mock_get(
+        repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut, None]
+    ) -> None:
         """
         Mock the `get` method of the repository mock to return a specific repository object.
 
@@ -186,7 +195,17 @@ class ServiceTestHelpers:
             repository_mock.get_breadcrumbs.side_effect = [breadcrumbs_obj]
 
     @staticmethod
-    def mock_list(repository_mock: Mock, repo_objs: List[Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut,]]) -> None:
+    def mock_list(
+        repository_mock: Mock,
+        repo_objs: List[
+            Union[
+                CatalogueCategoryOut,
+                CatalogueItemOut,
+                ItemOut,
+                SystemOut,
+            ]
+        ],
+    ) -> None:
         """
         Mock the `list` method of the repository mock to return a specific list of repository objects.
         objects.
@@ -197,7 +216,15 @@ class ServiceTestHelpers:
         repository_mock.list.return_value = repo_objs
 
     @staticmethod
-    def mock_update(repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut,]) -> None:
+    def mock_update(
+        repository_mock: Mock,
+        repo_obj: Union[
+            CatalogueCategoryOut,
+            CatalogueItemOut,
+            ItemOut,
+            SystemOut,
+        ],
+    ) -> None:
         """
         Mock the `update` method of the repository mock to return a repository object.
 

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -19,7 +19,7 @@ from inventory_management_system_api.models.catalogue_category import (
 )
 from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueCategoryPatchRequestSchema,
-    CatalogueCategoryPostRequestSchema
+    CatalogueCategoryPostRequestSchema,
 )
 
 

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -13,9 +13,7 @@ from inventory_management_system_api.core.exceptions import (
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
 from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
 from inventory_management_system_api.models.item import ItemOut, ItemIn
-from inventory_management_system_api.models.system import SystemOut
 from inventory_management_system_api.schemas.item import ItemPatchRequestSchema, ItemPostRequestSchema
-from test.unit.repositories.test_item import FULL_SYSTEM_A_INFO
 
 # pylint: disable=duplicate-code
 FULL_CATALOGUE_CATEGORY_A_INFO = {
@@ -295,6 +293,7 @@ def test_get_with_nonexistent_id(test_helpers, item_repository_mock, item_servic
     assert retrieved_item is None
     item_repository_mock.get.assert_called_once_with(item_id)
 
+
 def test_update(test_helpers, item_repository_mock, item_service):
     """
     Test updating an item,
@@ -306,16 +305,13 @@ def test_update(test_helpers, item_repository_mock, item_service):
     # Mock `get` to return an item
     test_helpers.mock_get(
         item_repository_mock,
-        ItemOut(
-            **{**item.model_dump(), "is_defective": True, "usage_status": 1}
-        ),
+        ItemOut(**{**item.model_dump(), "is_defective": True, "usage_status": 1}),
     )
     # Mock `update` to return the updated item
     test_helpers.mock_update(item_repository_mock, item)
 
     updated_item = item_service.update(
-        item.id,
-        ItemPatchRequestSchema(is_defective=item.is_defective, usage_status=item.usage_status)
+        item.id, ItemPatchRequestSchema(is_defective=item.is_defective, usage_status=item.usage_status)
     )
 
     item_repository_mock.update.assert_called_once_with(
@@ -324,9 +320,10 @@ def test_update(test_helpers, item_repository_mock, item_service):
             catalogue_item_id=item.catalogue_item_id,
             system_id=item.system_id,
             **FULL_ITEM_INFO,
-        )
+        ),
     )
     assert updated_item == item
+
 
 def test_update_with_nonexistent_id(test_helpers, item_repository_mock, item_service):
     """
@@ -342,7 +339,10 @@ def test_update_with_nonexistent_id(test_helpers, item_repository_mock, item_ser
         item_service.update(item_id, ItemPatchRequestSchema(properties=[]))
     assert str(exc.value) == f"No item found with ID: {item_id}"
 
-def test_update_change_catalogue_item_id(test_helpers, item_repository_mock, catalogue_item_repository_mock, catalogue_category_repository_mock, item_service):
+
+def test_update_change_catalogue_item_id(
+    test_helpers, item_repository_mock, catalogue_item_repository_mock, catalogue_category_repository_mock, item_service
+):
     """
     Test updating catalogue item id to an existing id
     """
@@ -351,13 +351,7 @@ def test_update_change_catalogue_item_id(test_helpers, item_repository_mock, cat
     # Mock `get` to return an item
     test_helpers.mock_get(
         item_repository_mock,
-        ItemOut(
-            **{
-                **item.model_dump(), 
-               "catalogue_item_id": str(ObjectId())
-            }
-
-        ),
+        ItemOut(**{**item.model_dump(), "catalogue_item_id": str(ObjectId())}),
     )
 
     catalogue_category_id = str(ObjectId())
@@ -388,14 +382,10 @@ def test_update_change_catalogue_item_id(test_helpers, item_repository_mock, cat
     )
 
     item_repository_mock.update.assert_called_once_with(
-        item.id,
-        ItemIn(
-            catalogue_item_id=item.catalogue_item_id,
-            system_id=item.system_id,
-            **FULL_ITEM_INFO
-        )
+        item.id, ItemIn(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **FULL_ITEM_INFO)
     )
     assert updated_item == item
+
 
 # def test_update_change_system_id(test_helpers, item_repository_mock, system_repository_mock, item_service):
 #     """
@@ -408,7 +398,7 @@ def test_update_change_catalogue_item_id(test_helpers, item_repository_mock, cat
 #         item_repository_mock,
 #         ItemOut(
 #             **{
-#                 **item.model_dump(), 
+#                 **item.model_dump(),
 #                "system_id": str(ObjectId())
 #             }
 
@@ -442,8 +432,9 @@ def test_update_change_catalogue_item_id(test_helpers, item_repository_mock, cat
 #     )
 #     assert updated_item == item
 
+
 def test_update_with_nonexistent_catalogue_item_id(
-        test_helpers, catalogue_item_repository_mock, item_repository_mock, item_service
+    test_helpers, catalogue_item_repository_mock, item_repository_mock, item_service
 ):
     """
     Test updating an item with a non-existent catalogue item ID.
@@ -463,6 +454,7 @@ def test_update_with_nonexistent_catalogue_item_id(
             ItemPatchRequestSchema(catalogue_item_id=catalogue_item_id),
         )
     assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
+
 
 # def test_update_with_nonexistent_system_id(
 #         test_helpers, system_repository_mock, item_repository_mock, item_service
@@ -485,23 +477,25 @@ def test_update_with_nonexistent_catalogue_item_id(
 #             ItemPatchRequestSchema(system_id=system_id),
 #         )
 #     assert str(exc.value) == f"No system found with ID: {system_id}"
-    
+
+
 def test_update_change_property_value(
-        test_helpers, catalogue_item_repository_mock, catalogue_category_repository_mock, item_repository_mock, item_service
+    test_helpers, catalogue_item_repository_mock, catalogue_category_repository_mock, item_repository_mock, item_service
 ):
     """
     Test updating a value of a property
     """
-    item_info = {**FULL_ITEM_INFO, "properties": [{"name": "Property A", "value": 1, "unit": "mm"}] + FULL_ITEM_INFO["properties"][-2:]}
+    item_info = {
+        **FULL_ITEM_INFO,
+        "properties": [{"name": "Property A", "value": 1, "unit": "mm"}] + FULL_ITEM_INFO["properties"][-2:],
+    }
 
-    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **item_info )
+    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **item_info)
 
     # Mock `get` to return an item
     test_helpers.mock_get(
         item_repository_mock,
-        ItemOut(
-            **{**item.model_dump(), **FULL_ITEM_INFO}
-        ),
+        ItemOut(**{**item.model_dump(), **FULL_ITEM_INFO}),
     )
 
     catalogue_category_id = str(ObjectId())
@@ -528,23 +522,17 @@ def test_update_change_property_value(
 
     updated_item = item_service.update(
         item.id,
-        ItemPatchRequestSchema(
-            properties=[{"name": prop.name, "value": prop.value} for prop in item.properties]
-        )
+        ItemPatchRequestSchema(properties=[{"name": prop.name, "value": prop.value} for prop in item.properties]),
     )
 
     item_repository_mock.update.assert_called_once_with(
-        item.id,
-        ItemIn(
-            catalogue_item_id=item.catalogue_item_id,
-            system_id=item.system_id,
-            **item_info
-        )
+        item.id, ItemIn(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **item_info)
     )
     assert updated_item == item
 
+
 def test_update_change_value_for_string_property_invalid_type(
-        test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock, item_service
+    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock, item_service
 ):
     """
     Test changing the value of a string property to an invalid type.
@@ -552,10 +540,7 @@ def test_update_change_value_for_string_property_invalid_type(
     item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
 
     # Mock `get` to return an item
-    test_helpers.mock_get(
-        item_repository_mock,
-        item
-    )
+    test_helpers.mock_get(item_repository_mock, item)
 
     catalogue_category_id = str(ObjectId())
     manufacturer_id = str(ObjectId())
@@ -585,8 +570,9 @@ def test_update_change_value_for_string_property_invalid_type(
         )
     assert str(exc.value) == "Invalid value type for catalogue item property 'Property C'. Expected type: string."
 
+
 def test_update_change_value_for_number_property_invalid_type(
-        test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock, item_service
+    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock, item_service
 ):
     """
     Test changing the value of a number property to an invalid type.
@@ -594,10 +580,7 @@ def test_update_change_value_for_number_property_invalid_type(
     item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
 
     # Mock `get` to return an item
-    test_helpers.mock_get(
-        item_repository_mock,
-        item
-    )
+    test_helpers.mock_get(item_repository_mock, item)
 
     catalogue_category_id = str(ObjectId())
     manufacturer_id = str(ObjectId())
@@ -627,8 +610,9 @@ def test_update_change_value_for_number_property_invalid_type(
         )
     assert str(exc.value) == "Invalid value type for catalogue item property 'Property A'. Expected type: number."
 
+
 def test_update_change_valuie_for_boolean_property_invalid_type(
-        test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock, item_service
+    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock, item_service
 ):
     """
     Test changing the value of a boolean property to an invalid type.
@@ -636,10 +620,7 @@ def test_update_change_valuie_for_boolean_property_invalid_type(
     item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
 
     # Mock `get` to return an item
-    test_helpers.mock_get(
-        item_repository_mock,
-        item
-    )
+    test_helpers.mock_get(item_repository_mock, item)
 
     catalogue_category_id = str(ObjectId())
     manufacturer_id = str(ObjectId())

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -7,7 +7,7 @@ import pytest
 from bson import ObjectId
 
 from inventory_management_system_api.core.exceptions import (
-    ChildrenElementsExistError,
+    ChildElementsExistError,
     InvalidCatalogueItemPropertyTypeError,
     MissingRecordError,
     DatabaseIntegrityError,
@@ -391,7 +391,7 @@ def test_try_to_update_catalogue_item_id(
     test_helpers.mock_get(item_repository_mock, item)
 
     catalogue_item_id = str(ObjectId())
-    with pytest.raises(ChildrenElementsExistError) as exc:
+    with pytest.raises(ChildElementsExistError) as exc:
         item_service.update(
             item.id,
             ItemPatchRequestSchema(catalogue_item_id=catalogue_item_id),

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -372,9 +372,7 @@ def test_update_with_nonexistent_id(test_helpers, item_repository_mock, item_ser
     assert str(exc.value) == f"No item found with ID: {item_id}"
 
 
-def test_try_to_update_catalogue_item_id(
-    test_helpers, item_repository_mock, item_service
-):
+def test_try_to_update_catalogue_item_id(test_helpers, item_repository_mock, item_service):
     """
     Test updating an item with a catalogue item ID.
     """

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -13,7 +13,10 @@ from inventory_management_system_api.core.exceptions import (
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
 from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
 from inventory_management_system_api.models.item import ItemOut, ItemIn
+from inventory_management_system_api.models.system import SystemOut
 from inventory_management_system_api.schemas.item import ItemPatchRequestSchema, ItemPostRequestSchema
+from test.unit.repositories.test_item import FULL_SYSTEM_A_INFO
+from test.unit.services.test_system import SYSTEM_A_INFO_FULL
 
 # pylint: disable=duplicate-code
 FULL_CATALOGUE_CATEGORY_A_INFO = {
@@ -386,53 +389,6 @@ def test_update_change_catalogue_item_id(
     )
     assert updated_item == item
 
-
-# def test_update_change_system_id(test_helpers, item_repository_mock, system_repository_mock, item_service):
-#     """
-#     Test updating system id to an existing id
-#     """
-#     item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
-
-#     # Mock `get` to return an item
-#     test_helpers.mock_get(
-#         item_repository_mock,
-#         ItemOut(
-#             **{
-#                 **item.model_dump(),
-#                "system_id": str(ObjectId())
-#             }
-
-#         ),
-#     )
-
-#     # Mock `get` to return a system
-#     test_helpers.mock_get(
-#         system_repository_mock,
-#         SystemOut(
-#             id=item.system_id,
-#             **FULL_SYSTEM_A_INFO
-#         ),
-#     )
-
-#     # Mock `update` to return the updated item
-#     test_helpers.mock_update(item_repository_mock, item)
-
-#     updated_item = item_service.update(
-#         item.id,
-#         ItemPatchRequestSchema(system_id=item.system_id),
-#     )
-
-#     item_repository_mock.update.assert_called_once_with(
-#         item.id,
-#         ItemIn(
-#             catalogue_item_id=item.catalogue_item_id,
-#             system_id=item.system_id,
-#             **FULL_ITEM_INFO
-#         )
-#     )
-#     assert updated_item == item
-
-
 def test_update_with_nonexistent_catalogue_item_id(
     test_helpers, catalogue_item_repository_mock, item_repository_mock, item_service
 ):
@@ -455,28 +411,72 @@ def test_update_with_nonexistent_catalogue_item_id(
         )
     assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
 
+def test_update_change_system_id(test_helpers, item_repository_mock, system_repository_mock, item_service):
+    """
+    Test updating system id to an existing id
+    """
+    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
 
-# def test_update_with_nonexistent_system_id(
-#         test_helpers, system_repository_mock, item_repository_mock, item_service
-# ):
-#     """
-#     Test updating an item with a non-existent system ID.
-#     """
-#     item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+    # Mock `get` to return an item
+    test_helpers.mock_get(
+        item_repository_mock,
+        ItemOut(
+            **{
+                **item.model_dump(),
+                "system_id": str(ObjectId())
+            }
 
-#     # Mock `get` to return an item
-#     test_helpers.mock_get(item_repository_mock, item)
+        ),
+    )
+    
+    # Mock `get` to return a system
+    test_helpers.mock_get(
+        system_repository_mock,
+        SystemOut(
+            id=item.system_id,
+            **SYSTEM_A_INFO_FULL
+        ),
+    )
 
-#     # Mock `get` to not return a catalogue item
-#     test_helpers.mock_get(system_repository_mock, None)
+    # Mock `update` to return the updated item
+    test_helpers.mock_update(item_repository_mock, item)
 
-#     system_id = str(ObjectId())
-#     with pytest.raises(MissingRecordError) as exc:
-#         item_service.update(
-#             item.id,
-#             ItemPatchRequestSchema(system_id=system_id),
-#         )
-#     assert str(exc.value) == f"No system found with ID: {system_id}"
+    updated_item = item_service.update(
+        item.id,
+        ItemPatchRequestSchema(system_id=item.system_id),
+    )
+
+    item_repository_mock.update.assert_called_once_with(
+        item.id,
+        ItemIn(
+            catalogue_item_id=item.catalogue_item_id,
+            system_id=item.system_id,
+            **FULL_ITEM_INFO
+        )
+    )
+    assert updated_item == item
+
+def test_update_with_nonexistent_system_id(
+        test_helpers, system_repository_mock, item_repository_mock, item_service
+):
+    """
+    Test updating an item with a non-existent system ID.
+    """
+    item = ItemOut(id=str(ObjectId()), catalogue_item_id=str(ObjectId()), system_id=str(ObjectId()), **FULL_ITEM_INFO)
+
+    # Mock `get` to return an item
+    test_helpers.mock_get(item_repository_mock, item)
+
+    # Mock `get` to not return a catalogue item
+    test_helpers.mock_get(system_repository_mock, None)
+
+    system_id = str(ObjectId())
+    with pytest.raises(MissingRecordError) as exc:
+        item_service.update(
+            item.id,
+            ItemPatchRequestSchema(system_id=system_id),
+        )
+    assert str(exc.value) == f"No system found with ID: {system_id}"
 
 
 def test_update_change_property_value(

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -1,6 +1,8 @@
 """
 Unit tests for the `ItemService` service.
 """
+from test.unit.services.test_system import SYSTEM_A_INFO_FULL
+
 import pytest
 from bson import ObjectId
 
@@ -15,8 +17,7 @@ from inventory_management_system_api.models.catalogue_item import CatalogueItemO
 from inventory_management_system_api.models.item import ItemOut, ItemIn
 from inventory_management_system_api.models.system import SystemOut
 from inventory_management_system_api.schemas.item import ItemPatchRequestSchema, ItemPostRequestSchema
-from test.unit.repositories.test_item import FULL_SYSTEM_A_INFO
-from test.unit.services.test_system import SYSTEM_A_INFO_FULL
+
 
 # pylint: disable=duplicate-code
 FULL_CATALOGUE_CATEGORY_A_INFO = {
@@ -389,6 +390,7 @@ def test_update_change_catalogue_item_id(
     )
     assert updated_item == item
 
+
 def test_update_with_nonexistent_catalogue_item_id(
     test_helpers, catalogue_item_repository_mock, item_repository_mock, item_service
 ):
@@ -411,6 +413,7 @@ def test_update_with_nonexistent_catalogue_item_id(
         )
     assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
 
+
 def test_update_change_system_id(test_helpers, item_repository_mock, system_repository_mock, item_service):
     """
     Test updating system id to an existing id
@@ -420,22 +423,13 @@ def test_update_change_system_id(test_helpers, item_repository_mock, system_repo
     # Mock `get` to return an item
     test_helpers.mock_get(
         item_repository_mock,
-        ItemOut(
-            **{
-                **item.model_dump(),
-                "system_id": str(ObjectId())
-            }
-
-        ),
+        ItemOut(**{**item.model_dump(), "system_id": str(ObjectId())}),
     )
-    
+
     # Mock `get` to return a system
     test_helpers.mock_get(
         system_repository_mock,
-        SystemOut(
-            id=item.system_id,
-            **SYSTEM_A_INFO_FULL
-        ),
+        SystemOut(id=item.system_id, **SYSTEM_A_INFO_FULL),
     )
 
     # Mock `update` to return the updated item
@@ -447,18 +441,12 @@ def test_update_change_system_id(test_helpers, item_repository_mock, system_repo
     )
 
     item_repository_mock.update.assert_called_once_with(
-        item.id,
-        ItemIn(
-            catalogue_item_id=item.catalogue_item_id,
-            system_id=item.system_id,
-            **FULL_ITEM_INFO
-        )
+        item.id, ItemIn(catalogue_item_id=item.catalogue_item_id, system_id=item.system_id, **FULL_ITEM_INFO)
     )
     assert updated_item == item
 
-def test_update_with_nonexistent_system_id(
-        test_helpers, system_repository_mock, item_repository_mock, item_service
-):
+
+def test_update_with_nonexistent_system_id(test_helpers, system_repository_mock, item_repository_mock, item_service):
     """
     Test updating an item with a non-existent system ID.
     """


### PR DESCRIPTION
## Description
Implemented api endpoint to be able to edit an item. Properties are handled and validated like in catalogue items, however you cannot edit the `catalogue_item_id`

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Closes #13 
