### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     schedule:
       # Check for updates every week
       interval: "weekly"
+    # Update multiple dependencies at the same time
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Maintain pip dependencies
   - package-ecosystem: "pip"
@@ -14,3 +19,8 @@ updates:
     schedule:
       # Check for updates every week
       interval: "weekly"
+    # Update multiple dependencies at the same time
+    groups:
+      pip:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description
Configures Dependabot as [per](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) so that it groups/updates multiple dependencies at the same time.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build