### PR TITLE
Allow catalogue items update with children #153

### DIFF
--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -1,6 +1,7 @@
 """
 Module for providing a repository for managing catalogue items in a MongoDB database.
 """
+
 import logging
 from typing import Optional, List
 
@@ -81,14 +82,9 @@ class CatalogueItemRepo:
 
         :param catalogue_item_id: The ID of the catalogue item to update.
         :param catalogue_item: The catalogue item containing the update data.
-        :raises ChildElementsExistError: If the catalogue item has child elements
         :return: The updated catalogue item.
         """
         catalogue_item_id = CustomObjectId(catalogue_item_id)
-        if self._has_child_elements(catalogue_item_id):
-            raise ChildElementsExistError(
-                f"Catalogue item with ID {str(catalogue_item_id)} has child elements and cannot be updated"
-            )
 
         logger.info("Updating catalogue item with ID: %s in the database", catalogue_item_id)
         self._catalogue_items_collection.update_one({"_id": catalogue_item_id}, {"$set": catalogue_item.model_dump()})
@@ -117,7 +113,7 @@ class CatalogueItemRepo:
         catalogue_items = self._catalogue_items_collection.find(query)
         return [CatalogueItemOut(**catalogue_item) for catalogue_item in catalogue_items]
 
-    def _has_child_elements(self, catalogue_item_id: CustomObjectId) -> bool:
+    def has_child_elements(self, catalogue_item_id: CustomObjectId) -> bool:
         """
         Check if a catalogue item has child elements based on its ID.
 

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -52,7 +52,7 @@ class CatalogueItemRepo:
         :raises MissingRecordError: If the catalogue item doesn't exist.
         """
         catalogue_item_id = CustomObjectId(catalogue_item_id)
-        if self._has_child_elements(catalogue_item_id):
+        if self.has_child_elements(catalogue_item_id):
             raise ChildElementsExistError(
                 f"Catalogue item with ID {str(catalogue_item_id)} has child elements and cannot be deleted"
             )

--- a/inventory_management_system_api/schemas/catalogue_item.py
+++ b/inventory_management_system_api/schemas/catalogue_item.py
@@ -1,6 +1,7 @@
 """
 Module for defining the API schema models for representing catalogue items.
 """
+
 from typing import List, Any, Optional
 
 from pydantic import BaseModel, Field, HttpUrl
@@ -54,6 +55,10 @@ class CatalogueItemPostRequestSchema(BaseModel):
         description="The properties specific to this catalogue item as defined in the corresponding "
         "catalogue category",
     )
+
+
+# Special fields that are not allowed to be changed in a post request while the catalogue item has child elements
+CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS = ["manufacturer_id", "properties"]
 
 
 class CatalogueItemPatchRequestSchema(CatalogueItemPostRequestSchema):

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -122,6 +122,7 @@ class CatalogueItemService:
         """
         return self._catalogue_item_repository.list(catalogue_category_id)
 
+    # pylint:disable=too-many-branches
     def update(self, catalogue_item_id: str, catalogue_item: CatalogueItemPatchRequestSchema) -> CatalogueItemOut:
         """
         Update a catalogue item by its ID.

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -824,10 +824,10 @@ def test_get_catalogue_items_with_invalid_catalogue_category_id_filter(test_clie
     assert len(catalogue_items) == 0
 
 
-def test_partial_update_catalogue_item_when_no_child_elements(test_client):
+def test_partial_update_catalogue_item_when_no_child_items(test_client):
     """
     Test changing the name and description of a catalogue item when it doesn't have any child
-    elements
+    items
     """
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
     catalogue_category_id = response.json()["id"]
@@ -859,7 +859,7 @@ def test_partial_update_catalogue_item_when_no_child_elements(test_client):
     }
 
 
-def test_partial_update_catalogue_item_when_has_child_elements(test_client):
+def test_partial_update_catalogue_item_when_has_child_items(test_client):
     """
     Test updating a catalogue item which has child items.
     """
@@ -1563,10 +1563,46 @@ def test_partial_update_catalogue_item_change_value_for_invalid_allowed_values_l
         response.json()["detail"] == "Invalid value for catalogue item property 'Property A'. Expected one of 2, 4, 6."
     )
 
-
-def test_partial_update_catalogue_item_change_manufacturer_id(test_client):
+def test_partial_update_catalogue_item_properties_when_has_child_items(test_client):
     """
-    Test updating the manufacturer ID of a catalogue item.
+    Test updating the properties of a catalogue item when it has child items.
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_d_id = response.json()["id"]
+
+    manufacturer_e_post = {
+        **MANUFACTURER,
+        "name": "Manufacturer E",
+    }
+    response = test_client.post("/v1/manufacturers", json=manufacturer_e_post)
+    manufacturer_e_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_A,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_d_id,
+    }
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    # Child
+    item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id}
+    test_client.post("/v1/items", json=item_post)
+
+    catalogue_item_patch = {
+        "manufacturer_id": manufacturer_e_id,
+    }
+    response = test_client.patch(f"/v1/catalogue-items/{response.json()['id']}", json=catalogue_item_patch)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Catalogue item has child elements and cannot be updated"
+
+def test_partial_update_catalogue_item_change_manufacturer_id_when_no_child_items(test_client):
+    """
+    Test updating the manufacturer ID of a catalogue item when it doesn't have any child items.
     """
     response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_B)
     catalogue_category_id = response.json()["id"]
@@ -1611,6 +1647,37 @@ def test_partial_update_catalogue_item_change_manufacturer_id(test_client):
         "catalogue_category_id": catalogue_category_id,
         "manufacturer_id": manufacturer_e_id,
     }
+
+
+def test_partial_update_catalogue_item_change_manufacturer_id_when_has_child_items(test_client):
+    """
+    Test updating the manufacturer ID of a catalogue item when it has child items.
+    """
+    response = test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+    catalogue_category_id = response.json()["id"]
+
+    response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
+    manufacturer_id = response.json()["id"]
+
+    catalogue_item_post = {
+        **CATALOGUE_ITEM_POST_A,
+        "catalogue_category_id": catalogue_category_id,
+        "manufacturer_id": manufacturer_id,
+    }
+    response = test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+    catalogue_item_id = response.json()["id"]
+
+    # Child
+    item_post = {**ITEM_POST, "catalogue_item_id": catalogue_item_id}
+    test_client.post("/v1/items", json=item_post)
+
+    catalogue_item_patch = {
+        "properties": CATALOGUE_ITEM_POST_A["properties"],
+    }
+    response = test_client.patch(f"/v1/catalogue-items/{response.json()['id']}", json=catalogue_item_patch)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Catalogue item has child elements and cannot be updated"
 
 
 def test_partial_update_catalogue_item_change_manufacturer_id_invalid_id(test_client):

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -1150,7 +1150,7 @@ def test_has_child_elements_with_child_categories(test_helpers, database_mock, c
 
     catalogue_category_id = str(ObjectId())
 
-    # Mock find_one to return 1 (children catalogue categories found)
+    # Mock find_one to return 1 (child catalogue categories found)
     test_helpers.mock_find_one(
         database_mock.catalogue_categories,
         {
@@ -1159,7 +1159,7 @@ def test_has_child_elements_with_child_categories(test_helpers, database_mock, c
             "parent_id": catalogue_category_id,
         },
     )
-    # Mock find_one to return 0 (children catalogue items not found)
+    # Mock find_one to return 0 (child catalogue items not found)
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
     result = catalogue_category_repository.has_child_elements(catalogue_category_id)

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the `CatalogueCategoryService` service.
 """
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -340,11 +341,12 @@ def test_list(catalogue_category_repository_mock, catalogue_category_service):
     assert result == catalogue_category_repository_mock.list.return_value
 
 
-def test_update(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+def test_update_when_no_child_elements(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
     """
-    Test updating a catalogue category.
+    Test updating a catalogue category without child elements
 
-    Verify that the `update` method properly handles the catalogue category to be updated.
+    Verify that the `update` method properly handles the catalogue category to be updated when it doesnt have any
+    child elements.
     """
     catalogue_category = CatalogueCategoryOut(
         id=str(ObjectId()),
@@ -367,6 +369,8 @@ def test_update(test_helpers, catalogue_category_repository_mock, catalogue_cate
             catalogue_item_properties=catalogue_category.catalogue_item_properties,
         ),
     )
+    # Mock so child elements not found
+    catalogue_category_repository_mock.has_child_elements.return_value = False
     # Mock `update` to return the updated catalogue category
     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
 
@@ -388,6 +392,55 @@ def test_update(test_helpers, catalogue_category_repository_mock, catalogue_cate
     # pylint: enable=duplicate-code
     assert updated_catalogue_category == catalogue_category
 
+def test_update_when_has_child_elements(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+    """
+    Test updating a catalogue category when it has child elements
+
+    Verify that the `update` method properly handles the catalogue category to be updated when it has children.
+    """
+    catalogue_category = CatalogueCategoryOut(
+        id=str(ObjectId()),
+        name="Category B",
+        code="category-b",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[],
+    )
+
+    # Mock `get` to return a catalogue category
+    test_helpers.mock_get(
+        catalogue_category_repository_mock,
+        CatalogueCategoryOut(
+            id=catalogue_category.id,
+            name="Category A",
+            code="category-a",
+            is_leaf=catalogue_category.is_leaf,
+            parent_id=catalogue_category.parent_id,
+            catalogue_item_properties=catalogue_category.catalogue_item_properties,
+        ),
+    )
+    # Mock so child elements found
+    catalogue_category_repository_mock.has_child_elements.return_value = True
+    # Mock `update` to return the updated catalogue category
+    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+    updated_catalogue_category = catalogue_category_service.update(
+        catalogue_category.id, CatalogueCategoryPatchRequestSchema(name=catalogue_category.name)
+    )
+
+    # pylint: disable=duplicate-code
+    catalogue_category_repository_mock.update.assert_called_once_with(
+        catalogue_category.id,
+        CatalogueCategoryIn(
+            name=catalogue_category.name,
+            code=catalogue_category.code,
+            is_leaf=catalogue_category.is_leaf,
+            parent_id=catalogue_category.parent_id,
+            catalogue_item_properties=catalogue_category.catalogue_item_properties,
+        ),
+    )
+    # pylint: enable=duplicate-code
+    assert updated_catalogue_category == catalogue_category
 
 def test_update_with_nonexistent_id(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
     """
@@ -432,6 +485,8 @@ def test_update_change_parent_id(test_helpers, catalogue_category_repository_moc
             catalogue_item_properties=catalogue_category.catalogue_item_properties,
         ),
     )
+    # Mock so child elements not found
+    catalogue_category_repository_mock.has_child_elements.return_value = False
     # Mock `get` to return a parent catalogue category
     # pylint: disable=duplicate-code
     test_helpers.mock_get(
@@ -486,6 +541,8 @@ def test_update_change_parent_id_leaf_parent_catalogue_category(
             catalogue_item_properties=[],
         ),
     )
+    # Mock so child elements not found
+    catalogue_category_repository_mock.has_child_elements.return_value = False
     catalogue_category_a_id = str(ObjectId())
     # Mock `get` to return a parent catalogue category
     test_helpers.mock_get(
@@ -528,9 +585,6 @@ def test_update_change_from_leaf_to_non_leaf_when_no_child_elements(
     )
     # pylint: enable=duplicate-code
 
-    # Mock so no child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-
     # Mock `get` to return a catalogue category
     test_helpers.mock_get(
         catalogue_category_repository_mock,
@@ -546,6 +600,8 @@ def test_update_change_from_leaf_to_non_leaf_when_no_child_elements(
             ],
         ),
     )
+    # Mock so child elements not found
+    catalogue_category_repository_mock.has_child_elements.return_value = False
     # Mock `update` to return the updated catalogue category
     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
 
@@ -588,9 +644,6 @@ def test_update_change_catalogue_item_properties_when_no_child_elements(
     )
     # pylint: enable=duplicate-code
 
-    # Mock so no child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-
     # Mock `get` to return a catalogue category
     # pylint: disable=duplicate-code
     test_helpers.mock_get(
@@ -604,6 +657,8 @@ def test_update_change_catalogue_item_properties_when_no_child_elements(
             catalogue_item_properties=[catalogue_category.catalogue_item_properties[1]],
         ),
     )
+    # Mock so child elements not found
+    catalogue_category_repository_mock.has_child_elements.return_value = False
     # pylint: enable=duplicate-code
     # Mock `update` to return the updated catalogue category
     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
@@ -645,9 +700,6 @@ def test_update_change_from_leaf_to_non_leaf_when_has_child_elements(
     )
     # pylint: enable=duplicate-code
 
-    # Mock so child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = True
-
     # Mock `get` to return a catalogue category
     test_helpers.mock_get(
         catalogue_category_repository_mock,
@@ -663,6 +715,8 @@ def test_update_change_from_leaf_to_non_leaf_when_has_child_elements(
             ],
         ),
     )
+    # Mock so child elements found
+    catalogue_category_repository_mock.has_child_elements.return_value = True
     # Mock `update` to return the updated catalogue category
     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
 
@@ -698,9 +752,6 @@ def test_update_change_catalogue_item_properties_when_has_child_elements(
     )
     # pylint: enable=duplicate-code
 
-    # Mock so child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = True
-
     # Mock `get` to return a catalogue category
     # pylint: disable=duplicate-code
     test_helpers.mock_get(
@@ -714,6 +765,8 @@ def test_update_change_catalogue_item_properties_when_has_child_elements(
             catalogue_item_properties=[catalogue_category.catalogue_item_properties[1]],
         ),
     )
+    # Mock so child elements found
+    catalogue_category_repository_mock.has_child_elements.return_value = True
     # pylint: enable=duplicate-code
     # Mock `update` to return the updated catalogue category
     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
@@ -768,6 +821,8 @@ def test_update_properties_to_have_duplicate_names(
             catalogue_item_properties=[catalogue_category.catalogue_item_properties[1]],
         ),
     )
+    # Mock so child elements not found
+    catalogue_category_repository_mock.has_child_elements.return_value = False
     # pylint: enable=duplicate-code
     # Mock `update` to return the updated catalogue category
     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)


### PR DESCRIPTION
## Description
Allows everything except manufacturer_id and properties to be updated in a catalogue item while it has children. Handled in the same way as #98.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #153
