### PR TITLE
Fix bug in dev_cli script's db-generate command

### DIFF
--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -242,7 +242,7 @@ class CommandDBGenerate(SubCommand):
         add_mongodb_auth_args(parser)
 
         parser.add_argument(
-            "-d", "--dump", action="store_false", help="Whether to dump the output into a file that can be committed"
+            "-d", "--dump", action="store_true", help="Whether to dump the output into a file that can be committed"
         )
 
     def run(self, args: argparse.Namespace):

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -255,9 +255,7 @@ class CommandDBGenerate(SubCommand):
             # Delete the existing data
             logging.info("Deleting database contents...")
             run_mongodb_command(
-                [
-                    "mongosh",
-                ]
+                ["mongosh", "ims"]
                 + get_mongodb_auth_args(args)
                 + [
                     "--eval",


### PR DESCRIPTION
## Description
Make `db-generate` dump when `-d` or `--dump` is supplied rather than when they aren't. Also it only cleared the test database as I had forgotten to specify ims.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
