### PR TITLE
Prevent moving a system/category to child of itself #129

### DIFF
--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -13,6 +13,7 @@ from inventory_management_system_api.core.database import get_database
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     DuplicateRecordError,
+    InvalidActionError,
     MissingRecordError,
 )
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryIn, CatalogueCategoryOut
@@ -140,11 +141,26 @@ class CatalogueCategoryRepo:
             raise MissingRecordError(f"No parent catalogue category found with ID: {parent_id}")
 
         stored_catalogue_category = self.get(str(catalogue_category_id))
+        moving_catalogue_category = parent_id != stored_catalogue_category.parent_id
         if (
-            catalogue_category.name != stored_catalogue_category.name
-            or parent_id != stored_catalogue_category.parent_id
+            catalogue_category.name != stored_catalogue_category.name or moving_catalogue_category
         ) and self._is_duplicate_catalogue_category(parent_id, catalogue_category.code):
             raise DuplicateRecordError("Duplicate catalogue category found within the parent catalogue category")
+
+        # Prevent a catalogue category from being moved to one of its own children
+        if moving_catalogue_category:
+            if parent_id is not None and not utils.check_move_result(
+                list(
+                    self._catalogue_categories_collection.aggregate(
+                        utils.create_move_check_aggregation_pipeline(
+                            entity_id=str(catalogue_category_id),
+                            destination_id=parent_id,
+                            collection_name="catalogue_categories",
+                        )
+                    )
+                )
+            ):
+                raise InvalidActionError("Cannot move a catalogue category to one of its own children")
 
         logger.info("Updating catalogue category with ID: %s in the database", catalogue_category_id)
         self._catalogue_categories_collection.update_one(

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -133,6 +133,8 @@ class CatalogueCategoryRepo:
         :return: The updated catalogue category.
         :raises MissingRecordError: If the parent catalogue category specified by `parent_id` doesn't exist.
         :raises DuplicateRecordError: If a duplicate catalogue category is found within the parent catalogue category.
+        :raises InvalidActionError: If attempting to change the `parent_id` to one of its own child catalogue category
+                                    ids.
         """
         catalogue_category_id = CustomObjectId(catalogue_category_id)
 
@@ -149,7 +151,7 @@ class CatalogueCategoryRepo:
 
         # Prevent a catalogue category from being moved to one of its own children
         if moving_catalogue_category:
-            if parent_id is not None and not utils.check_move_result(
+            if parent_id is not None and not utils.is_valid_move_result(
                 list(
                     self._catalogue_categories_collection.aggregate(
                         utils.create_move_check_aggregation_pipeline(

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -115,6 +115,7 @@ class SystemRepo:
         :return: The updated System
         :raises MissingRecordError: If the parent System specified by `parent_id` doesn't exist
         :raises DuplicateRecordError: If a duplicate System is found within the parent System
+        :raises InvalidActionError: If attempting to change the `parent_id` to one of its own child system ids
         """
         system_id = CustomObjectId(system_id)
 
@@ -129,7 +130,7 @@ class SystemRepo:
 
         # Prevent a system from being moved to one of its own children
         if moving_system:
-            if parent_id is not None and not utils.check_move_result(
+            if parent_id is not None and not utils.is_valid_move_result(
                 list(
                     self._systems_collection.aggregate(
                         utils.create_move_check_aggregation_pipeline(

--- a/inventory_management_system_api/repositories/utils.py
+++ b/inventory_management_system_api/repositories/utils.py
@@ -132,7 +132,7 @@ def create_move_check_aggregation_pipeline(entity_id: str, destination_id: str, 
 
     :raises InvalidObjectIdError: If the given entity_id or destination_id is invalid
     :return: The query to feed to the collection's aggregate method. The value of list(result) should
-             be passed to check_move_result below.
+             be passed to is_valid_move_result below.
     """
     return [
         {"$match": {"_id": CustomObjectId(destination_id)}},
@@ -170,9 +170,10 @@ def create_move_check_aggregation_pipeline(entity_id: str, destination_id: str, 
     ]
 
 
-def check_move_result(move_parent_check_result: list) -> bool:
+def is_valid_move_result(move_parent_check_result: list) -> bool:
     """
-    Processes the result of running the query returned by create_move_check_aggregation_pipeline above
+    Processes the result of running the query returned by create_move_check_aggregation_pipeline above and returns
+    whether it represents a valid move
 
     :param move_parent_check_result: Result of running the aggregation pipeline returned by
                                      create_move_check_aggregation_pipeline

--- a/inventory_management_system_api/repositories/utils.py
+++ b/inventory_management_system_api/repositories/utils.py
@@ -179,4 +179,4 @@ def check_move_result(move_parent_check_result: list) -> bool:
     :return: True if the move is valid, False when the move destination is a child of the entity being moved
     """
     result = move_parent_check_result[0]["result"]
-    return len(result) > 0 and result[0]["parent_id"] == None
+    return len(result) > 0 and result[0]["parent_id"] is None

--- a/inventory_management_system_api/repositories/utils.py
+++ b/inventory_management_system_api/repositories/utils.py
@@ -95,6 +95,7 @@ def compute_breadcrumbs(breadcrumb_query_result: list, entity_id: str, collectio
                                     create_breadcrumbs_aggregation_pipeline
     :param collection_name: Should be the same as the value passed to create_breadcrumbs_aggregation_pipeline
                             (used for error messages)
+    :raises MissingRecordError: If the entity with id 'entity_id' isn't found in the database
     :raises DatabaseIntegrityError: If the query returned less than the maximum allowed trail while not
                                     giving the full trail - this indicates a parent_id is invalid or doesn't
                                     exist in the database which shouldn't occur

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -175,7 +175,7 @@ def partial_update_catalogue_category(
     except InvalidActionError as exc:
         message = str(exc)
         logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
 
 
 @router.delete(

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -12,6 +12,7 @@ from inventory_management_system_api.core.exceptions import (
     DatabaseIntegrityError,
     DuplicateCatalogueItemPropertyNameError,
     DuplicateRecordError,
+    InvalidActionError,
     InvalidObjectIdError,
     LeafCategoryError,
     MissingRecordError,
@@ -171,6 +172,10 @@ def partial_update_catalogue_category(
     except DuplicateCatalogueItemPropertyNameError as exc:
         logger.exception(str(exc))
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except InvalidActionError as exc:
+        message = str(exc)
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
 
 
 @router.delete(

--- a/inventory_management_system_api/routers/v1/system.py
+++ b/inventory_management_system_api/routers/v1/system.py
@@ -139,7 +139,7 @@ def partial_update_system(
     except InvalidActionError as exc:
         message = str(exc)
         logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
 
 
 @router.delete(

--- a/inventory_management_system_api/routers/v1/system.py
+++ b/inventory_management_system_api/routers/v1/system.py
@@ -12,6 +12,7 @@ from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     DatabaseIntegrityError,
     DuplicateRecordError,
+    InvalidActionError,
     InvalidObjectIdError,
     MissingRecordError,
 )
@@ -135,6 +136,10 @@ def partial_update_system(
         message = "A System with the same name already exists within the parent System"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except InvalidActionError as exc:
+        message = str(exc)
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message)
 
 
 @router.delete(

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -48,7 +48,7 @@ class CatalogueItemPropertySchema(BaseModel):
     )
 
     @classmethod
-    def validate_property_type(cls, expected_property_type: CatalogueItemPropertyType, property_value: Any) -> bool:
+    def is_valid_property_type(cls, expected_property_type: CatalogueItemPropertyType, property_value: Any) -> bool:
         """
         Validates a given value has a type matching a CatalogueItemPropertyType and returns false if they don't
 
@@ -109,7 +109,7 @@ class CatalogueItemPropertySchema(BaseModel):
             if isinstance(allowed_values, AllowedValuesListSchema):
                 # List type should have all values the same type
                 for allowed_value in allowed_values.values:
-                    if not CatalogueItemPropertySchema.validate_property_type(
+                    if not CatalogueItemPropertySchema.is_valid_property_type(
                         expected_property_type=info.data["type"], property_value=allowed_value
                     ):
                         raise ValueError(

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -120,7 +120,7 @@ def _validate_catalogue_item_property_value(defined_property: Dict, supplied_pro
     supplied_property_name = supplied_property["name"]
     supplied_property_value = supplied_property["value"]
 
-    if not CatalogueItemPropertySchema.validate_property_type(defined_type, supplied_property_value):
+    if not CatalogueItemPropertySchema.is_valid_property_type(defined_type, supplied_property_value):
         raise InvalidCatalogueItemPropertyTypeError(
             f"Invalid value type for catalogue item property '{supplied_property_name}'. Expected type: {defined_type}."
         )

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -794,6 +794,21 @@ def test_partial_update_catalogue_category_change_parent_id(test_client):
     }
 
 
+def test_partial_update_catalogue_category_change_parent_id_to_child_id(test_client):
+    """
+    Test updating a System's parent_id to be the id of one of its children
+    """
+    nested_categories = _post_n_catalogue_categories(test_client, 4)
+
+    # Attempt to move first into one of its children
+    response = test_client.patch(
+        f"/v1/catalogue-categories/{nested_categories[0]['id']}", json={"parent_id": nested_categories[3]["id"]}
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Cannot move a catalogue category to one of its own children"
+
+
 def test_partial_update_catalogue_category_change_parent_id_has_child_catalogue_categories(test_client):
     """
     Test moving a catalogue category with child categories to another parent catalogue category.

--- a/test/e2e/test_system.py
+++ b/test/e2e/test_system.py
@@ -398,6 +398,19 @@ def test_partial_update_system_parent_id(test_client):
     _test_partial_update_system(test_client, {"parent_id": parent_system["id"]}, {})
 
 
+def test_partial_update_system_parent_id_to_child_id(test_client):
+    """
+    Test updating a System's parent_id to be the id of one of its children
+    """
+    nested_systems = _post_n_systems(test_client, 4)
+
+    # Attempt to move first into one of its children
+    response = test_client.patch(f"/v1/systems/{nested_systems[0]['id']}", json={"parent_id": nested_systems[3]["id"]})
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Cannot move a system to one of its own children"
+
+
 def test_partial_update_system_invalid_parent_id(test_client):
     """
     Test updating a System's parent_id when the ID is invalid

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -2,7 +2,7 @@
 Module for providing common test configuration, test fixtures, and helper functions.
 """
 from typing import List, Type
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from bson import ObjectId
@@ -85,12 +85,6 @@ def fixture_system_repository(database_mock: Mock) -> SystemRepo:
     :return: `SystemRepo` instance with the mocked dependency.
     """
     return SystemRepo(database_mock)
-
-
-@pytest.fixture(autouse=True, scope="function", name="utils_mock")
-def fixture_utils_mock():
-    with patch("inventory_management_system_api.repositories.system.utils") as mock_utils:
-        yield mock_utils
 
 
 class RepositoryTestHelpers:

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -2,7 +2,7 @@
 Module for providing common test configuration, test fixtures, and helper functions.
 """
 from typing import List, Type
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 
 import pytest
 from bson import ObjectId
@@ -85,6 +85,12 @@ def fixture_system_repository(database_mock: Mock) -> SystemRepo:
     :return: `SystemRepo` instance with the mocked dependency.
     """
     return SystemRepo(database_mock)
+
+
+@pytest.fixture(autouse=True, scope="function", name="utils_mock")
+def fixture_utils_mock():
+    with patch("inventory_management_system_api.repositories.system.utils") as mock_utils:
+        yield mock_utils
 
 
 class RepositoryTestHelpers:

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -903,7 +903,7 @@ def test_update_parent_id(utils_mock, test_helpers, database_mock, catalogue_cat
     # Mock utils so not moving to a child of itself
     mock_aggregation_pipeline = MagicMock()
     utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
-    utils_mock.check_move_result.return_value = True
+    utils_mock.is_valid_move_result.return_value = True
     database_mock.catalogue_categories.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
 
     catalogue_category_in = CatalogueCategoryIn(**{**CATALOGUE_CATEGORY_INFO, "parent_id": new_parent_id})
@@ -912,7 +912,7 @@ def test_update_parent_id(utils_mock, test_helpers, database_mock, catalogue_cat
     utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
         entity_id=catalogue_category.id, destination_id=new_parent_id, collection_name="catalogue_categories"
     )
-    utils_mock.check_move_result.assert_called_once()
+    utils_mock.is_valid_move_result.assert_called_once()
 
     database_mock.catalogue_categories.update_one.assert_called_once_with(
         {"_id": CustomObjectId(catalogue_category.id)},
@@ -969,7 +969,7 @@ def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_moc
     # Mock utils so not moving to a child of itself
     mock_aggregation_pipeline = MagicMock()
     utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
-    utils_mock.check_move_result.return_value = False
+    utils_mock.is_valid_move_result.return_value = False
     database_mock.catalogue_categories.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
 
     catalogue_category_in = CatalogueCategoryIn(**{**CATALOGUE_CATEGORY_INFO, "parent_id": new_parent_id})
@@ -981,7 +981,7 @@ def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_moc
     utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
         entity_id=catalogue_category.id, destination_id=new_parent_id, collection_name="catalogue_categories"
     )
-    utils_mock.check_move_result.assert_called_once()
+    utils_mock.is_valid_move_result.assert_called_once()
 
     database_mock.catalogue_categories.update_one.assert_not_called()
     database_mock.catalogue_categories.find_one.assert_has_calls(

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -3,7 +3,10 @@
 Unit tests for the `CatalogueCategoryRepo` repository.
 """
 from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
-from test.unit.repositories.test_utils import MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH
+from test.unit.repositories.test_utils import (
+    MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH,
+    MOCK_MOVE_QUERY_RESULT_VALID,
+)
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -13,6 +16,7 @@ from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     DuplicateRecordError,
+    InvalidActionError,
     InvalidObjectIdError,
     MissingRecordError,
 )
@@ -854,6 +858,139 @@ def test_update(test_helpers, database_mock, catalogue_category_repository):
         ]
     )
     assert updated_catalogue_category == catalogue_category
+
+
+@patch("inventory_management_system_api.repositories.catalogue_category.utils")
+def test_update_parent_id(utils_mock, test_helpers, database_mock, catalogue_category_repository):
+    """
+    Test updating a catalogue category's parent_id
+
+    Verify that the `update` method properly handles the update of a catalogue category when the
+    parent_id changes
+    """
+    parent_catalogue_category_id = str(ObjectId())
+    catalogue_category = CatalogueCategoryOut(
+        id=str(ObjectId()), **{**CATALOGUE_CATEGORY_INFO, "parent_id": parent_catalogue_category_id}
+    )
+    new_parent_id = str(ObjectId())
+    expected_catalogue_category = CatalogueCategoryOut(
+        **{**catalogue_category.model_dump(), "parent_id": new_parent_id}
+    )
+
+    # Mock `find_one` to return a parent catalogue category document
+    test_helpers.mock_find_one(
+        database_mock.catalogue_categories,
+        {
+            **CATALOGUE_CATEGORY_INFO,
+            "_id": CustomObjectId(new_parent_id),
+        },
+    )
+    # Mock `find_one` to return the stored catalogue category document
+    test_helpers.mock_find_one(
+        database_mock.catalogue_categories,
+        catalogue_category.model_dump(),
+    )
+    # Mock `find_one` to return no duplicate catalogue categories found
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
+    # Mock `update_one` to return an object for the updated catalogue category document
+    test_helpers.mock_update_one(database_mock.catalogue_categories)
+    # Mock `find_one` to return the updated catalogue category document
+    test_helpers.mock_find_one(
+        database_mock.catalogue_categories,
+        {**catalogue_category.model_dump(), "parent_id": CustomObjectId(new_parent_id)},
+    )
+
+    # Mock utils so not moving to a child of itself
+    mock_aggregation_pipeline = MagicMock()
+    utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
+    utils_mock.check_move_result.return_value = True
+    database_mock.catalogue_categories.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
+
+    catalogue_category_in = CatalogueCategoryIn(**{**CATALOGUE_CATEGORY_INFO, "parent_id": new_parent_id})
+    updated_catalogue_category = catalogue_category_repository.update(catalogue_category.id, catalogue_category_in)
+
+    utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
+        entity_id=catalogue_category.id, destination_id=new_parent_id, collection_name="catalogue_categories"
+    )
+    utils_mock.check_move_result.assert_called_once()
+
+    database_mock.catalogue_categories.update_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_category.id)},
+        {"$set": {**catalogue_category_in.model_dump()}},
+    )
+    database_mock.catalogue_categories.find_one.assert_has_calls(
+        [
+            call({"_id": CustomObjectId(new_parent_id)}),
+            call({"_id": CustomObjectId(catalogue_category.id)}),
+            call({"parent_id": CustomObjectId(new_parent_id), "code": catalogue_category.code}),
+            call({"_id": CustomObjectId(catalogue_category.id)}),
+        ]
+    )
+    assert updated_catalogue_category == expected_catalogue_category
+
+
+@patch("inventory_management_system_api.repositories.catalogue_category.utils")
+def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_mock, catalogue_category_repository):
+    """
+    Test updating a catalogue category's parent_id when moving to a child of itself
+
+    Verify that the `update` method properly handles the update of a catalogue category when the new
+    parent_id is a child of itself
+    """
+    parent_catalogue_category_id = str(ObjectId())
+    catalogue_category = CatalogueCategoryOut(
+        id=str(ObjectId()), **{**CATALOGUE_CATEGORY_INFO, "parent_id": parent_catalogue_category_id}
+    )
+    new_parent_id = str(ObjectId())
+
+    # Mock `find_one` to return a parent catalogue category document
+    test_helpers.mock_find_one(
+        database_mock.catalogue_categories,
+        {
+            **CATALOGUE_CATEGORY_INFO,
+            "_id": CustomObjectId(new_parent_id),
+        },
+    )
+    # Mock `find_one` to return the stored catalogue category document
+    test_helpers.mock_find_one(
+        database_mock.catalogue_categories,
+        catalogue_category.model_dump(),
+    )
+    # Mock `find_one` to return no duplicate catalogue categories found
+    test_helpers.mock_find_one(database_mock.catalogue_categories, None)
+    # Mock `update_one` to return an object for the updated catalogue category document
+    test_helpers.mock_update_one(database_mock.catalogue_categories)
+    # Mock `find_one` to return the updated catalogue category document
+    test_helpers.mock_find_one(
+        database_mock.catalogue_categories,
+        {**catalogue_category.model_dump(), "parent_id": CustomObjectId(new_parent_id)},
+    )
+
+    # Mock utils so not moving to a child of itself
+    mock_aggregation_pipeline = MagicMock()
+    utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
+    utils_mock.check_move_result.return_value = False
+    database_mock.catalogue_categories.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
+
+    catalogue_category_in = CatalogueCategoryIn(**{**CATALOGUE_CATEGORY_INFO, "parent_id": new_parent_id})
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_repository.update(catalogue_category.id, catalogue_category_in)
+    assert str(exc.value) == "Cannot move a catalogue category to one of its own children"
+
+    utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
+        entity_id=catalogue_category.id, destination_id=new_parent_id, collection_name="catalogue_categories"
+    )
+    utils_mock.check_move_result.assert_called_once()
+
+    database_mock.catalogue_categories.update_one.assert_not_called()
+    database_mock.catalogue_categories.find_one.assert_has_calls(
+        [
+            call({"_id": CustomObjectId(new_parent_id)}),
+            call({"_id": CustomObjectId(catalogue_category.id)}),
+            call({"parent_id": CustomObjectId(new_parent_id), "code": catalogue_category.code}),
+        ]
+    )
 
 
 def test_update_with_invalid_id(catalogue_category_repository):

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -3,7 +3,7 @@
 Unit tests for the `CatalogueCategoryRepo` repository.
 """
 from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
-from test.unit.repositories.test_utils import MOCK_QUERY_RESULT_LESS_THAN_MAX_LENGTH
+from test.unit.repositories.test_utils import MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -576,7 +576,7 @@ def test_get_breadcrumbs(mock_utils, database_mock, catalogue_category_repositor
 
     mock_utils.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
     mock_utils.compute_breadcrumbs.return_value = mock_breadcrumbs
-    database_mock.catalogue_categories.aggregate.return_value = MOCK_QUERY_RESULT_LESS_THAN_MAX_LENGTH
+    database_mock.catalogue_categories.aggregate.return_value = MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH
 
     retrieved_breadcrumbs = catalogue_category_repository.get_breadcrumbs(catalogue_category_id)
 
@@ -584,7 +584,7 @@ def test_get_breadcrumbs(mock_utils, database_mock, catalogue_category_repositor
         entity_id=catalogue_category_id, collection_name="catalogue_categories"
     )
     mock_utils.compute_breadcrumbs.assert_called_once_with(
-        list(MOCK_QUERY_RESULT_LESS_THAN_MAX_LENGTH),
+        list(MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH),
         entity_id=catalogue_category_id,
         collection_name="catalogue_categories",
     )

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -3,7 +3,7 @@ Unit tests for the `SystemRepo` repository
 """
 
 
-from test.unit.repositories.test_utils import MOCK_QUERY_RESULT_LESS_THAN_MAX_LENGTH
+from test.unit.repositories.test_utils import MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH
 from typing import Optional
 from unittest.mock import MagicMock, call, patch
 
@@ -272,7 +272,7 @@ def test_get_breadcrumbs(mock_utils, database_mock, system_repository):
 
     mock_utils.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
     mock_utils.compute_breadcrumbs.return_value = mock_breadcrumbs
-    database_mock.systems.aggregate.return_value = MOCK_QUERY_RESULT_LESS_THAN_MAX_LENGTH
+    database_mock.systems.aggregate.return_value = MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH
 
     retrieved_breadcrumbs = system_repository.get_breadcrumbs(system_id)
 
@@ -280,7 +280,7 @@ def test_get_breadcrumbs(mock_utils, database_mock, system_repository):
         entity_id=system_id, collection_name="systems"
     )
     mock_utils.compute_breadcrumbs.assert_called_once_with(
-        list(MOCK_QUERY_RESULT_LESS_THAN_MAX_LENGTH),
+        list(MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH),
         entity_id=system_id,
         collection_name="systems",
     )

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -378,7 +378,7 @@ def test_update(utils_mock, test_helpers, database_mock, system_repository):
     updated_system = system_repository.update(system.id, system_in)
 
     utils_mock.create_breadcrumbs_aggregation_pipeline.assert_not_called()
-    utils_mock.check_move_result.assert_not_called()
+    utils_mock.is_valid_move_result.assert_not_called()
 
     database_mock.systems.update_one.assert_called_once_with(
         {
@@ -438,7 +438,7 @@ def test_update_parent_id(utils_mock, test_helpers, database_mock, system_reposi
     # Mock utils so not moving to a child of itself
     mock_aggregation_pipeline = MagicMock()
     utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
-    utils_mock.check_move_result.return_value = True
+    utils_mock.is_valid_move_result.return_value = True
     database_mock.systems.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
 
     system_in = SystemIn(**{**SYSTEM_A_INFO, "parent_id": new_parent_id})
@@ -447,7 +447,7 @@ def test_update_parent_id(utils_mock, test_helpers, database_mock, system_reposi
     utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
         entity_id=system.id, destination_id=new_parent_id, collection_name="systems"
     )
-    utils_mock.check_move_result.assert_called_once()
+    utils_mock.is_valid_move_result.assert_called_once()
 
     database_mock.systems.update_one.assert_called_once_with(
         {
@@ -509,7 +509,7 @@ def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_moc
     # Mock utils so moving to a child of itself
     mock_aggregation_pipeline = MagicMock()
     utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
-    utils_mock.check_move_result.return_value = False
+    utils_mock.is_valid_move_result.return_value = False
     database_mock.systems.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_INVALID
 
     system_in = SystemIn(**{**SYSTEM_A_INFO, "parent_id": new_parent_id})
@@ -521,7 +521,7 @@ def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_moc
     utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
         entity_id=system.id, destination_id=new_parent_id, collection_name="systems"
     )
-    utils_mock.check_move_result.assert_called_once()
+    utils_mock.is_valid_move_result.assert_called_once()
 
     database_mock.systems.update_one.assert_not_called()
     database_mock.systems.find_one.assert_has_calls(

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -3,7 +3,11 @@ Unit tests for the `SystemRepo` repository
 """
 
 
-from test.unit.repositories.test_utils import MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH
+from test.unit.repositories.test_utils import (
+    MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH,
+    MOCK_MOVE_QUERY_RESULT_INVALID,
+    MOCK_MOVE_QUERY_RESULT_VALID,
+)
 from typing import Optional
 from unittest.mock import MagicMock, call, patch
 
@@ -14,6 +18,7 @@ from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     DuplicateRecordError,
+    InvalidActionError,
     InvalidObjectIdError,
     MissingRecordError,
 )
@@ -348,7 +353,7 @@ def test_list_with_invalid_parent_id_filter(test_helpers, database_mock, system_
     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
 
 
-def test_update(test_helpers, database_mock, system_repository):
+def test_update(test_helpers, database_mock, system_repository, utils_mock):
     """
     Test updating a System
 
@@ -356,13 +361,10 @@ def test_update(test_helpers, database_mock, system_repository):
     """
     system = SystemOut(id=str(ObjectId()), **SYSTEM_A_INFO)
 
-    # Mock `find_one` to return a System document
+    # Mock `find_one` to return the stored System document
     test_helpers.mock_find_one(
         database_mock.systems,
-        {
-            **SYSTEM_A_INFO,
-            "_id": CustomObjectId(system.id),
-        },
+        system.model_dump(),
     )
 
     # Mock `update_one` to return an object for the updated System document
@@ -371,11 +373,11 @@ def test_update(test_helpers, database_mock, system_repository):
     # Mock `find_one` to return the updated System document
     test_helpers.mock_find_one(database_mock.systems, {**SYSTEM_A_INFO, "_id": CustomObjectId(system.id)})
 
-    # Mock `find_one` to not return a parent System document
-    test_helpers.mock_find_one(database_mock.systems, None)
-
     system_in = SystemIn(**SYSTEM_A_INFO)
     updated_system = system_repository.update(system.id, system_in)
+
+    utils_mock.create_breadcrumbs_aggregation_pipeline.assert_not_called()
+    utils_mock.check_move_result.assert_not_called()
 
     database_mock.systems.update_one.assert_called_once_with(
         {
@@ -394,6 +396,144 @@ def test_update(test_helpers, database_mock, system_repository):
         ]
     )
     assert updated_system == system
+
+
+def test_update_parent_id(test_helpers, database_mock, system_repository, utils_mock):
+    """
+    Test updating a System's parent_id
+
+    Verify that the `update` method properly handles the update of a System when the parent id changes
+    """
+    parent_system_id = str(ObjectId())
+    system = SystemOut(id=str(ObjectId()), **{**SYSTEM_A_INFO, "parent_id": parent_system_id})
+    new_parent_id = str(ObjectId())
+    expected_system = SystemOut(id=system.id, **{**SYSTEM_A_INFO, "parent_id": new_parent_id})
+
+    # Mock `find_one` to return a parent System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {
+            **SYSTEM_B_INFO,
+            "_id": CustomObjectId(new_parent_id),
+        },
+    )
+
+    # Mock `find_one` to return the stored System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        system.model_dump(),
+    )
+
+    # Mock `find_one` to return no duplicates found
+    test_helpers.mock_find_one(database_mock.systems, None)
+
+    # Mock `update_one` to return an object for the updated System document
+    test_helpers.mock_update_one(database_mock.systems)
+
+    # Mock `find_one` to return the updated System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {**SYSTEM_A_INFO, "_id": CustomObjectId(system.id), "parent_id": CustomObjectId(new_parent_id)},
+    )
+
+    # Mock utils so not moving to a child of itself
+    mock_aggregation_pipeline = MagicMock()
+    utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
+    utils_mock.check_move_result.return_value = True
+    database_mock.systems.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
+
+    system_in = SystemIn(**{**SYSTEM_A_INFO, "parent_id": new_parent_id})
+    updated_system = system_repository.update(system.id, system_in)
+
+    utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
+        entity_id=system.id, destination_id=new_parent_id, collection_name="systems"
+    )
+    utils_mock.check_move_result.assert_called_once()
+
+    database_mock.systems.update_one.assert_called_once_with(
+        {
+            "_id": CustomObjectId(system.id),
+        },
+        {
+            "$set": {
+                **system_in.model_dump(),
+            },
+        },
+    )
+    database_mock.systems.find_one.assert_has_calls(
+        [
+            call({"_id": CustomObjectId(new_parent_id)}),
+            call({"_id": CustomObjectId(system.id)}),
+            call({"parent_id": CustomObjectId(new_parent_id), "code": system.code}),
+            call({"_id": CustomObjectId(system.id)}),
+        ]
+    )
+    assert updated_system == expected_system
+
+
+def test_update_parent_id_moving_to_child(test_helpers, database_mock, system_repository, utils_mock):
+    """
+    Test updating a System's parent_id when moving to a child of itself
+
+    Verify that the `update` method properly handles the update of a System when new parent id
+    is a child of itself
+    """
+    parent_system_id = str(ObjectId())
+    system = SystemOut(id=str(ObjectId()), **{**SYSTEM_A_INFO, "parent_id": parent_system_id})
+    new_parent_id = str(ObjectId())
+
+    # Mock `find_one` to return a parent System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {
+            **SYSTEM_B_INFO,
+            "_id": CustomObjectId(new_parent_id),
+        },
+    )
+
+    # Mock `find_one` to return the stored System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        system.model_dump(),
+    )
+
+    # Mock `find_one` to return no duplicates found
+    test_helpers.mock_find_one(database_mock.systems, None)
+
+    # Mock `update_one` to return an object for the updated System document
+    test_helpers.mock_update_one(database_mock.systems)
+
+    # Mock `find_one` to return the updated System document
+    test_helpers.mock_find_one(
+        database_mock.systems,
+        {**SYSTEM_A_INFO, "_id": CustomObjectId(system.id), "parent_id": CustomObjectId(new_parent_id)},
+    )
+
+    # Mock utils so moving to a child of itself
+    mock_aggregation_pipeline = MagicMock()
+    utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
+    utils_mock.check_move_result.return_value = False
+    database_mock.systems.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_INVALID
+
+    system_in = SystemIn(**{**SYSTEM_A_INFO, "parent_id": new_parent_id})
+
+    with pytest.raises(InvalidActionError) as exc:
+        system_repository.update(system.id, system_in)
+    assert str(exc.value) == "Cannot move a system to one of its own children"
+
+    utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
+        entity_id=system.id, destination_id=new_parent_id, collection_name="systems"
+    )
+    utils_mock.check_move_result.assert_called_once()
+
+    database_mock.systems.update_one.assert_not_called()
+    database_mock.systems.find_one.assert_has_calls(
+        [
+            call({"_id": CustomObjectId(new_parent_id)}),
+            call({"_id": CustomObjectId(system.id)}),
+            call({"parent_id": CustomObjectId(new_parent_id), "code": system.code}),
+        ]
+    )
 
 
 def test_update_with_invalid_id(database_mock, system_repository):

--- a/test/unit/repositories/test_utils.py
+++ b/test/unit/repositories/test_utils.py
@@ -179,17 +179,17 @@ class TestCreateMoveCheckAggregationPipeline:
         assert str(exc.value) == f"Invalid ObjectId value '{destination_id}'"
 
 
-class TestCheckMoveResult:
-    """Test check_move_result functions correctly"""
+class TestIsValidMoveResult:
+    """Test is_valid_move_result functions correctly"""
 
-    def test_check_move_result_when_valid(self):
+    def test_is_valid_move_result_when_valid(self):
         """Test compute_breadcrumbs functions correctly when the result is valid"""
-        assert utils.check_move_result(MOCK_MOVE_QUERY_RESULT_VALID) is True
+        assert utils.is_valid_move_result(MOCK_MOVE_QUERY_RESULT_VALID) is True
 
-    def test_check_move_result_when_invalid(self):
+    def test_is_valid_move_result_when_invalid(self):
         """Test compute_breadcrumbs functions correctly when the result is invalid"""
-        assert utils.check_move_result(MOCK_MOVE_QUERY_RESULT_INVALID) is False
+        assert utils.is_valid_move_result(MOCK_MOVE_QUERY_RESULT_INVALID) is False
 
-    def test_check_when_entity_not_found(self):
+    def test_is_valid_move_result_when_entity_not_found(self):
         """Test compute_breadcrumbs functions correctly when the entity ID doesnt exist in the database to begin with"""
-        assert utils.check_move_result(MOCK_MOVE_QUERY_RESULT_NON_EXISTENT_ID) is False
+        assert utils.is_valid_move_result(MOCK_MOVE_QUERY_RESULT_NON_EXISTENT_ID) is False


### PR DESCRIPTION
## Description
Prevents moving a system/category to a child of itself.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Closes #129 
