### PR TITLE
Add allowed_values in catalogue category properties #159

### DIFF
--- a/inventory_management_system_api/models/catalogue_category.py
+++ b/inventory_management_system_api/models/catalogue_category.py
@@ -9,6 +9,10 @@ from inventory_management_system_api.models.custom_object_id_data_types import C
 
 
 class AllowedValuesList(BaseModel):
+    """
+    Model representing a list of allowed values for a catalogue item property
+    """
+
     type: Literal["list"]
     values: List[Any]
 

--- a/inventory_management_system_api/models/catalogue_category.py
+++ b/inventory_management_system_api/models/catalogue_category.py
@@ -1,11 +1,20 @@
 """
 Module for defining the database models for representing catalogue categories.
 """
-from typing import List, Optional, Any
+from typing import Annotated, Any, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from inventory_management_system_api.models.custom_object_id_data_types import CustomObjectIdField, StringObjectIdField
+
+
+class AllowedValuesList(BaseModel):
+    type: Literal["list"]
+    values: List[Any]
+
+
+# Use discriminated union for any additional types of allowed values (so can use Pydantic's validation)
+AllowedValues = Annotated[AllowedValuesList, Field(discriminator="type")]
 
 
 class CatalogueItemProperty(BaseModel):
@@ -17,6 +26,7 @@ class CatalogueItemProperty(BaseModel):
     type: str
     unit: Optional[str] = None
     mandatory: bool
+    allowed_values: Optional[AllowedValues] = None
 
 
 class CatalogueCategoryIn(BaseModel):

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -5,7 +5,7 @@ from enum import Enum
 from numbers import Number
 from typing import Annotated, Any, List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, conlist, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
 
@@ -25,7 +25,7 @@ class AllowedValuesListSchema(BaseModel):
     """
 
     type: Literal["list"]
-    values: List[Any]
+    values: conlist(Any, min_length=1)
 
 
 # Use discriminated union for any additional types of allowed values (so can use Pydantic's validation)

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -20,6 +20,10 @@ class CatalogueItemPropertyType(str, Enum):
 
 
 class AllowedValuesListSchema(BaseModel):
+    """
+    Schema model representing a list of allowed values for a catalogue item property
+    """
+
     type: Literal["list"]
     values: List[Any]
 
@@ -39,7 +43,8 @@ class CatalogueItemPropertySchema(BaseModel):
     mandatory: bool = Field(description="Whether the property must be supplied when a catalogue item is created")
     allowed_values: Optional[AllowedValuesSchema] = Field(
         default=None,
-        description="Definition of the allowed values this property can take. 'null' indicates any value matching the type is allowed.",
+        description="Definition of the allowed values this property can take. 'null' indicates any value matching the "
+        "type is allowed.",
     )
 
     @classmethod

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -99,7 +99,7 @@ class CatalogueItemPropertySchema(BaseModel):
             # Ensure the type is not boolean
             if info.data["type"] == CatalogueItemPropertyType.BOOLEAN:
                 raise ValueError(
-                    f"allowed_values not allowed for boolean catalogue item property '{info.data['name']}'"
+                    f"allowed_values not allowed for a boolean catalogue item property '{info.data['name']}'"
                 )
             # Ensure the allowed values have the correct type
             if isinstance(allowed_values, AllowedValuesListSchema):

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -113,7 +113,7 @@ def _validate_catalogue_item_property_value(
     :param defined_property: Definition of the property from the catalogue category
     :param supplied_property_name: Name of the supplied property
     :param supplied_property_value: Value of the supplied property
-    :raises InvalidCatalogueItemPropertyTypeError: If the suppplied property value is found to either be an
+    :raises InvalidCatalogueItemPropertyTypeError: If the supplied property value is found to either be an
                                                    invalid type, or not an allowed value
     """
 

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -4,7 +4,7 @@ Collection of some utility functions used by services
 
 import logging
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 from inventory_management_system_api.core.exceptions import (
     InvalidCatalogueItemPropertyTypeError,
@@ -113,6 +113,8 @@ def _validate_catalogue_item_property_value(
     :param defined_property: Definition of the property from the catalogue category
     :param supplied_property_name: Name of the supplied property
     :param supplied_property_value: Value of the supplied property
+    :raises InvalidCatalogueItemPropertyTypeError: If the suppplied property value is found to either be an
+                                                   invalid type, or not an allowed value
     """
 
     defined_type = defined_property["type"]
@@ -129,7 +131,8 @@ def _validate_catalogue_item_property_value(
             values = defined_allowed_values["values"]
             if supplied_property_value not in values:
                 raise InvalidCatalogueItemPropertyTypeError(
-                    f"Invalid value for catalogue item property '{supplied_property_name}'. Expected one of {', '.join(values)}"
+                    f"Invalid value for catalogue item property '{supplied_property_name}'. Expected one of "
+                    f"{', '.join([str(value) for value in values])}."
                 )
 
 
@@ -144,8 +147,8 @@ def _validate_catalogue_item_property_values(
     :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
                                database.
     :param supplied_properties: The supplied catalogue item properties.
-    :raises InvalidCatalogueItemPropertyTypeError: If the any of the types of the supplied values does not match the expected
-                                                   type.
+    :raises InvalidCatalogueItemPropertyTypeError: If the any of the types of the supplied values does not match the
+                                                   expected type.
     """
     logger.info("Validating the values of the supplied properties against the expected property types")
     for supplied_property_name, supplied_property in supplied_properties.items():

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -4,15 +4,14 @@ Collection of some utility functions used by services
 
 import logging
 import re
-from numbers import Number
-from typing import Dict, Union, List
+from typing import Dict, List, Union
 
 from inventory_management_system_api.core.exceptions import (
-    MissingMandatoryCatalogueItemProperty,
     InvalidCatalogueItemPropertyTypeError,
+    MissingMandatoryCatalogueItemProperty,
 )
 from inventory_management_system_api.models.catalogue_category import CatalogueItemProperty
-from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyType
+from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertySchema
 from inventory_management_system_api.schemas.catalogue_item import PropertyPostRequestSchema
 
 logger = logging.getLogger()
@@ -113,33 +112,20 @@ def _validate_catalogue_item_property_values(
     of the supplied value does not match the expected type.
 
     :param defined_properties: The defined catalogue item properties stored as part of the catalogue category in the
-        database.
+                               database.
     :param supplied_properties: The supplied catalogue item properties.
-    :raises InvalidCatalogueItemPropertyTypeError: If the type of the supplied value does not match the expected
-        type.
+    :raises InvalidCatalogueItemPropertyTypeError: If the any of the types of the supplied values does not match the expected
+                                                   type.
     """
     logger.info("Validating the values of the supplied properties against the expected property types")
     for supplied_property_name, supplied_property in supplied_properties.items():
         expected_property_type = defined_properties[supplied_property_name]["type"]
         supplied_property_value = supplied_property["value"]
 
-        if expected_property_type == CatalogueItemPropertyType.STRING and not isinstance(supplied_property_value, str):
-            raise InvalidCatalogueItemPropertyTypeError(
-                f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: string."
-            )
-        if expected_property_type == CatalogueItemPropertyType.NUMBER and not isinstance(
-            supplied_property_value, Number
-        ):
-            raise InvalidCatalogueItemPropertyTypeError(
-                f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: number."
-            )
-        if expected_property_type == CatalogueItemPropertyType.BOOLEAN and not isinstance(
-            supplied_property_value, bool
-        ):
-            raise InvalidCatalogueItemPropertyTypeError(
-                f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: "
-                f"boolean."
-            )
+    if not CatalogueItemPropertySchema.validate_property_type(expected_property_type, supplied_property_value):
+        raise InvalidCatalogueItemPropertyTypeError(
+            f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: {expected_property_type}."
+        )
 
 
 def _check_missing_mandatory_catalogue_item_properties(

--- a/test/e2e/mock_schemas.py
+++ b/test/e2e/mock_schemas.py
@@ -26,27 +26,12 @@ CATALOGUE_CATEGORY_POST_ALLOWED_VALUES = {
         },
     ],
 }
+
 CATALOGUE_CATEGORY_POST_ALLOWED_VALUES_EXPECTED = {
     **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
     "id": ANY,
     "code": "category-allowed-values",
     "parent_id": None,
-    "catalogue_item_properties": [
-        {
-            "name": "Property A",
-            "type": "number",
-            "unit": "mm",
-            "mandatory": False,
-            "allowed_values": {"type": "list", "values": [2, 4, 6]},
-        },
-        {
-            "name": "Property B",
-            "type": "string",
-            "unit": None,
-            "mandatory": True,
-            "allowed_values": {"type": "list", "values": ["red", "green"]},
-        },
-    ],
 }
 
 # To be posted on CATALOGUE_CATEGORY_POST_ALLOWED_VALUES

--- a/test/e2e/mock_schemas.py
+++ b/test/e2e/mock_schemas.py
@@ -69,6 +69,7 @@ CATALOGUE_ITEM_POST_ALLOWED_VALUES_EXPECTED = {
     "item_model_number": None,
     "obsolete_reason": None,
     "obsolete_replacement_catalogue_item_id": None,
+    "notes": None,
     "properties": [
         {"name": "Property A", "unit": "mm", "value": 4},
         {"name": "Property B", "value": "red", "unit": None},

--- a/test/e2e/mock_schemas.py
+++ b/test/e2e/mock_schemas.py
@@ -1,0 +1,98 @@
+"""
+Mock data for sharing between different e2e tests - In particular avoids circular imports between them
+"""
+
+# Leaf with allowed values in properties
+from unittest.mock import ANY
+
+# pylint: disable=duplicate-code
+CATALOGUE_CATEGORY_POST_ALLOWED_VALUES = {
+    "name": "Category Allowed Values",
+    "is_leaf": True,
+    "catalogue_item_properties": [
+        {
+            "name": "Property A",
+            "type": "number",
+            "unit": "mm",
+            "mandatory": False,
+            "allowed_values": {"type": "list", "values": [2, 4, 6]},
+        },
+        {
+            "name": "Property B",
+            "type": "string",
+            "unit": None,
+            "mandatory": True,
+            "allowed_values": {"type": "list", "values": ["red", "green"]},
+        },
+    ],
+}
+CATALOGUE_CATEGORY_POST_ALLOWED_VALUES_EXPECTED = {
+    **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
+    "id": ANY,
+    "code": "category-allowed-values",
+    "parent_id": None,
+    "catalogue_item_properties": [
+        {
+            "name": "Property A",
+            "type": "number",
+            "unit": "mm",
+            "mandatory": False,
+            "allowed_values": {"type": "list", "values": [2, 4, 6]},
+        },
+        {
+            "name": "Property B",
+            "type": "string",
+            "unit": None,
+            "mandatory": True,
+            "allowed_values": {"type": "list", "values": ["red", "green"]},
+        },
+    ],
+}
+
+# To be posted on CATALOGUE_CATEGORY_POST_ALLOWED_VALUES
+CATALOGUE_ITEM_POST_ALLOWED_VALUES = {
+    "name": "Catalogue Item D",
+    "description": "This is Catalogue Item D",
+    "cost_gbp": 300.00,
+    "cost_to_rework_gbp": 120.99,
+    "days_to_replace": 1.5,
+    "days_to_rework": 3.0,
+    "drawing_number": "789xyz",
+    "is_obsolete": False,
+    "properties": [{"name": "Property A", "value": 4}, {"name": "Property B", "value": "red"}],
+}
+
+CATALOGUE_ITEM_POST_ALLOWED_VALUES_EXPECTED = {
+    **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
+    "id": ANY,
+    "drawing_link": None,
+    "item_model_number": None,
+    "obsolete_reason": None,
+    "obsolete_replacement_catalogue_item_id": None,
+    "properties": [
+        {"name": "Property A", "unit": "mm", "value": 4},
+        {"name": "Property B", "value": "red", "unit": None},
+    ],
+}
+
+ITEM_POST_ALLOWED_VALUES = {
+    "is_defective": False,
+    "usage_status": 0,
+    "warranty_end_date": "2015-11-15T23:59:59Z",
+    "serial_number": "xyz123",
+    "delivered_date": "2012-12-05T12:00:00Z",
+    "notes": "Test notes",
+    "properties": [{"name": "Property A", "value": 6}, {"name": "Property B", "value": "green"}],
+}
+
+ITEM_POST_ALLOWED_VALUES_EXPECTED = {
+    **ITEM_POST_ALLOWED_VALUES,
+    "id": ANY,
+    "purchase_order_number": None,
+    "asset_number": None,
+    "properties": [
+        {"name": "Property A", "unit": "mm", "value": 6},
+        {"name": "Property B", "value": "green", "unit": None},
+    ],
+}
+# pylint: enable=duplicate-code

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -319,10 +319,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     )
 
     assert response.status_code == 422
-    assert (
-        response.json()["detail"][0]["msg"]
-        == "List should have at least 1 item after validation, not 0"
-    )
+    assert response.json()["detail"][0]["msg"] == "List should have at least 1 item after validation, not 0"
 
 
 def test_create_catalogue_category_with_properties_with_allowed_values(test_client):
@@ -1170,6 +1167,93 @@ def test_partial_update_catalogue_category_modify_catalogue_item_property(test_c
         "code": "category-a",
         "parent_id": None,
     }
+
+
+def test_partial_update_catalogue_category_modify_catalogue_item_property_to_have_allowed_values_list(test_client):
+    """
+    Test modifying catalogue item properties to have a list of allowed values
+    """
+    catalogue_item_properties = [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "string", "unit": None, "mandatory": False},
+    ]
+    catalogue_category_post = {
+        **CATALOGUE_CATEGORY_POST_B,
+        "catalogue_item_properties": catalogue_item_properties,
+    }
+    response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
+
+    catalogue_item_properties[0]["allowed_values"] = {"type": "list", "values": [2, 4, 6]}
+    catalogue_item_properties[1]["allowed_values"] = {"type": "list", "values": ["red", "green"]}
+    catalogue_category_patch = {"catalogue_item_properties": catalogue_item_properties}
+    response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        **catalogue_category_post,
+        **catalogue_category_patch,
+        "id": ANY,
+        "code": "category-b",
+        "parent_id": None,
+    }
+
+
+def test_partial_update_catalogue_category_modify_catalogue_item_property_to_have_invalid_allowed_values_list_number(
+    test_client,
+):
+    """
+    Test modifying catalogue item properties to have a number property containing an allowed_values list with an
+    invalid number
+    """
+    catalogue_item_properties = [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "string", "unit": None, "mandatory": False},
+    ]
+    catalogue_category_post = {
+        **CATALOGUE_CATEGORY_POST_B,
+        "catalogue_item_properties": catalogue_item_properties,
+    }
+    response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
+
+    catalogue_item_properties[0]["allowed_values"] = {"type": "list", "values": [2, "4", 6]}
+    catalogue_item_properties[1]["allowed_values"] = {"type": "list", "values": ["red", "green"]}
+    catalogue_category_patch = {"catalogue_item_properties": catalogue_item_properties}
+    response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Value error, allowed_values must only contain values of the same type as the property itself"
+    )
+
+
+def test_partial_update_catalogue_category_modify_catalogue_item_property_to_have_invalid_allowed_values_list_string(
+    test_client,
+):
+    """
+    Test modifying catalogue item properties to have a string property containing an allowed_values list with an
+    invalid string
+    """
+    catalogue_item_properties = [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "string", "unit": None, "mandatory": False},
+    ]
+    catalogue_category_post = {
+        **CATALOGUE_CATEGORY_POST_B,
+        "catalogue_item_properties": catalogue_item_properties,
+    }
+    response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
+
+    catalogue_item_properties[0]["allowed_values"] = {"type": "list", "values": [2, 4, 6]}
+    catalogue_item_properties[1]["allowed_values"] = {"type": "list", "values": ["red", "green", 6]}
+    catalogue_category_patch = {"catalogue_item_properties": catalogue_item_properties}
+    response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Value error, allowed_values must only contain values of the same type as the property itself"
+    )
 
 
 def test_partial_update_catalogue_category_change_catalogue_item_properties_has_child_catalogue_items(test_client):

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -2,10 +2,15 @@
 """
 End-to-End tests for the catalogue category router.
 """
+from test.e2e.mock_schemas import (
+    CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
+    CATALOGUE_CATEGORY_POST_ALLOWED_VALUES_EXPECTED)
 from unittest.mock import ANY
+
 from bson import ObjectId
 
-from inventory_management_system_api.core.consts import BREADCRUMBS_TRAIL_MAX_LENGTH
+from inventory_management_system_api.core.consts import \
+    BREADCRUMBS_TRAIL_MAX_LENGTH
 
 CATALOGUE_CATEGORY_POST_A = {"name": "Category A", "is_leaf": False}
 CATALOGUE_CATEGORY_POST_A_EXPECTED = {
@@ -52,50 +57,6 @@ CATALOGUE_CATEGORY_POST_C_EXPECTED = {
     "catalogue_item_properties": [
         {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None},
         {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True, "allowed_values": None},
-    ],
-}
-
-# Leaf with allowed values in properties
-CATALOGUE_CATEGORY_POST_D = {
-    "name": "Category D",
-    "is_leaf": True,
-    "catalogue_item_properties": [
-        {
-            "name": "Property A",
-            "type": "number",
-            "unit": "mm",
-            "mandatory": False,
-            "allowed_values": {"type": "list", "values": [2, 4, 6]},
-        },
-        {
-            "name": "Property B",
-            "type": "string",
-            "unit": None,
-            "mandatory": True,
-            "allowed_values": {"type": "list", "values": ["red", "green"]},
-        },
-    ],
-}
-CATALOGUE_CATEGORY_POST_D_EXPECTED = {
-    **CATALOGUE_CATEGORY_POST_D,
-    "id": ANY,
-    "code": "category-d",
-    "parent_id": None,
-    "catalogue_item_properties": [
-        {
-            "name": "Property A",
-            "type": "number",
-            "unit": "mm",
-            "mandatory": False,
-            "allowed_values": {"type": "list", "values": [2, 4, 6]},
-        },
-        {
-            "name": "Property B",
-            "type": "string",
-            "unit": None,
-            "mandatory": True,
-            "allowed_values": {"type": "list", "values": ["red", "green"]},
-        },
     ],
 }
 
@@ -342,11 +303,11 @@ def test_create_catalogue_category_with_properties_with_allowed_values(test_clie
     """
     Test creating a catalogue category with specific allowed values given
     """
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
 
     assert response.status_code == 201
     catalogue_category = response.json()
-    assert catalogue_category == CATALOGUE_CATEGORY_POST_D_EXPECTED
+    assert catalogue_category == CATALOGUE_CATEGORY_POST_ALLOWED_VALUES_EXPECTED
 
 
 def test_create_catalogue_category_with_properties_with_invalid_allowed_values_list_number(test_client):
@@ -357,7 +318,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     response = test_client.post(
         "/v1/catalogue-categories",
         json={
-            **CATALOGUE_CATEGORY_POST_D,
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
             "catalogue_item_properties": [
                 {
                     "name": "Property A",
@@ -384,7 +345,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     response = test_client.post(
         "/v1/catalogue-categories",
         json={
-            **CATALOGUE_CATEGORY_POST_D,
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
             "catalogue_item_properties": [
                 {
                     "name": "Property A",
@@ -410,7 +371,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     response = test_client.post(
         "/v1/catalogue-categories",
         json={
-            **CATALOGUE_CATEGORY_POST_D,
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
             "catalogue_item_properties": [
                 {
                     "name": "Property A",
@@ -436,7 +397,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_t
     response = test_client.post(
         "/v1/catalogue-categories",
         json={
-            **CATALOGUE_CATEGORY_POST_D,
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
             "catalogue_item_properties": [
                 {
                     "name": "Property A",

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -4,13 +4,13 @@ End-to-End tests for the catalogue category router.
 """
 from test.e2e.mock_schemas import (
     CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
-    CATALOGUE_CATEGORY_POST_ALLOWED_VALUES_EXPECTED)
+    CATALOGUE_CATEGORY_POST_ALLOWED_VALUES_EXPECTED,
+)
 from unittest.mock import ANY
 
 from bson import ObjectId
 
-from inventory_management_system_api.core.consts import \
-    BREADCRUMBS_TRAIL_MAX_LENGTH
+from inventory_management_system_api.core.consts import BREADCRUMBS_TRAIL_MAX_LENGTH
 
 CATALOGUE_CATEGORY_POST_A = {"name": "Category A", "is_leaf": False}
 CATALOGUE_CATEGORY_POST_A_EXPECTED = {
@@ -297,6 +297,32 @@ def test_create_non_leaf_catalogue_category_with_catalogue_item_properties(test_
     assert response.status_code == 201
     catalogue_category = response.json()
     assert catalogue_category == CATALOGUE_CATEGORY_POST_A_EXPECTED
+
+
+def test_create_catalogue_category_with_properties_with_invalid_allowed_values_list_length(test_client):
+    """
+    Test creating a catalogue category with a number property containing an allowed_values list that is empty
+    """
+    response = test_client.post(
+        "/v1/catalogue-categories",
+        json={
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
+            "catalogue_item_properties": [
+                {
+                    "name": "Property A",
+                    "type": "number",
+                    "mandatory": False,
+                    "allowed_values": {"type": "list", "values": []},
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "List should have at least 1 item after validation, not 0"
+    )
 
 
 def test_create_catalogue_category_with_properties_with_allowed_values(test_client):

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -30,8 +30,8 @@ CATALOGUE_CATEGORY_POST_B_EXPECTED = {
     "id": ANY,
     "code": "category-b",
     "catalogue_item_properties": [
-        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
-        {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True},
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None},
+        {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True, "allowed_values": None},
     ],
 }
 
@@ -50,8 +50,8 @@ CATALOGUE_CATEGORY_POST_C_EXPECTED = {
     "code": "category-c",
     "parent_id": None,
     "catalogue_item_properties": [
-        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
-        {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True},
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None},
+        {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True, "allowed_values": None},
     ],
 }
 
@@ -631,7 +631,9 @@ def test_partial_update_catalogue_category_change_from_non_leaf_to_leaf(test_cli
 
     catalogue_category_patch = {
         "is_leaf": True,
-        "catalogue_item_properties": [{"name": "Property A", "type": "number", "unit": "mm", "mandatory": False}],
+        "catalogue_item_properties": [
+            {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None}
+        ],
     }
     response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
 
@@ -777,7 +779,9 @@ def test_partial_update_catalogue_category_change_parent_id(test_client):
         "name": "Category B",
         "is_leaf": True,
         "parent_id": catalogue_category_a_id,
-        "catalogue_item_properties": [{"name": "Property A", "type": "number", "unit": "mm", "mandatory": False}],
+        "catalogue_item_properties": [
+            {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None}
+        ],
     }
     response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
     catalogue_category_b_id = response.json()["id"]
@@ -933,7 +937,9 @@ def test_partial_update_catalogue_category_add_catalogue_item_property(test_clie
     """
     Test adding a catalogue item property.
     """
-    catalogue_item_properties = [{"name": "Property A", "type": "number", "unit": "mm", "mandatory": False}]
+    catalogue_item_properties = [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None}
+    ]
     catalogue_category_post = {
         "name": "Category A",
         "is_leaf": True,
@@ -941,7 +947,9 @@ def test_partial_update_catalogue_category_add_catalogue_item_property(test_clie
     }
     response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
 
-    catalogue_item_properties.append({"name": "Property B", "type": "boolean", "mandatory": True})
+    catalogue_item_properties.append(
+        {"name": "Property B", "type": "boolean", "mandatory": True, "allowed_values": None}
+    )
     catalogue_category_patch = {"catalogue_item_properties": catalogue_item_properties}
     response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
 
@@ -961,8 +969,8 @@ def test_partial_update_catalogue_category_remove_catalogue_item_property(test_c
     Test removing a catalogue item property.
     """
     catalogue_item_properties = [
-        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
-        {"name": "Property B", "type": "boolean", "mandatory": True},
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None},
+        {"name": "Property B", "type": "boolean", "mandatory": True, "allowed_values": None},
     ]
     catalogue_category_post = {
         "name": "Category A",
@@ -991,8 +999,8 @@ def test_partial_update_catalogue_category_modify_catalogue_item_property(test_c
     Test modifying a catalogue item property.
     """
     catalogue_item_properties = [
-        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
-        {"name": "Property B", "type": "boolean", "mandatory": True},
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False, "allowed_values": None},
+        {"name": "Property B", "type": "boolean", "mandatory": True, "allowed_values": None},
     ]
     catalogue_category_post = {
         "name": "Category A",

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -2,12 +2,15 @@
 """
 End-to-End tests for the catalogue item router.
 """
-from unittest.mock import ANY
-from test.e2e.test_catalogue_category import CATALOGUE_CATEGORY_POST_D
-
+from test.e2e.mock_schemas import (
+    CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
+    CATALOGUE_ITEM_POST_ALLOWED_VALUES,
+    CATALOGUE_ITEM_POST_ALLOWED_VALUES_EXPECTED,
+)
 from test.e2e.test_item import ITEM_POST
-from bson import ObjectId
+from unittest.mock import ANY
 
+from bson import ObjectId
 
 # pylint: disable=duplicate-code
 CATALOGUE_CATEGORY_POST_A = {
@@ -94,32 +97,6 @@ CATALOGUE_ITEM_POST_B_EXPECTED = {
     "obsolete_reason": None,
     "obsolete_replacement_catalogue_item_id": None,
     "properties": [{"name": "Property A", "value": True, "unit": None}],
-}
-
-# To be posted on CATALOGUE_CATEGORY_D
-CATALOGUE_ITEM_POST_D = {
-    "name": "Catalogue Item D",
-    "description": "This is Catalogue Item D",
-    "cost_gbp": 300.00,
-    "cost_to_rework_gbp": 120.99,
-    "days_to_replace": 1.5,
-    "days_to_rework": 3.0,
-    "drawing_number": "789xyz",
-    "is_obsolete": False,
-    "properties": [{"name": "Property A", "value": 4}, {"name": "Property B", "value": "red"}],
-}
-
-CATALOGUE_ITEM_POST_D_EXPECTED = {
-    **CATALOGUE_ITEM_POST_D,
-    "id": ANY,
-    "drawing_link": None,
-    "item_model_number": None,
-    "obsolete_reason": None,
-    "obsolete_replacement_catalogue_item_id": None,
-    "properties": [
-        {"name": "Property A", "unit": "mm", "value": 4},
-        {"name": "Property B", "value": "red", "unit": None},
-    ],
 }
 
 
@@ -498,14 +475,14 @@ def test_create_catalogue_item_with_allowed_values(test_client):
     Test creating a catalogue item when using allowed_values in the properties.
     """
     # pylint: disable=duplicate-code
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
     catalogue_category_id = response.json()["id"]
 
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_id = response.json()["id"]
 
     catalogue_item_post = {
-        **CATALOGUE_ITEM_POST_D,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
     }
@@ -517,7 +494,7 @@ def test_create_catalogue_item_with_allowed_values(test_client):
     catalogue_item = response.json()
 
     assert catalogue_item == {
-        **CATALOGUE_ITEM_POST_D_EXPECTED,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES_EXPECTED,
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
     }
@@ -529,14 +506,14 @@ def test_create_catalogue_item_with_allowed_values_invalid_list_string(test_clie
     the defined allowed_values list
     """
     # pylint: disable=duplicate-code
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
     catalogue_category_id = response.json()["id"]
 
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_id = response.json()["id"]
 
     catalogue_item_post = {
-        **CATALOGUE_ITEM_POST_D,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
         "properties": [{"name": "Property A", "value": 4}, {"name": "Property B", "value": "blue"}],
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
@@ -557,14 +534,14 @@ def test_create_catalogue_item_with_allowed_values_invalid_list_number(test_clie
     the defined allowed_values list
     """
     # pylint: disable=duplicate-code
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
     catalogue_category_id = response.json()["id"]
 
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_id = response.json()["id"]
 
     catalogue_item_post = {
-        **CATALOGUE_ITEM_POST_D,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
         "properties": [{"name": "Property A", "value": 10}, {"name": "Property B", "value": "red"}],
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
@@ -1478,14 +1455,14 @@ def test_partial_update_catalogue_item_change_values_with_allowed_values(test_cl
     """
     Test changing the value of properties with allowed_values defined
     """
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
     catalogue_category_id = response.json()["id"]
 
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_id = response.json()["id"]
 
     catalogue_item_post = {
-        **CATALOGUE_ITEM_POST_D,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
     }
@@ -1504,7 +1481,7 @@ def test_partial_update_catalogue_item_change_values_with_allowed_values(test_cl
     catalogue_item = response.json()
 
     assert catalogue_item == {
-        **CATALOGUE_ITEM_POST_D_EXPECTED,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES_EXPECTED,
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
         "properties": [
@@ -1519,14 +1496,14 @@ def test_partial_update_catalogue_item_change_value_for_invalid_allowed_values_l
     Test updating a catalogue item when giving a string property a value that is not within
     the defined allowed_values list
     """
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
     catalogue_category_id = response.json()["id"]
 
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_id = response.json()["id"]
 
     catalogue_item_post = {
-        **CATALOGUE_ITEM_POST_D,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
     }
@@ -1552,14 +1529,14 @@ def test_partial_update_catalogue_item_change_value_for_invalid_allowed_values_l
     Test updating a catalogue item when giving a number property a value that is not within
     the defined allowed_values list
     """
-    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_ALLOWED_VALUES)
     catalogue_category_id = response.json()["id"]
 
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_id = response.json()["id"]
 
     catalogue_item_post = {
-        **CATALOGUE_ITEM_POST_D,
+        **CATALOGUE_ITEM_POST_ALLOWED_VALUES,
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_id,
     }

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -3,6 +3,7 @@
 End-to-End tests for the catalogue item router.
 """
 from unittest.mock import ANY
+from test.e2e.test_catalogue_category import CATALOGUE_CATEGORY_POST_D
 
 from test.e2e.test_item import ITEM_POST
 from bson import ObjectId
@@ -93,6 +94,32 @@ CATALOGUE_ITEM_POST_B_EXPECTED = {
     "obsolete_reason": None,
     "obsolete_replacement_catalogue_item_id": None,
     "properties": [{"name": "Property A", "value": True, "unit": None}],
+}
+
+# To be posted on CATALOGUE_CATEGORY_D
+CATALOGUE_ITEM_POST_D = {
+    "name": "Catalogue Item D",
+    "description": "This is Catalogue Item D",
+    "cost_gbp": 300.00,
+    "cost_to_rework_gbp": 120.99,
+    "days_to_replace": 1.5,
+    "days_to_rework": 3.0,
+    "drawing_number": "789xyz",
+    "is_obsolete": False,
+    "properties": [{"name": "Property A", "value": 4}, {"name": "Property B", "value": "red"}],
+}
+
+CATALOGUE_ITEM_POST_D_EXPECTED = {
+    **CATALOGUE_ITEM_POST_D,
+    "id": ANY,
+    "drawing_link": None,
+    "item_model_number": None,
+    "obsolete_reason": None,
+    "obsolete_replacement_catalogue_item_id": None,
+    "properties": [
+        {"name": "Property A", "unit": "mm", "value": 4},
+        {"name": "Property B", "value": "red", "unit": None},
+    ],
 }
 
 
@@ -463,6 +490,91 @@ def test_create_catalogue_item_with_invalid_value_type_for_boolean_property(test
     assert (
         response.json()["detail"]
         == "Invalid value type for catalogue item property 'Property B'. Expected type: boolean."
+    )
+
+
+def test_create_catalogue_item_with_allowed_values(test_client):
+    """
+    Test creating a catalogue item when using allowed_values in the properties.
+    """
+    # pylint: disable=duplicate-code
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_D,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    # pylint: enable=duplicate-code
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    assert response.status_code == 201
+
+    catalogue_item = response.json()
+
+    assert catalogue_item == {
+        **CATALOGUE_ITEM_POST_D_EXPECTED,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+
+
+def test_create_catalogue_item_with_allowed_values_invalid_list_string(test_client):
+    """
+    Test creating a catalogue item when giving a string property a value that is not within
+    the defined allowed_values list
+    """
+    # pylint: disable=duplicate-code
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_D,
+        "properties": [{"name": "Property A", "value": 4}, {"name": "Property B", "value": "blue"}],
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    # pylint: enable=duplicate-code
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == "Invalid value for catalogue item property 'Property B'. Expected one of red, green."
+    )
+
+
+def test_create_catalogue_item_with_allowed_values_invalid_list_number(test_client):
+    """
+    Test creating a catalogue item when giving a number property a value that is not within
+    the defined allowed_values list
+    """
+    # pylint: disable=duplicate-code
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_D,
+        "properties": [{"name": "Property A", "value": 10}, {"name": "Property B", "value": "red"}],
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    # pylint: enable=duplicate-code
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"] == "Invalid value for catalogue item property 'Property A'. Expected one of 2, 4, 6."
     )
 
 
@@ -1359,6 +1471,111 @@ def test_partial_update_catalogue_item_change_value_for_boolean_property_invalid
     assert (
         response.json()["detail"]
         == "Invalid value type for catalogue item property 'Property B'. Expected type: boolean."
+    )
+
+
+def test_partial_update_catalogue_item_change_values_with_allowed_values(test_client):
+    """
+    Test changing the value of properties with allowed_values defined
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_D,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    catalogue_item_patch = {
+        "properties": [
+            {"name": "Property A", "value": 6},
+            {"name": "Property B", "value": "green"},
+        ]
+    }
+    response = test_client.patch(f"/v1/catalogue-items/{response.json()['id']}", json=catalogue_item_patch)
+
+    assert response.status_code == 200
+
+    catalogue_item = response.json()
+
+    assert catalogue_item == {
+        **CATALOGUE_ITEM_POST_D_EXPECTED,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+        "properties": [
+            {"name": "Property A", "unit": "mm", "value": 6},
+            {"name": "Property B", "unit": None, "value": "green"},
+        ],
+    }
+
+
+def test_partial_update_catalogue_item_change_value_for_invalid_allowed_values_list_string(test_client):
+    """
+    Test updating a catalogue item when giving a string property a value that is not within
+    the defined allowed_values list
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_D,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    catalogue_item_patch = {
+        "properties": [
+            {"name": "Property A", "value": 4},
+            {"name": "Property B", "value": "blue"},
+        ]
+    }
+    response = test_client.patch(f"/v1/catalogue-items/{response.json()['id']}", json=catalogue_item_patch)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == "Invalid value for catalogue item property 'Property B'. Expected one of red, green."
+    )
+
+
+def test_partial_update_catalogue_item_change_value_for_invalid_allowed_values_list_number(test_client):
+    """
+    Test updating a catalogue item when giving a number property a value that is not within
+    the defined allowed_values list
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_D)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_D,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+
+    catalogue_item_patch = {
+        "properties": [
+            {"name": "Property A", "value": 10},
+            {"name": "Property B", "value": "green"},
+        ]
+    }
+    response = test_client.patch(f"/v1/catalogue-items/{response.json()['id']}", json=catalogue_item_patch)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"] == "Invalid value for catalogue item property 'Property A'. Expected one of 2, 4, 6."
     )
 
 


### PR DESCRIPTION
## Description
Adds the ability to specify `allowed_values` for a catalogue item property at the category level that is used in validating during catalogue item/item create and update requests and can be used on the front end to produce a drop down list of available options.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #159