### PR TITLE
Add session parameter to all repo methods #239

### DIFF
--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -6,6 +6,7 @@ import logging
 from typing import List, Optional
 
 from fastapi import Depends
+from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 from pymongo.database import Database
 
@@ -39,7 +40,7 @@ class CatalogueCategoryRepo:
         self._catalogue_categories_collection: Collection = self._database.catalogue_categories
         self._catalogue_items_collection: Collection = self._database.catalogue_items
 
-    def create(self, catalogue_category: CatalogueCategoryIn) -> CatalogueCategoryOut:
+    def create(self, catalogue_category: CatalogueCategoryIn, session: ClientSession = None) -> CatalogueCategoryOut:
         """
         Create a new catalogue category in a MongoDB database.
 
@@ -48,23 +49,24 @@ class CatalogueCategoryRepo:
         category is found within the parent catalogue category and raises a `DuplicateRecordError` if it is.
 
         :param catalogue_category: The catalogue category to be created.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The created catalogue category.
         :raises MissingRecordError: If the parent catalogue category specified by `parent_id` doesn't exist.
         :raises DuplicateRecordError: If a duplicate catalogue category is found within the parent catalogue category.
         """
         parent_id = str(catalogue_category.parent_id) if catalogue_category.parent_id else None
-        if parent_id and not self.get(parent_id):
+        if parent_id and not self.get(parent_id, session=session):
             raise MissingRecordError(f"No parent catalogue category found with ID: {parent_id}")
 
-        if self._is_duplicate_catalogue_category(parent_id, catalogue_category.code):
+        if self._is_duplicate_catalogue_category(parent_id, catalogue_category.code, session=session):
             raise DuplicateRecordError("Duplicate catalogue category found within the parent catalogue category")
 
         logger.info("Inserting the new catalogue category into the database")
-        result = self._catalogue_categories_collection.insert_one(catalogue_category.model_dump())
-        catalogue_category = self.get(str(result.inserted_id))
+        result = self._catalogue_categories_collection.insert_one(catalogue_category.model_dump(), session=session)
+        catalogue_category = self.get(str(result.inserted_id), session=session)
         return catalogue_category
 
-    def delete(self, catalogue_category_id: str) -> None:
+    def delete(self, catalogue_category_id: str, session: ClientSession = None) -> None:
         """
         Delete a catalogue category by its ID from a MongoDB database.
 
@@ -72,39 +74,44 @@ class CatalogueCategoryRepo:
         does.
 
         :param catalogue_category_id: The ID of the catalogue category to delete.
+        :param session: PyMongo ClientSession to use for database operations
         :raises ChildElementsExistError: If the catalogue category has child elements.
         :raises MissingRecordError: If the catalogue category doesn't exist.
         """
         catalogue_category_id = CustomObjectId(catalogue_category_id)
-        if self.has_child_elements(catalogue_category_id):
+        if self.has_child_elements(catalogue_category_id, session=session):
             raise ChildElementsExistError(
                 f"Catalogue category with ID {str(catalogue_category_id)} has child elements and cannot be deleted"
             )
 
         logger.info("Deleting catalogue category with ID: %s from the database", catalogue_category_id)
-        result = self._catalogue_categories_collection.delete_one({"_id": catalogue_category_id})
+        result = self._catalogue_categories_collection.delete_one({"_id": catalogue_category_id}, session=session)
         if result.deleted_count == 0:
             raise MissingRecordError(f"No catalogue category found with ID: {str(catalogue_category_id)}")
 
-    def get(self, catalogue_category_id: str) -> Optional[CatalogueCategoryOut]:
+    def get(self, catalogue_category_id: str, session: ClientSession = None) -> Optional[CatalogueCategoryOut]:
         """
         Retrieve a catalogue category by its ID from a MongoDB database.
 
         :param catalogue_category_id: The ID of the catalogue category to retrieve.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The retrieved catalogue category, or `None` if not found.
         """
         catalogue_category_id = CustomObjectId(catalogue_category_id)
         logger.info("Retrieving catalogue category with ID: %s from the database", catalogue_category_id)
-        catalogue_category = self._catalogue_categories_collection.find_one({"_id": catalogue_category_id})
+        catalogue_category = self._catalogue_categories_collection.find_one(
+            {"_id": catalogue_category_id}, session=session
+        )
         if catalogue_category:
             return CatalogueCategoryOut(**catalogue_category)
         return None
 
-    def get_breadcrumbs(self, catalogue_category_id: str) -> BreadcrumbsGetSchema:
+    def get_breadcrumbs(self, catalogue_category_id: str, session: ClientSession = None) -> BreadcrumbsGetSchema:
         """
         Retrieve the breadcrumbs for a specific catalogue category
 
         :param catalogue_category_id: ID of the catalogue category to retrieve breadcrumbs for
+        :param session: PyMongo ClientSession to use for database operations
         :return: Breadcrumbs
         """
         logger.info("Querying breadcrumbs for catalogue category with id '%s'", catalogue_category_id)
@@ -113,14 +120,17 @@ class CatalogueCategoryRepo:
                 self._catalogue_categories_collection.aggregate(
                     utils.create_breadcrumbs_aggregation_pipeline(
                         entity_id=catalogue_category_id, collection_name="catalogue_categories"
-                    )
+                    ),
+                    session=session,
                 )
             ),
             entity_id=catalogue_category_id,
             collection_name="catalogue_categories",
         )
 
-    def update(self, catalogue_category_id: str, catalogue_category: CatalogueCategoryIn) -> CatalogueCategoryOut:
+    def update(
+        self, catalogue_category_id: str, catalogue_category: CatalogueCategoryIn, session: ClientSession = None
+    ) -> CatalogueCategoryOut:
         """
         Update a catalogue category by its ID in a MongoDB database.
 
@@ -131,6 +141,7 @@ class CatalogueCategoryRepo:
 
         :param catalogue_category_id: The ID of the catalogue category to update.
         :param catalogue_category: The catalogue category containing the update data.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The updated catalogue category.
         :raises MissingRecordError: If the parent catalogue category specified by `parent_id` doesn't exist.
         :raises DuplicateRecordError: If a duplicate catalogue category is found within the parent catalogue category.
@@ -140,14 +151,14 @@ class CatalogueCategoryRepo:
         catalogue_category_id = CustomObjectId(catalogue_category_id)
 
         parent_id = str(catalogue_category.parent_id) if catalogue_category.parent_id else None
-        if parent_id and not self.get(parent_id):
+        if parent_id and not self.get(parent_id, session=session):
             raise MissingRecordError(f"No parent catalogue category found with ID: {parent_id}")
 
-        stored_catalogue_category = self.get(str(catalogue_category_id))
+        stored_catalogue_category = self.get(str(catalogue_category_id), session=session)
         moving_catalogue_category = parent_id != stored_catalogue_category.parent_id
         if (
             catalogue_category.name != stored_catalogue_category.name or moving_catalogue_category
-        ) and self._is_duplicate_catalogue_category(parent_id, catalogue_category.code):
+        ) and self._is_duplicate_catalogue_category(parent_id, catalogue_category.code, session=session):
             raise DuplicateRecordError("Duplicate catalogue category found within the parent catalogue category")
 
         # Prevent a catalogue category from being moved to one of its own children
@@ -159,7 +170,8 @@ class CatalogueCategoryRepo:
                             entity_id=str(catalogue_category_id),
                             destination_id=parent_id,
                             collection_name="catalogue_categories",
-                        )
+                        ),
+                        session=session,
                     )
                 )
             ):
@@ -167,39 +179,46 @@ class CatalogueCategoryRepo:
 
         logger.info("Updating catalogue category with ID: %s in the database", catalogue_category_id)
         self._catalogue_categories_collection.update_one(
-            {"_id": catalogue_category_id}, {"$set": catalogue_category.model_dump()}
+            {"_id": catalogue_category_id}, {"$set": catalogue_category.model_dump()}, session=session
         )
-        catalogue_category = self.get(str(catalogue_category_id))
+        catalogue_category = self.get(str(catalogue_category_id), session=session)
         return catalogue_category
 
-    def list(self, parent_id: Optional[str]) -> List[CatalogueCategoryOut]:
+    def list(self, parent_id: Optional[str], session: ClientSession = None) -> List[CatalogueCategoryOut]:
         """
         Retrieve catalogue categories from a MongoDB database based on the provided filters.
 
         :param parent_id: The parent_id to filter catalogue categories by.
+        :param session: PyMongo ClientSession to use for database operations
         :return: A list of catalogue categories, or an empty list if no catalogue categories are returned by the
                  database.
         """
         query = utils.list_query(parent_id, "catalogue categories")
 
-        catalogue_categories = self._catalogue_categories_collection.find(query)
+        catalogue_categories = self._catalogue_categories_collection.find(query, session=session)
         return [CatalogueCategoryOut(**catalogue_category) for catalogue_category in catalogue_categories]
 
-    def _is_duplicate_catalogue_category(self, parent_id: Optional[str], code: str) -> bool:
+    def _is_duplicate_catalogue_category(
+        self, parent_id: Optional[str], code: str, session: ClientSession = None
+    ) -> bool:
         """
         Check if a catalogue category with the same code already exists within the parent category.
 
         :param parent_id: The ID of the parent catalogue category which can also be `None`.
         :param code: The code of the catalogue category to check for duplicates.
+        :param session: PyMongo ClientSession to use for database operations
         :return: `True` if a duplicate catalogue category code is found, `False` otherwise.
         """
         logger.info("Checking if catalogue category with code '%s' already exists within the parent category", code)
         if parent_id:
             parent_id = CustomObjectId(parent_id)
 
-        return self._catalogue_categories_collection.find_one({"parent_id": parent_id, "code": code}) is not None
+        return (
+            self._catalogue_categories_collection.find_one({"parent_id": parent_id, "code": code}, session=session)
+            is not None
+        )
 
-    def has_child_elements(self, catalogue_category_id: CustomObjectId) -> bool:
+    def has_child_elements(self, catalogue_category_id: CustomObjectId, session: ClientSession = None) -> bool:
         """
         Check if a catalogue category has child elements based on its ID.
 
@@ -207,11 +226,16 @@ class CatalogueCategoryRepo:
         items.
 
         :param catalogue_category_id: The ID of the catalogue category to check.
+        :param session: PyMongo ClientSession to use for database operations
         :return: True if the catalogue category has child elements, False otherwise.
         """
         logger.info("Checking if catalogue category with ID '%s' has children elements", catalogue_category_id)
 
         return (
-            self._catalogue_categories_collection.find_one({"parent_id": catalogue_category_id}) is not None
-            or self._catalogue_items_collection.find_one({"catalogue_category_id": catalogue_category_id}) is not None
+            self._catalogue_categories_collection.find_one({"parent_id": catalogue_category_id}, session=session)
+            is not None
+            or self._catalogue_items_collection.find_one(
+                {"catalogue_category_id": catalogue_category_id}, session=session
+            )
+            is not None
         )

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -3,16 +3,17 @@ Module for providing a repository for managing catalogue items in a MongoDB data
 """
 
 import logging
-from typing import Optional, List
+from typing import List, Optional
 
 from fastapi import Depends
+from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 from pymongo.database import Database
 
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.database import get_database
 from inventory_management_system_api.core.exceptions import ChildElementsExistError, MissingRecordError
-from inventory_management_system_api.models.catalogue_item import CatalogueItemOut, CatalogueItemIn
+from inventory_management_system_api.models.catalogue_item import CatalogueItemIn, CatalogueItemOut
 
 logger = logging.getLogger()
 
@@ -32,70 +33,79 @@ class CatalogueItemRepo:
         self._catalogue_items_collection: Collection = self._database.catalogue_items
         self._items_collection: Collection = self._database.items
 
-    def create(self, catalogue_item: CatalogueItemIn) -> CatalogueItemOut:
+    def create(self, catalogue_item: CatalogueItemIn, session: ClientSession = None) -> CatalogueItemOut:
         """
         Create a new catalogue item in a MongoDB database.
 
         :param catalogue_item: The catalogue item to be created.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The created catalogue item.
         """
         logger.info("Inserting the new catalogue item into the database")
-        result = self._catalogue_items_collection.insert_one(catalogue_item.model_dump())
-        catalogue_item = self.get(str(result.inserted_id))
+        result = self._catalogue_items_collection.insert_one(catalogue_item.model_dump(), session=session)
+        catalogue_item = self.get(str(result.inserted_id), session=session)
         return catalogue_item
 
-    def delete(self, catalogue_item_id: str) -> None:
+    def delete(self, catalogue_item_id: str, session: ClientSession = None) -> None:
         """
         Delete a catalogue item by its ID from a MongoDB database.
 
         :param catalogue_item_id: The ID of the catalogue item to delete.
+        :param session: PyMongo ClientSession to use for database operations
         :raises MissingRecordError: If the catalogue item doesn't exist.
         """
         catalogue_item_id = CustomObjectId(catalogue_item_id)
-        if self.has_child_elements(catalogue_item_id):
+        if self.has_child_elements(catalogue_item_id, session=session):
             raise ChildElementsExistError(
                 f"Catalogue item with ID {str(catalogue_item_id)} has child elements and cannot be deleted"
             )
 
         logger.info("Deleting catalogue item with ID: %s from the database", catalogue_item_id)
-        result = self._catalogue_items_collection.delete_one({"_id": catalogue_item_id})
+        result = self._catalogue_items_collection.delete_one({"_id": catalogue_item_id}, session=session)
         if result.deleted_count == 0:
             raise MissingRecordError(f"No catalogue item found with ID: {str(catalogue_item_id)}")
 
-    def get(self, catalogue_item_id: str) -> Optional[CatalogueItemOut]:
+    def get(self, catalogue_item_id: str, session: ClientSession = None) -> Optional[CatalogueItemOut]:
         """
         Retrieve a catalogue item by its ID from a MongoDB database.
 
         :param catalogue_item_id: The ID of the catalogue item to retrieve.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The retrieved catalogue item, or `None` if not found.
         """
         catalogue_item_id = CustomObjectId(catalogue_item_id)
         logger.info("Retrieving catalogue item with ID: %s from the database", catalogue_item_id)
-        catalogue_item = self._catalogue_items_collection.find_one({"_id": catalogue_item_id})
+        catalogue_item = self._catalogue_items_collection.find_one({"_id": catalogue_item_id}, session=session)
         if catalogue_item:
             return CatalogueItemOut(**catalogue_item)
         return None
 
-    def update(self, catalogue_item_id: str, catalogue_item: CatalogueItemIn) -> CatalogueItemOut:
+    def update(
+        self, catalogue_item_id: str, catalogue_item: CatalogueItemIn, session: ClientSession = None
+    ) -> CatalogueItemOut:
         """
         Update a catalogue item by its ID in a MongoDB database.
 
         :param catalogue_item_id: The ID of the catalogue item to update.
         :param catalogue_item: The catalogue item containing the update data.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The updated catalogue item.
         """
         catalogue_item_id = CustomObjectId(catalogue_item_id)
 
         logger.info("Updating catalogue item with ID: %s in the database", catalogue_item_id)
-        self._catalogue_items_collection.update_one({"_id": catalogue_item_id}, {"$set": catalogue_item.model_dump()})
-        catalogue_item = self.get(str(catalogue_item_id))
+        self._catalogue_items_collection.update_one(
+            {"_id": catalogue_item_id}, {"$set": catalogue_item.model_dump()}, session=session
+        )
+        catalogue_item = self.get(str(catalogue_item_id), session=session)
         return catalogue_item
 
-    def list(self, catalogue_category_id: Optional[str]) -> List[CatalogueItemOut]:
+    def list(self, catalogue_category_id: Optional[str], session: ClientSession = None) -> List[CatalogueItemOut]:
         """
         Retrieve all catalogue items from a MongoDB.
 
         :param catalogue_category_id: The ID of the catalogue category to filter catalogue items by.
+        :param session: PyMongo ClientSession to use for database operations
         :return: A list of catalogue items, or an empty list if no catalogue items are returned by the database.
         """
         query = {}
@@ -110,18 +120,19 @@ class CatalogueItemRepo:
             logger.info("%s matching the provided catalogue category ID filter", message)
             logger.debug("Provided catalogue category ID filter: %s", catalogue_category_id)
 
-        catalogue_items = self._catalogue_items_collection.find(query)
+        catalogue_items = self._catalogue_items_collection.find(query, session=session)
         return [CatalogueItemOut(**catalogue_item) for catalogue_item in catalogue_items]
 
-    def has_child_elements(self, catalogue_item_id: CustomObjectId) -> bool:
+    def has_child_elements(self, catalogue_item_id: CustomObjectId, session: ClientSession = None) -> bool:
         """
         Check if a catalogue item has child elements based on its ID.
 
         Child elements in this case means whether a catalogue item has child items
 
         :param catalogue_item_id: The ID of the catalogue item to check
+        :param session: PyMongo ClientSession to use for database operations
         :return: True if the catalogue item has child elements, False otherwise.
         """
         logger.info("Checking if catalogue item with ID '%s' has child elements", catalogue_item_id)
-        item = self._items_collection.find_one({"catalogue_item_id": catalogue_item_id})
+        item = self._items_collection.find_one({"catalogue_item_id": catalogue_item_id}, session=session)
         return item is not None

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -6,10 +6,11 @@ import logging
 from typing import List, Optional
 
 from fastapi import Depends
+from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 from pymongo.database import Database
-from inventory_management_system_api.core.custom_object_id import CustomObjectId
 
+from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.database import get_database
 from inventory_management_system_api.core.exceptions import MissingRecordError
 from inventory_management_system_api.models.item import ItemIn, ItemOut
@@ -32,55 +33,61 @@ class ItemRepo:
         self._items_collection: Collection = self._database.items
         self._systems_collection: Collection = self._database.systems
 
-    def create(self, item: ItemIn) -> ItemOut:
+    def create(self, item: ItemIn, session: ClientSession = None) -> ItemOut:
         """
         Create a new item in a MongoDB database.
 
         :param item: The item to be created.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The created item.
         """
-        if item.system_id and not self._systems_collection.find_one({"_id": item.system_id}):
+        if item.system_id and not self._systems_collection.find_one({"_id": item.system_id}, session=session):
             raise MissingRecordError(f"No system found with ID: {item.system_id}")
 
         logger.info("Inserting the new item into the database")
-        result = self._items_collection.insert_one(item.model_dump())
+        result = self._items_collection.insert_one(item.model_dump(), session=session)
 
-        item = self.get(str(result.inserted_id))
+        item = self.get(str(result.inserted_id), session=session)
         return item
 
-    def delete(self, item_id: str) -> None:
+    def delete(self, item_id: str, session: ClientSession = None) -> None:
         """
         Delete an item by its ID from a MongoDB database.
 
         :param item_id: The ID of the item to delete.
+        :param session: PyMongo ClientSession to use for database operations
         :raises MissingRecordError: If the item doesn't exist
         """
         item_id = CustomObjectId(item_id)
         logger.info("Deleting item with ID: %s from the database", item_id)
-        result = self._items_collection.delete_one({"_id": item_id})
+        result = self._items_collection.delete_one({"_id": item_id}, session=session)
         if result.deleted_count == 0:
             raise MissingRecordError(f"No item found with ID: {str(item_id)}")
 
-    def get(self, item_id: str) -> Optional[ItemOut]:
+    def get(self, item_id: str, session: ClientSession = None) -> Optional[ItemOut]:
         """
         Retrieve an item by its ID from a MongoDB database.
 
         :param item_id: The ID of the item to retrieve
+        :param session: PyMongo ClientSession to use for database operations
         :return: The retrieved item, or `None` if not found.
         """
         item_id = CustomObjectId(item_id)
         logger.info("Retrieving item with ID %s from the database", item_id)
-        item = self._items_collection.find_one({"_id": item_id})
+        item = self._items_collection.find_one({"_id": item_id}, session=session)
         if item:
             return ItemOut(**item)
         return None
 
-    def list(self, system_id: Optional[str], catalogue_item_id: Optional[str]) -> List[ItemOut]:
+    def list(
+        self, system_id: Optional[str], catalogue_item_id: Optional[str], session: ClientSession = None
+    ) -> List[ItemOut]:
         """
         Get all items from the MongoDB database
 
         :param system_id: The ID of the system to filter items by.
         :param catalogue_item_id: The ID of the catalogue item to filter by.
+        :param session: PyMongo ClientSession to use for database operations
         :return List of items, or empty list if there are no items
         """
         query = {}
@@ -101,19 +108,20 @@ class ItemRepo:
             if catalogue_item_id:
                 logger.debug("Provided catalogue item ID filter: %s", catalogue_item_id)
 
-        items = self._items_collection.find(query)
+        items = self._items_collection.find(query, session=session)
         return [ItemOut(**item) for item in items]
 
-    def update(self, item_id: str, item: ItemIn) -> ItemOut:
+    def update(self, item_id: str, item: ItemIn, session: ClientSession = None) -> ItemOut:
         """
         Update an item by its ID in a MongoDB database.
 
         :param item_id: The ID of the item to update.
         :param item: The item containing the update data.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The updated item.
         """
         item_id = CustomObjectId(item_id)
         logger.info("Updating item with ID: %s in the database", item_id)
-        self._items_collection.update_one({"_id": item_id}, {"$set": item.model_dump()})
-        item = self.get(str(item_id))
+        self._items_collection.update_one({"_id": item_id}, {"$set": item.model_dump()}, session=session)
+        item = self.get(str(item_id), session=session)
         return item

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -6,6 +6,7 @@ import logging
 from typing import Optional
 
 from fastapi import Depends
+from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 from pymongo.database import Database
 
@@ -39,7 +40,7 @@ class SystemRepo:
         self._systems_collection: Collection = self._database.systems
         self._items_collection: Collection = self._database.items
 
-    def create(self, system: SystemIn) -> SystemOut:
+    def create(self, system: SystemIn, session: ClientSession = None) -> SystemOut:
         """
         Create a new System in a MongoDB database
 
@@ -48,71 +49,77 @@ class SystemRepo:
         System and raises a `DuplicateRecordError` if it is.
 
         :param system: System to be created
+        :param session: PyMongo ClientSession to use for database operations
         :return: Created System
         :raises MissingRecordError: If the parent System specified by `parent_id` doesn't exist
         :raises DuplicateRecordError: If a duplicate System is found within the parent System
         """
         parent_id = str(system.parent_id) if system.parent_id else None
-        if parent_id and not self.get(parent_id):
+        if parent_id and not self.get(parent_id, session=session):
             raise MissingRecordError(f"No parent System found with ID: {parent_id}")
 
-        if self._is_duplicate_system(parent_id, system.code):
+        if self._is_duplicate_system(parent_id, system.code, session=session):
             raise DuplicateRecordError("Duplicate System found within the parent System")
 
         logger.info("Inserting the new System into the database")
-        result = self._systems_collection.insert_one(system.model_dump())
-        system = self.get(str(result.inserted_id))
+        result = self._systems_collection.insert_one(system.model_dump(), session=session)
+        system = self.get(str(result.inserted_id), session=session)
         return system
 
-    def get(self, system_id: str) -> Optional[SystemOut]:
+    def get(self, system_id: str, session: ClientSession = None) -> Optional[SystemOut]:
         """
         Retrieve a System by its ID from a MongoDB database
 
         :param system_id: ID of the System to retrieve
+        :param session: PyMongo ClientSession to use for database operations
         :return: Retrieved System or `None` if not found
         """
         system_id = CustomObjectId(system_id)
         logger.info("Retrieving system with ID: %s from the database", system_id)
-        system = self._systems_collection.find_one({"_id": system_id})
+        system = self._systems_collection.find_one({"_id": system_id}, session=session)
         if system:
             return SystemOut(**system)
         return None
 
-    def get_breadcrumbs(self, system_id: str) -> BreadcrumbsGetSchema:
+    def get_breadcrumbs(self, system_id: str, session: ClientSession = None) -> BreadcrumbsGetSchema:
         """
         Retrieve the breadcrumbs for a specific system
 
         :param system_id: ID of the system to retrieve breadcrumbs for
+        :param session: PyMongo ClientSession to use for database operations
         :return: Breadcrumbs
         """
         logger.info("Querying breadcrumbs for system with id '%s'", system_id)
         return utils.compute_breadcrumbs(
             list(
                 self._systems_collection.aggregate(
-                    utils.create_breadcrumbs_aggregation_pipeline(entity_id=system_id, collection_name="systems")
+                    utils.create_breadcrumbs_aggregation_pipeline(entity_id=system_id, collection_name="systems"),
+                    session=session,
                 )
             ),
             entity_id=system_id,
             collection_name="systems",
         )
 
-    def list(self, parent_id: Optional[str]) -> list[SystemOut]:
+    def list(self, parent_id: Optional[str], session: ClientSession = None) -> list[SystemOut]:
         """
         Retrieve Systems from a MongoDB database based on the provided filters
 
         :param parent_id: parent_id to filter Systems by
+        :param session: PyMongo ClientSession to use for database operations
         :return: List of Systems or an empty list if no Systems are retrieved
         """
         query = utils.list_query(parent_id, "systems")
 
-        systems = self._systems_collection.find(query)
+        systems = self._systems_collection.find(query, session=session)
         return [SystemOut(**system) for system in systems]
 
-    def update(self, system_id: str, system: SystemIn) -> SystemOut:
+    def update(self, system_id: str, system: SystemIn, session: ClientSession = None) -> SystemOut:
         """Update a system by its ID in a MongoDB database
 
         :param system_id: ID of the System to update
         :param system: System containing the update data
+        :param session: PyMongo ClientSession to use for database operations
         :return: The updated System
         :raises MissingRecordError: If the parent System specified by `parent_id` doesn't exist
         :raises DuplicateRecordError: If a duplicate System is found within the parent System
@@ -121,12 +128,14 @@ class SystemRepo:
         system_id = CustomObjectId(system_id)
 
         parent_id = str(system.parent_id) if system.parent_id else None
-        if parent_id and not self.get(parent_id):
+        if parent_id and not self.get(parent_id, session=session):
             raise MissingRecordError(f"No parent System found with ID: {parent_id}")
 
-        stored_system = self.get(str(system_id))
+        stored_system = self.get(str(system_id), session=session)
         moving_system = parent_id != stored_system.parent_id
-        if (system.name != stored_system.name or moving_system) and self._is_duplicate_system(parent_id, system.code):
+        if (system.name != stored_system.name or moving_system) and self._is_duplicate_system(
+            parent_id, system.code, session=session
+        ):
             raise DuplicateRecordError("Duplicate System found within the parent System")
 
         # Prevent a system from being moved to one of its own children
@@ -136,60 +145,64 @@ class SystemRepo:
                     self._systems_collection.aggregate(
                         utils.create_move_check_aggregation_pipeline(
                             entity_id=str(system_id), destination_id=parent_id, collection_name="systems"
-                        )
+                        ),
+                        session=session,
                     )
                 )
             ):
                 raise InvalidActionError("Cannot move a system to one of its own children")
 
         logger.info("Updating system with ID: %s in the database", system_id)
-        self._systems_collection.update_one({"_id": system_id}, {"$set": system.model_dump()})
+        self._systems_collection.update_one({"_id": system_id}, {"$set": system.model_dump()}, session=session)
 
-        return self.get(str(system_id))
+        return self.get(str(system_id), session=session)
 
-    def delete(self, system_id: str) -> None:
+    def delete(self, system_id: str, session: ClientSession = None) -> None:
         """
         Delete a System by its ID from a MongoDB database
 
         The method checks if the system has any child and raises a `ChildElementsExistError` if it does
 
         :param system_id: ID of the System to delete
+        :param session: PyMongo ClientSession to use for database operations
         :raises ChildElementsExistError: If the System has child elements
         :raises MissingRecordError: If the System doesn't exist
         """
         system_id = CustomObjectId(system_id)
-        if self._has_child_elements(system_id):
+        if self._has_child_elements(system_id, session=session):
             raise ChildElementsExistError(f"System with ID {str(system_id)} has child elements and cannot be deleted")
 
         logger.info("Deleting system with ID: %s from the database", system_id)
-        result = self._systems_collection.delete_one({"_id": system_id})
+        result = self._systems_collection.delete_one({"_id": system_id}, session=session)
         if result.deleted_count == 0:
             raise MissingRecordError(f"No System found with ID: {str(system_id)}")
 
-    def _is_duplicate_system(self, parent_id: Optional[str], code: str) -> bool:
+    def _is_duplicate_system(self, parent_id: Optional[str], code: str, session: ClientSession = None) -> bool:
         """
         Check if a System with the same code already exists within the parent System
 
         :param parent_id: ID of the parent System which can also be `None`
         :param code: Code of the System to check for duplicates
+        :param session: PyMongo ClientSession to use for database operations
         :return: `True` if a duplicate System code is found under the given parent, `False` otherwise
         """
         logger.info("Checking if System with code '%s' already exists within the parent System", code)
         if parent_id:
             parent_id = CustomObjectId(parent_id)
 
-        return self._systems_collection.find_one({"parent_id": parent_id, "code": code}) is not None
+        return self._systems_collection.find_one({"parent_id": parent_id, "code": code}, session=session) is not None
 
-    def _has_child_elements(self, system_id: CustomObjectId) -> bool:
+    def _has_child_elements(self, system_id: CustomObjectId, session: ClientSession = None) -> bool:
         """
         Check if a System has any child System's or any Item's based on its ID
 
         :param system_id: ID of the System to check
+        :param session: PyMongo ClientSession to use for database operations
         :return: True if the System has child elements, False otherwise
         """
         logger.info("Checking if system with ID '%s' has child elements", str(system_id))
 
         return (
-            self._systems_collection.find_one({"parent_id": system_id}) is not None
-            or self._items_collection.find_one({"system_id": system_id}) is not None
+            self._systems_collection.find_one({"parent_id": system_id}, session=session) is not None
+            or self._items_collection.find_one({"system_id": system_id}, session=session) is not None
         )

--- a/inventory_management_system_api/repositories/unit.py
+++ b/inventory_management_system_api/repositories/unit.py
@@ -3,6 +3,7 @@ Module for providing a repository for managing Units in a MongoDB database
 """
 
 from fastapi import Depends
+from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 from pymongo.database import Database
 
@@ -24,11 +25,12 @@ class UnitRepo:
         self._database = database
         self._units_collection: Collection = self._database.units
 
-    def list(self) -> list[UnitOut]:
+    def list(self, session: ClientSession = None) -> list[UnitOut]:
         """
         Retrieve Units from a MongoDB database
 
+        :param session: PyMongo ClientSession to use for database operations
         :return: List of Units or an empty list if no Units are retrieved
         """
-        units = self._units_collection.find()
+        units = self._units_collection.find(session=session)
         return [UnitOut(**unit) for unit in units]

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -53,6 +53,7 @@ def test_create(test_helpers, database_mock, catalogue_category_repository):
     )
     catalogue_category_info = catalogue_category_in.model_dump()
     catalogue_category_out = CatalogueCategoryOut(id=str(ObjectId()), **catalogue_category_info)
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return no duplicate catalogue categories found
@@ -69,9 +70,9 @@ def test_create(test_helpers, database_mock, catalogue_category_repository):
         },
     )
 
-    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in)
+    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in, session=session)
 
-    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info)
+    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info, session=session)
     assert created_catalogue_category == catalogue_category_out
 
 
@@ -94,6 +95,7 @@ def test_create_leaf_category_without_catalogue_item_properties(
     )
     catalogue_category_info = catalogue_category_in.model_dump()
     catalogue_category_out = CatalogueCategoryOut(id=str(ObjectId()), **catalogue_category_info)
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return no duplicate catalogue categories found
@@ -106,9 +108,9 @@ def test_create_leaf_category_without_catalogue_item_properties(
         {**catalogue_category_info, "_id": CustomObjectId(catalogue_category_out.id)},
     )
 
-    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in)
+    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in, session=session)
 
-    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info)
+    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info, session=session)
     assert created_catalogue_category == catalogue_category_out
 
 
@@ -134,6 +136,7 @@ def test_create_leaf_category_with_catalogue_item_properties(
     )
     catalogue_category_info = catalogue_category_in.model_dump()
     catalogue_category_out = CatalogueCategoryOut(id=str(ObjectId()), **catalogue_category_info)
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return no duplicate catalogue categories found
@@ -149,9 +152,9 @@ def test_create_leaf_category_with_catalogue_item_properties(
         },
     )
 
-    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in)
+    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in, session=session)
 
-    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info)
+    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info, session=session)
     assert created_catalogue_category == catalogue_category_out
 
 
@@ -175,6 +178,7 @@ def test_create_with_parent_id(test_helpers, database_mock, catalogue_category_r
     )
     catalogue_category_info = catalogue_category_in.model_dump()
     catalogue_category_out = CatalogueCategoryOut(id=str(ObjectId()), **catalogue_category_info)
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return the parent catalogue category document
@@ -201,24 +205,27 @@ def test_create_with_parent_id(test_helpers, database_mock, catalogue_category_r
         },
     )
 
-    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in)
+    created_catalogue_category = catalogue_category_repository.create(catalogue_category_in, session=session)
 
-    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info)
+    database_mock.catalogue_categories.insert_one.assert_called_once_with(catalogue_category_info, session=session)
     database_mock.catalogue_categories.find_one.assert_has_calls(
         [
-            call({"_id": CustomObjectId(catalogue_category_out.parent_id)}),
-            call({"parent_id": CustomObjectId(catalogue_category_out.parent_id), "code": catalogue_category_out.code}),
-            call({"_id": CustomObjectId(catalogue_category_out.id)}),
+            call({"_id": CustomObjectId(catalogue_category_out.parent_id)}, session=session),
+            call(
+                {"parent_id": CustomObjectId(catalogue_category_out.parent_id), "code": catalogue_category_out.code},
+                session=session,
+            ),
+            call({"_id": CustomObjectId(catalogue_category_out.id)}, session=session),
         ]
     )
     assert created_catalogue_category == catalogue_category_out
 
 
-def test_create_with_nonexistent_parent_id(test_helpers, database_mock, catalogue_category_repository):
+def test_create_with_non_existent_parent_id(test_helpers, database_mock, catalogue_category_repository):
     """
-    Test creating a catalogue category with a nonexistent parent ID.
+    Test creating a catalogue category with a non-existent parent ID.
 
-    Verify that the `create` method properly handles a catalogue category with a nonexistent parent ID, does not find a
+    Verify that the `create` method properly handles a catalogue category with a non-existent parent ID, does not find a
     parent catalogue category with an ID specified by `parent_id`, and does not create the catalogue category.
     """
     # pylint: disable=duplicate-code
@@ -288,7 +295,8 @@ def test_create_with_duplicate_name_within_parent(test_helpers, database_mock, c
 
     assert str(exc.value) == "Duplicate catalogue category found within the parent catalogue category"
     database_mock.catalogue_categories.find_one.assert_called_with(
-        {"parent_id": CustomObjectId(catalogue_category_out.parent_id), "code": catalogue_category_out.code}
+        {"parent_id": CustomObjectId(catalogue_category_out.parent_id), "code": catalogue_category_out.code},
+        session=None,
     )
 
 
@@ -299,6 +307,7 @@ def test_delete(test_helpers, database_mock, catalogue_category_repository):
     Verify that the `delete` method properly handles the deletion of a catalogue category by ID.
     """
     catalogue_category_id = str(ObjectId())
+    session = MagicMock()
 
     # Mock `delete_one` to return that one document has been deleted
     test_helpers.mock_delete_one(database_mock.catalogue_categories, 1)
@@ -307,10 +316,10 @@ def test_delete(test_helpers, database_mock, catalogue_category_repository):
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
     test_helpers.mock_find_one(database_mock.catalogue_categories, None)
 
-    catalogue_category_repository.delete(catalogue_category_id)
+    catalogue_category_repository.delete(catalogue_category_id, session=session)
 
     database_mock.catalogue_categories.delete_one.assert_called_once_with(
-        {"_id": CustomObjectId(catalogue_category_id)}
+        {"_id": CustomObjectId(catalogue_category_id)}, session=session
     )
 
 
@@ -381,11 +390,11 @@ def test_delete_with_invalid_id(catalogue_category_repository):
     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
 
 
-def test_delete_with_nonexistent_id(test_helpers, database_mock, catalogue_category_repository):
+def test_delete_with_non_existent_id(test_helpers, database_mock, catalogue_category_repository):
     """
-    Test deleting a catalogue category with a nonexistent ID.
+    Test deleting a catalogue category with a non-existent ID.
 
-    Verify that the `delete` method properly handles the deletion of a catalogue category with a nonexistent ID.
+    Verify that the `delete` method properly handles the deletion of a catalogue category with a non-existent ID.
     """
     catalogue_category_id = str(ObjectId())
 
@@ -400,7 +409,7 @@ def test_delete_with_nonexistent_id(test_helpers, database_mock, catalogue_categ
         catalogue_category_repository.delete(catalogue_category_id)
     assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
     database_mock.catalogue_categories.delete_one.assert_called_once_with(
-        {"_id": CustomObjectId(catalogue_category_id)}
+        {"_id": CustomObjectId(catalogue_category_id)}, session=None
     )
 
 
@@ -420,6 +429,7 @@ def test_get(test_helpers, database_mock, catalogue_category_repository):
         catalogue_item_properties=[],
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return a catalogue category document
@@ -436,9 +446,11 @@ def test_get(test_helpers, database_mock, catalogue_category_repository):
         },
     )
 
-    retrieved_catalogue_category = catalogue_category_repository.get(catalogue_category.id)
+    retrieved_catalogue_category = catalogue_category_repository.get(catalogue_category.id, session=session)
 
-    database_mock.catalogue_categories.find_one.assert_called_once_with({"_id": CustomObjectId(catalogue_category.id)})
+    database_mock.catalogue_categories.find_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_category.id)}, session=session
+    )
     assert retrieved_catalogue_category == catalogue_category
 
 
@@ -453,11 +465,11 @@ def test_get_with_invalid_id(catalogue_category_repository):
     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
 
 
-def test_get_with_nonexistent_id(test_helpers, database_mock, catalogue_category_repository):
+def test_get_with_non_existent_id(test_helpers, database_mock, catalogue_category_repository):
     """
-    Test getting a catalogue category with a nonexistent ID.
+    Test getting a catalogue category with a non-existent ID.
 
-    Verify that the `get` method properly handles the retrieval of a catalogue category with a nonexistent ID.
+    Verify that the `get` method properly handles the retrieval of a catalogue category with a non-existent ID.
     """
     catalogue_category_id = str(ObjectId())
 
@@ -467,7 +479,9 @@ def test_get_with_nonexistent_id(test_helpers, database_mock, catalogue_category
     retrieved_catalogue_category = catalogue_category_repository.get(catalogue_category_id)
 
     assert retrieved_catalogue_category is None
-    database_mock.catalogue_categories.find_one.assert_called_once_with({"_id": CustomObjectId(catalogue_category_id)})
+    database_mock.catalogue_categories.find_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_category_id)}, session=None
+    )
 
 
 @patch("inventory_management_system_api.repositories.catalogue_category.utils")
@@ -525,6 +539,7 @@ def test_list(test_helpers, database_mock, catalogue_category_repository):
         catalogue_item_properties=[],
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of catalogue category documents
@@ -552,9 +567,9 @@ def test_list(test_helpers, database_mock, catalogue_category_repository):
         ],
     )
 
-    retrieved_catalogue_categories = catalogue_category_repository.list(None)
+    retrieved_catalogue_categories = catalogue_category_repository.list(None, session=session)
 
-    database_mock.catalogue_categories.find.assert_called_once_with({})
+    database_mock.catalogue_categories.find.assert_called_once_with({}, session=session)
     assert retrieved_catalogue_categories == [catalogue_category_a, catalogue_category_b]
 
 
@@ -575,6 +590,7 @@ def test_list_with_parent_id_filter(test_helpers, database_mock, catalogue_categ
         catalogue_item_properties=[],
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of catalogue category documents
@@ -594,9 +610,9 @@ def test_list_with_parent_id_filter(test_helpers, database_mock, catalogue_categ
     )
 
     parent_id = ObjectId()
-    retrieved_catalogue_categories = catalogue_category_repository.list(str(parent_id))
+    retrieved_catalogue_categories = catalogue_category_repository.list(str(parent_id), session=session)
 
-    database_mock.catalogue_categories.find.assert_called_once_with({"parent_id": parent_id})
+    database_mock.catalogue_categories.find.assert_called_once_with({"parent_id": parent_id}, session=session)
     assert retrieved_catalogue_categories == [catalogue_category]
 
 
@@ -627,6 +643,7 @@ def test_list_with_null_parent_id_filter(test_helpers, database_mock, catalogue_
         catalogue_item_properties=[],
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find` to return a list of catalogue category documents
@@ -654,9 +671,9 @@ def test_list_with_null_parent_id_filter(test_helpers, database_mock, catalogue_
         ],
     )
 
-    retrieved_catalogue_categories = catalogue_category_repository.list("null")
+    retrieved_catalogue_categories = catalogue_category_repository.list("null", session=session)
 
-    database_mock.catalogue_categories.find.assert_called_once_with({"parent_id": None})
+    database_mock.catalogue_categories.find.assert_called_once_with({"parent_id": None}, session=session)
     assert retrieved_catalogue_categories == [catalogue_category_a, catalogue_category_b]
 
 
@@ -668,13 +685,15 @@ def test_list_with_parent_id_filter_no_matching_results(test_helpers, database_m
     Verify that the `list` method properly handles the retrieval of catalogue categories based on the provided
     parent_id filter when there are no matching results in the database
     """
+    session = MagicMock()
+
     # Mock `find` to return an empty list of catalogue category documents
     test_helpers.mock_find(database_mock.catalogue_categories, [])
 
     parent_id = ObjectId()
-    retrieved_catalogue_categories = catalogue_category_repository.list(str(parent_id))
+    retrieved_catalogue_categories = catalogue_category_repository.list(str(parent_id), session=session)
 
-    database_mock.catalogue_categories.find.assert_called_once_with({"parent_id": parent_id})
+    database_mock.catalogue_categories.find.assert_called_once_with({"parent_id": parent_id}, session=session)
     assert retrieved_catalogue_categories == []
 
 
@@ -710,6 +729,7 @@ def test_update(test_helpers, database_mock, catalogue_category_repository):
         catalogue_item_properties=[],
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return a catalogue category document
@@ -747,7 +767,9 @@ def test_update(test_helpers, database_mock, catalogue_category_repository):
         },
     )
 
-    updated_catalogue_category = catalogue_category_repository.update(catalogue_category.id, catalogue_category_in)
+    updated_catalogue_category = catalogue_category_repository.update(
+        catalogue_category.id, catalogue_category_in, session=session
+    )
 
     database_mock.catalogue_categories.update_one.assert_called_once_with(
         {"_id": CustomObjectId(catalogue_category.id)},
@@ -756,12 +778,13 @@ def test_update(test_helpers, database_mock, catalogue_category_repository):
                 **catalogue_category_in.model_dump(),
             }
         },
+        session=session,
     )
     database_mock.catalogue_categories.find_one.assert_has_calls(
         [
-            call({"_id": CustomObjectId(catalogue_category.id)}),
-            call({"parent_id": catalogue_category.parent_id, "code": catalogue_category.code}),
-            call({"_id": CustomObjectId(catalogue_category.id)}),
+            call({"_id": CustomObjectId(catalogue_category.id)}, session=session),
+            call({"parent_id": catalogue_category.parent_id, "code": catalogue_category.code}, session=session),
+            call({"_id": CustomObjectId(catalogue_category.id)}, session=session),
         ]
     )
     assert updated_catalogue_category == CatalogueCategoryOut(
@@ -782,6 +805,7 @@ def test_update_parent_id(utils_mock, test_helpers, database_mock, catalogue_cat
         id=str(ObjectId()),
         **{**CATALOGUE_CATEGORY_INFO, "parent_id": parent_catalogue_category_id, **MOCK_CREATED_MODIFIED_TIME},
     )
+    session = MagicMock()
     new_parent_id = str(ObjectId())
     expected_catalogue_category = CatalogueCategoryOut(
         **{**catalogue_category.model_dump(), "parent_id": new_parent_id}
@@ -813,30 +837,34 @@ def test_update_parent_id(utils_mock, test_helpers, database_mock, catalogue_cat
 
     # Mock utils so not moving to a child of itself
     mock_aggregation_pipeline = MagicMock()
-    utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
+    utils_mock.create_move_check_aggregation_pipeline.return_value = mock_aggregation_pipeline
     utils_mock.is_valid_move_result.return_value = True
     database_mock.catalogue_categories.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
 
     catalogue_category_in = CatalogueCategoryIn(
         **{**CATALOGUE_CATEGORY_INFO, "parent_id": new_parent_id, **MOCK_CREATED_MODIFIED_TIME}
     )
-    updated_catalogue_category = catalogue_category_repository.update(catalogue_category.id, catalogue_category_in)
+    updated_catalogue_category = catalogue_category_repository.update(
+        catalogue_category.id, catalogue_category_in, session=session
+    )
 
     utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
         entity_id=catalogue_category.id, destination_id=new_parent_id, collection_name="catalogue_categories"
     )
+    database_mock.catalogue_categories.aggregate.assert_called_once_with(mock_aggregation_pipeline, session=session)
     utils_mock.is_valid_move_result.assert_called_once()
 
     database_mock.catalogue_categories.update_one.assert_called_once_with(
         {"_id": CustomObjectId(catalogue_category.id)},
         {"$set": {**catalogue_category_in.model_dump()}},
+        session=session,
     )
     database_mock.catalogue_categories.find_one.assert_has_calls(
         [
-            call({"_id": CustomObjectId(new_parent_id)}),
-            call({"_id": CustomObjectId(catalogue_category.id)}),
-            call({"parent_id": CustomObjectId(new_parent_id), "code": catalogue_category.code}),
-            call({"_id": CustomObjectId(catalogue_category.id)}),
+            call({"_id": CustomObjectId(new_parent_id)}, session=session),
+            call({"_id": CustomObjectId(catalogue_category.id)}, session=session),
+            call({"parent_id": CustomObjectId(new_parent_id), "code": catalogue_category.code}, session=session),
+            call({"_id": CustomObjectId(catalogue_category.id)}, session=session),
         ]
     )
     assert updated_catalogue_category == expected_catalogue_category
@@ -855,6 +883,7 @@ def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_moc
         id=str(ObjectId()),
         **{**CATALOGUE_CATEGORY_INFO, "parent_id": parent_catalogue_category_id, **MOCK_CREATED_MODIFIED_TIME},
     )
+    session = MagicMock()
     new_parent_id = str(ObjectId())
 
     # Mock `find_one` to return a parent catalogue category document
@@ -890,25 +919,26 @@ def test_update_parent_id_moving_to_child(utils_mock, test_helpers, database_moc
 
     # Mock utils so not moving to a child of itself
     mock_aggregation_pipeline = MagicMock()
-    utils_mock.create_breadcrumbs_aggregation_pipeline.return_value = mock_aggregation_pipeline
+    utils_mock.create_move_check_aggregation_pipeline.return_value = mock_aggregation_pipeline
     utils_mock.is_valid_move_result.return_value = False
     database_mock.catalogue_categories.aggregate.return_value = MOCK_MOVE_QUERY_RESULT_VALID
 
     with pytest.raises(InvalidActionError) as exc:
-        catalogue_category_repository.update(catalogue_category.id, catalogue_category_in)
+        catalogue_category_repository.update(catalogue_category.id, catalogue_category_in, session=session)
     assert str(exc.value) == "Cannot move a catalogue category to one of its own children"
 
     utils_mock.create_move_check_aggregation_pipeline.assert_called_once_with(
         entity_id=catalogue_category.id, destination_id=new_parent_id, collection_name="catalogue_categories"
     )
+    database_mock.catalogue_categories.aggregate.assert_called_once_with(mock_aggregation_pipeline, session=session)
     utils_mock.is_valid_move_result.assert_called_once()
 
     database_mock.catalogue_categories.update_one.assert_not_called()
     database_mock.catalogue_categories.find_one.assert_has_calls(
         [
-            call({"_id": CustomObjectId(new_parent_id)}),
-            call({"_id": CustomObjectId(catalogue_category.id)}),
-            call({"parent_id": CustomObjectId(new_parent_id), "code": catalogue_category.code}),
+            call({"_id": CustomObjectId(new_parent_id)}, session=session),
+            call({"_id": CustomObjectId(catalogue_category.id)}, session=session),
+            call({"parent_id": CustomObjectId(new_parent_id), "code": catalogue_category.code}, session=session),
         ]
     )
 

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -77,6 +77,7 @@ def test_create(test_helpers, database_mock, catalogue_item_repository):
         **catalogue_item_info,
         id=str(ObjectId()),
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `insert_one` to return an object for the inserted catalogue item document
@@ -94,9 +95,9 @@ def test_create(test_helpers, database_mock, catalogue_item_repository):
     # Mock `find_one` to return no duplicate catalogue items found
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
-    created_catalogue_item = catalogue_item_repository.create(catalogue_item_in)
+    created_catalogue_item = catalogue_item_repository.create(catalogue_item_in, session=session)
 
-    database_mock.catalogue_items.insert_one.assert_called_once_with(catalogue_item_info)
+    database_mock.catalogue_items.insert_one.assert_called_once_with(catalogue_item_info, session=session)
     assert created_catalogue_item == catalogue_item_out
 
 
@@ -107,6 +108,7 @@ def test_delete(test_helpers, database_mock, catalogue_item_repository):
     Verify that the `delete` method properly handles the deletion of a catalogue item by ID.
     """
     catalogue_item_id = str(ObjectId())
+    session = MagicMock()
 
     # Mock `delete_one` to return that one document has been deleted
     test_helpers.mock_delete_one(database_mock.catalogue_items, 1)
@@ -114,9 +116,11 @@ def test_delete(test_helpers, database_mock, catalogue_item_repository):
     # Mock `find_one` to return no child item document
     test_helpers.mock_find_one(database_mock.items, None)
 
-    catalogue_item_repository.delete(catalogue_item_id)
+    catalogue_item_repository.delete(catalogue_item_id, session=session)
 
-    database_mock.catalogue_items.delete_one.assert_called_once_with({"_id": CustomObjectId(catalogue_item_id)})
+    database_mock.catalogue_items.delete_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_item_id)}, session=session
+    )
 
 
 def test_delete_with_child_items(test_helpers, database_mock, catalogue_item_repository):
@@ -153,11 +157,11 @@ def test_delete_with_invalid_id(catalogue_item_repository):
     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
 
 
-def test_delete_with_nonexistent_id(test_helpers, database_mock, catalogue_item_repository):
+def test_delete_with_non_existent_id(test_helpers, database_mock, catalogue_item_repository):
     """
-    Test deleting a catalogue item with a nonexistent ID.
+    Test deleting a catalogue item with a non-existent ID.
 
-    Verify that the `delete` method properly handles the deletion of a catalogue item with a nonexistent ID.
+    Verify that the `delete` method properly handles the deletion of a catalogue item with a non-existent ID.
     """
     catalogue_item_id = str(ObjectId())
 
@@ -170,7 +174,9 @@ def test_delete_with_nonexistent_id(test_helpers, database_mock, catalogue_item_
     with pytest.raises(MissingRecordError) as exc:
         catalogue_item_repository.delete(catalogue_item_id)
     assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
-    database_mock.catalogue_items.delete_one.assert_called_once_with({"_id": CustomObjectId(catalogue_item_id)})
+    database_mock.catalogue_items.delete_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_item_id)}, session=None
+    )
 
 
 def test_get(test_helpers, database_mock, catalogue_item_repository):
@@ -187,6 +193,7 @@ def test_get(test_helpers, database_mock, catalogue_item_repository):
         **FULL_CATALOGUE_ITEM_A_INFO,
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return a catalogue item document
@@ -201,9 +208,11 @@ def test_get(test_helpers, database_mock, catalogue_item_repository):
         },
     )
 
-    retrieved_catalogue_item = catalogue_item_repository.get(catalogue_item.id)
+    retrieved_catalogue_item = catalogue_item_repository.get(catalogue_item.id, session=session)
 
-    database_mock.catalogue_items.find_one.assert_called_once_with({"_id": CustomObjectId(catalogue_item.id)})
+    database_mock.catalogue_items.find_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_item.id)}, session=session
+    )
     assert retrieved_catalogue_item == catalogue_item
 
 
@@ -218,11 +227,11 @@ def test_get_with_invalid_id(catalogue_item_repository):
     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
 
 
-def test_get_with_nonexistent_id(test_helpers, database_mock, catalogue_item_repository):
+def test_get_with_non_existent_id(test_helpers, database_mock, catalogue_item_repository):
     """
-    Test getting a catalogue item with a nonexistent ID.
+    Test getting a catalogue item with a non-existent ID.
 
-    Verify that the `get` method properly handles the retrieval of a catalogue item with a nonexistent ID.
+    Verify that the `get` method properly handles the retrieval of a catalogue item with a non-existent ID.
     """
     catalogue_item_id = str(ObjectId())
 
@@ -232,7 +241,9 @@ def test_get_with_nonexistent_id(test_helpers, database_mock, catalogue_item_rep
     retrieved_catalogue_item = catalogue_item_repository.get(catalogue_item_id)
 
     assert retrieved_catalogue_item is None
-    database_mock.catalogue_items.find_one.assert_called_once_with({"_id": CustomObjectId(catalogue_item_id)})
+    database_mock.catalogue_items.find_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_item_id)}, session=None
+    )
 
 
 def test_list(test_helpers, database_mock, catalogue_item_repository):
@@ -255,6 +266,7 @@ def test_list(test_helpers, database_mock, catalogue_item_repository):
         **FULL_CATALOGUE_ITEM_B_INFO,
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
 
     # Mock `find` to return a list of catalogue item documents
     test_helpers.mock_find(
@@ -277,9 +289,9 @@ def test_list(test_helpers, database_mock, catalogue_item_repository):
         ],
     )
 
-    retrieved_catalogue_items = catalogue_item_repository.list(None)
+    retrieved_catalogue_items = catalogue_item_repository.list(None, session=session)
 
-    database_mock.catalogue_items.find.assert_called_once_with({})
+    database_mock.catalogue_items.find.assert_called_once_with({}, session=session)
     assert retrieved_catalogue_items == [catalogue_item_a, catalogue_item_b]
 
 
@@ -298,6 +310,7 @@ def test_list_with_catalogue_category_id_filter(test_helpers, database_mock, cat
         **FULL_CATALOGUE_ITEM_A_INFO,
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
     # Mock `find` to return a list of catalogue item documents
     test_helpers.mock_find(
@@ -313,10 +326,10 @@ def test_list_with_catalogue_category_id_filter(test_helpers, database_mock, cat
         ],
     )
 
-    retrieved_catalogue_items = catalogue_item_repository.list(catalogue_item.catalogue_category_id)
+    retrieved_catalogue_items = catalogue_item_repository.list(catalogue_item.catalogue_category_id, session=session)
 
     database_mock.catalogue_items.find.assert_called_once_with(
-        {"catalogue_category_id": CustomObjectId(catalogue_item.catalogue_category_id)}
+        {"catalogue_category_id": CustomObjectId(catalogue_item.catalogue_category_id)}, session=session
     )
     assert retrieved_catalogue_items == [catalogue_item]
 
@@ -331,14 +344,16 @@ def test_list_with_catalogue_category_id_filter_no_matching_results(
     Verify that the `list` method properly handles the retrieval of catalogue items based on the provided catalogue
     category ID filter.
     """
+    session = MagicMock()
+
     # Mock `find` to return an empty list of catalogue item documents
     test_helpers.mock_find(database_mock.catalogue_items, [])
 
     catalogue_category_id = str(ObjectId())
-    retrieved_catalogue_items = catalogue_item_repository.list(catalogue_category_id)
+    retrieved_catalogue_items = catalogue_item_repository.list(catalogue_category_id, session=session)
 
     database_mock.catalogue_items.find.assert_called_once_with(
-        {"catalogue_category_id": CustomObjectId(catalogue_category_id)}
+        {"catalogue_category_id": CustomObjectId(catalogue_category_id)}, session=session
     )
     assert retrieved_catalogue_items == []
 
@@ -374,6 +389,7 @@ def test_update(test_helpers, database_mock, catalogue_item_repository):
         catalogue_category_id=str(ObjectId()),
         manufacturer_id=str(ObjectId()),
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `update_one` to return an object for the updated catalogue item document
@@ -397,7 +413,7 @@ def test_update(test_helpers, database_mock, catalogue_item_repository):
         catalogue_category_id=catalogue_item.catalogue_category_id,
         manufacturer_id=catalogue_item.manufacturer_id,
     )
-    updated_catalogue_item = catalogue_item_repository.update(catalogue_item.id, catalogue_item_in)
+    updated_catalogue_item = catalogue_item_repository.update(catalogue_item.id, catalogue_item_in, session=session)
 
     database_mock.catalogue_items.update_one.assert_called_once_with(
         {"_id": CustomObjectId(catalogue_item.id)},
@@ -407,8 +423,11 @@ def test_update(test_helpers, database_mock, catalogue_item_repository):
                 **catalogue_item_in.model_dump(),
             }
         },
+        session=session,
     )
-    database_mock.catalogue_items.find_one.assert_called_once_with({"_id": CustomObjectId(catalogue_item.id)})
+    database_mock.catalogue_items.find_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_item.id)}, session=session
+    )
     assert updated_catalogue_item == catalogue_item
 
 

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -45,6 +45,7 @@ def test_create(test_helpers, database_mock, manufacturer_repository):
         **manufacturer_info,
         id=str(ObjectId()),
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return no duplicate manufacturers found
@@ -60,13 +61,13 @@ def test_create(test_helpers, database_mock, manufacturer_repository):
         },
     )
 
-    created_manufacturer = manufacturer_repository.create(manufacturer_in)
+    created_manufacturer = manufacturer_repository.create(manufacturer_in, session=session)
 
-    database_mock.manufacturers.insert_one.assert_called_once_with(manufacturer_in.model_dump())
+    database_mock.manufacturers.insert_one.assert_called_once_with(manufacturer_in.model_dump(), session=session)
     database_mock.manufacturers.find_one.assert_has_calls(
         [
-            call({"code": manufacturer_out.code}),
-            call({"_id": CustomObjectId(manufacturer_out.id)}),
+            call({"code": manufacturer_out.code}, session=session),
+            call({"_id": CustomObjectId(manufacturer_out.id)}, session=session),
         ]
     )
     assert created_manufacturer == manufacturer_out
@@ -145,6 +146,7 @@ def test_list(test_helpers, database_mock, manufacturer_repository):
         ),
         telephone="073434394",
     )
+    session = MagicMock()
 
     test_helpers.mock_find(
         database_mock.manufacturers,
@@ -170,9 +172,9 @@ def test_list(test_helpers, database_mock, manufacturer_repository):
         ],
     )
 
-    retrieved_manufacturers = manufacturer_repository.list()
+    retrieved_manufacturers = manufacturer_repository.list(session=session)
 
-    database_mock.manufacturers.find.assert_called_once()
+    database_mock.manufacturers.find.assert_called_once_with(session=session)
     assert retrieved_manufacturers == [manufacturer_1, manufacturer_2]
 
 
@@ -203,6 +205,8 @@ def test_get(test_helpers, database_mock, manufacturer_repository):
         telephone="0932348348",
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
+
     test_helpers.mock_find_one(
         database_mock.manufacturers,
         {
@@ -215,8 +219,10 @@ def test_get(test_helpers, database_mock, manufacturer_repository):
             "telephone": manufacturer.telephone,
         },
     )
-    retrieved_manufacturer = manufacturer_repository.get(manufacturer.id)
-    database_mock.manufacturers.find_one.assert_called_once_with({"_id": CustomObjectId(manufacturer.id)})
+    retrieved_manufacturer = manufacturer_repository.get(manufacturer.id, session=session)
+    database_mock.manufacturers.find_one.assert_called_once_with(
+        {"_id": CustomObjectId(manufacturer.id)}, session=session
+    )
     assert retrieved_manufacturer == manufacturer
 
 
@@ -238,7 +244,7 @@ def test_get_with_nonexistent_id(test_helpers, database_mock, manufacturer_repos
     retrieved_manufacturer = manufacturer_repository.get(manufacturer_id)
 
     assert retrieved_manufacturer is None
-    database_mock.manufacturers.find_one.assert_called_once_with({"_id": CustomObjectId(manufacturer_id)})
+    database_mock.manufacturers.find_one.assert_called_once_with({"_id": CustomObjectId(manufacturer_id)}, session=None)
 
 
 def test_update(test_helpers, database_mock, manufacturer_repository):
@@ -259,6 +265,7 @@ def test_update(test_helpers, database_mock, manufacturer_repository):
         telephone="0932348348",
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock 'find_one' to return the existing manufacturer document
@@ -296,15 +303,11 @@ def test_update(test_helpers, database_mock, manufacturer_repository):
     )
 
     # pylint: disable=duplicate-code
-    updated_manufacturer = manufacturer_repository.update(
-        manufacturer.id,
-        manufacturer_in,
-    )
+    updated_manufacturer = manufacturer_repository.update(manufacturer.id, manufacturer_in, session=session)
     # pylint: enable=duplicate-code
 
     database_mock.manufacturers.update_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer.id)},
-        {"$set": manufacturer_in.model_dump()},
+        {"_id": CustomObjectId(manufacturer.id)}, {"$set": manufacturer_in.model_dump()}, session=session
     )
 
     assert updated_manufacturer == ManufacturerOut(id=manufacturer.id, **manufacturer_in.model_dump())
@@ -408,6 +411,7 @@ def test_partial_update_address(test_helpers, database_mock, manufacturer_reposi
         telephone="0932348348",
         **MOCK_CREATED_MODIFIED_TIME,
     )
+    session = MagicMock()
     # pylint: enable=duplicate-code
 
     # Mock `find_one` to return the existing manufacturer document
@@ -443,7 +447,7 @@ def test_partial_update_address(test_helpers, database_mock, manufacturer_reposi
         },
     )
 
-    manufactuerer_in = ManufacturerIn(
+    manufacturer_in = ManufacturerIn(
         name=manufacturer.name,
         code=manufacturer.code,
         url=manufacturer.url,
@@ -451,16 +455,14 @@ def test_partial_update_address(test_helpers, database_mock, manufacturer_reposi
         telephone=manufacturer.telephone,
     )
 
-    updated_manufacturer = manufacturer_repository.update(
-        manufacturer.id,
-        manufactuerer_in,
-    )
+    updated_manufacturer = manufacturer_repository.update(manufacturer.id, manufacturer_in, session=session)
 
     database_mock.manufacturers.update_one.assert_called_once_with(
         {"_id": CustomObjectId(manufacturer.id)},
         {
-            "$set": manufactuerer_in.model_dump(),
+            "$set": manufacturer_in.model_dump(),
         },
+        session=session,
     )
     assert updated_manufacturer == manufacturer
 
@@ -468,15 +470,18 @@ def test_partial_update_address(test_helpers, database_mock, manufacturer_reposi
 def test_delete(test_helpers, database_mock, manufacturer_repository):
     """Test trying to delete a manufacturer"""
     manufacturer_id = str(ObjectId())
+    session = MagicMock()
 
     test_helpers.mock_delete_one(database_mock.manufacturers, 1)
 
     # Mock `find_one` to return no child catalogue item document
     test_helpers.mock_find_one(database_mock.catalogue_items, None)
 
-    manufacturer_repository.delete(manufacturer_id)
+    manufacturer_repository.delete(manufacturer_id, session=session)
 
-    database_mock.manufacturers.delete_one.assert_called_once_with({"_id": CustomObjectId(manufacturer_id)})
+    database_mock.manufacturers.delete_one.assert_called_once_with(
+        {"_id": CustomObjectId(manufacturer_id)}, session=session
+    )
 
 
 def test_delete_with_an_invalid_id(manufacturer_repository):
@@ -488,7 +493,7 @@ def test_delete_with_an_invalid_id(manufacturer_repository):
     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
 
 
-def test_delete_with_a_nonexistent_id(test_helpers, database_mock, manufacturer_repository):
+def test_delete_with_a_non_existent_id(test_helpers, database_mock, manufacturer_repository):
     """Test trying to delete a manufacturer with a non-existent ID"""
     manufacturer_id = str(ObjectId())
 
@@ -499,7 +504,9 @@ def test_delete_with_a_nonexistent_id(test_helpers, database_mock, manufacturer_
     with pytest.raises(MissingRecordError) as exc:
         manufacturer_repository.delete(manufacturer_id)
     assert str(exc.value) == f"No manufacturer found with ID: {manufacturer_id}"
-    database_mock.manufacturers.delete_one.assert_called_once_with({"_id": CustomObjectId(manufacturer_id)})
+    database_mock.manufacturers.delete_one.assert_called_once_with(
+        {"_id": CustomObjectId(manufacturer_id)}, session=None
+    )
 
 
 def test_delete_manufacturer_that_is_part_of_a_catalogue_item(test_helpers, database_mock, manufacturer_repository):

--- a/test/unit/repositories/test_unit.py
+++ b/test/unit/repositories/test_unit.py
@@ -2,11 +2,12 @@
 Unit tests for the `UnitRepo` repository
 """
 
+from unittest.mock import MagicMock
+
 from bson import ObjectId
+
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
-
 from inventory_management_system_api.models.units import UnitOut
-
 
 UNIT_A_INFO = {"value": "millimeter"}
 UNIT_B_INFO = {"value": "micrometer"}
@@ -20,6 +21,7 @@ def test_list(test_helpers, database_mock, unit_repository):
     """
     unit_a = UnitOut(id=str(ObjectId()), **UNIT_A_INFO)
     unit_b = UnitOut(id=str(ObjectId()), **UNIT_B_INFO)
+    session = MagicMock()
 
     # Mock `find` to return a list of Unit documents
     test_helpers.mock_find(
@@ -27,7 +29,7 @@ def test_list(test_helpers, database_mock, unit_repository):
         [{"_id": CustomObjectId(unit_a.id), **UNIT_A_INFO}, {"_id": CustomObjectId(unit_b.id), **UNIT_B_INFO}],
     )
 
-    retrieved_units = unit_repository.list()
+    retrieved_units = unit_repository.list(session=session)
 
-    database_mock.units.find.assert_called_once_with()
+    database_mock.units.find.assert_called_once_with(session=session)
     assert retrieved_units == [unit_a, unit_b]


### PR DESCRIPTION
## Description
I thought this may be the best approach for #239, but happy to discuss. With this we can reuse any and all repo methods, but pass in the session after the transaction has started. Also has potential of use in consistent sessions (not that we need them), as get requests that happen after edit can use the same session in the update methods for example.

Note: Also replaces a few `nonexistent` -> `non-existent`, and fixes a mistake in move check tests (it was still mocking as though it was for breadcrumbs and didn't check the aggregate function was called)

Would also want these changes for #231, #234.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #239 
