### PR TITLE
Pin python docker images to SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       interval: daily
       time: "08:00"
       timezone: "Europe/London"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,9 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      # Check for updates every week
-      interval: "weekly"
+      interval: daily
+      time: "08:00"
+      timezone: "Europe/London"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
-          registry: harbor.stfc.ac.uk/inventory-management-system
+          registry: ${{ secrets.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -109,7 +109,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
-          images: harbor.stfc.ac.uk/inventory-management-system/ims-api
+          images: ${{ secrets.HARBOR_URL }}/ims-api
 
       - name: Build and push Docker image to Harbor
         uses: docker/build-push-action@af5a7ed5ba88268d5278f7203fb52cd833f66d6e # v5.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.19
+FROM python:3.12.2-alpine3.19@sha256:1a0501213b470de000d8432b3caab9d8de5489e9443c2cc7ccaa6b0aa5c3148e
 
 WORKDIR /inventory-management-system-api-run
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.19
+FROM python:3.12.2-alpine3.19@sha256:1a0501213b470de000d8432b3caab9d8de5489e9443c2cc7ccaa6b0aa5c3148e
 
 WORKDIR /inventory-management-system-api-run
 


### PR DESCRIPTION
## Description
This PR pins the Python docker images in the Dockerfiles to commit SHAs so that Dependabot can create PRs each time there is a change in the upstream base images that the Python image is set to use as new SHAs are generated on every upstream change. Unfortunately, Dependabot only updates the Python versions but not the OS versions and there is an open issue for this. This means that we will have to do the Alpine version updates manually for now. This PR also configures Dependabot to ignore Python major and minor versions so again we will have to do such Python upgrades manually when we are ready to do that.

Please note that I have pinned it to an older SHA to verify that Dependabot will create a PR.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build