### PR TITLE
Add POST property endpoint for catalogue categories #259

### DIFF
--- a/inventory_management_system_api/models/catalogue_item.py
+++ b/inventory_management_system_api/models/catalogue_item.py
@@ -71,6 +71,7 @@ class CatalogueItemBase(BaseModel):
         if properties is None:
             properties = []
         return properties
+
     # pylint: enable=duplicate-code
 
     @field_serializer("drawing_link")

--- a/inventory_management_system_api/models/catalogue_item.py
+++ b/inventory_management_system_api/models/catalogue_item.py
@@ -2,7 +2,7 @@
 Module for defining the database models for representing catalogue items.
 """
 
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_serializer, field_validator
 
@@ -17,7 +17,7 @@ class PropertyIn(BaseModel):
 
     id: CustomObjectIdField = Field(serialization_alias="_id")
     name: str
-    value: Optional[Union[str, float, bool]]
+    value: Any
     unit: Optional[str] = None
 
 
@@ -28,7 +28,7 @@ class PropertyOut(BaseModel):
 
     id: StringObjectIdField = Field(alias="_id")
     name: str
-    value: Optional[Union[str, float, bool]]
+    value: Any
     unit: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/inventory_management_system_api/models/catalogue_item.py
+++ b/inventory_management_system_api/models/catalogue_item.py
@@ -2,7 +2,7 @@
 Module for defining the database models for representing catalogue items.
 """
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_serializer, field_validator
 
@@ -17,7 +17,7 @@ class PropertyIn(BaseModel):
 
     id: CustomObjectIdField = Field(serialization_alias="_id")
     name: str
-    value: Any
+    value: Optional[Union[str, float, bool]]
     unit: Optional[str] = None
 
 
@@ -28,7 +28,7 @@ class PropertyOut(BaseModel):
 
     id: StringObjectIdField = Field(alias="_id")
     name: str
-    value: Any
+    value: Optional[Union[str, float, bool]]
     unit: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/inventory_management_system_api/models/item.py
+++ b/inventory_management_system_api/models/item.py
@@ -42,6 +42,7 @@ class ItemBase(BaseModel):
         if properties is None:
             properties = []
         return properties
+
     # pylint: enable=duplicate-code
 
 

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -3,6 +3,7 @@ Module for providing a repository for managing catalogue categories in a MongoDB
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from fastapi import Depends
@@ -18,7 +19,12 @@ from inventory_management_system_api.core.exceptions import (
     InvalidActionError,
     MissingRecordError,
 )
-from inventory_management_system_api.models.catalogue_category import CatalogueCategoryIn, CatalogueCategoryOut
+from inventory_management_system_api.models.catalogue_category import (
+    CatalogueCategoryIn,
+    CatalogueCategoryOut,
+    CatalogueItemPropertyIn,
+    CatalogueItemPropertyOut,
+)
 from inventory_management_system_api.repositories import utils
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
 
@@ -241,3 +247,36 @@ class CatalogueCategoryRepo:
             )
             is not None
         )
+
+    def create_catalogue_item_property(
+        self,
+        catalogue_category_id: str,
+        catalogue_item_property: CatalogueItemPropertyIn,
+        session: ClientSession = None,
+    ) -> CatalogueItemPropertyOut:
+        """
+        Create a new a catalogue item property within a catalogue category given its ID in a MongoDB database
+
+        This method only affects catalogue categories so this should only be used in conjunction with the respective
+        insert methods within the catalogue items and items repos if the catalogue category may have children.
+
+        :param catalogue_category_id: The ID of the catalogue category to add the property to
+        :param catalogue_item_property: The catalogue item property containing the property data
+        :param session: PyMongo ClientSession to use for database operations
+        :return: The added catalogue category
+        """
+
+        logger.info(
+            "Inserting new catalogue item property into catalogue category with ID: %s in the database",
+            catalogue_category_id,
+        )
+        catalogue_item_property_data = catalogue_item_property.model_dump(by_alias=True)
+        self._catalogue_categories_collection.update_one(
+            {"_id": CustomObjectId(catalogue_category_id)},
+            {
+                "$push": {"catalogue_item_properties": catalogue_item_property_data},
+                "$set": {"modified_time": datetime.now(timezone.utc)},
+            },
+            session=session,
+        )
+        return CatalogueItemPropertyOut(**catalogue_item_property_data)

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -2,9 +2,11 @@
 Module for providing a repository for managing catalogue items in a MongoDB database.
 """
 
+from datetime import datetime, timezone
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+from bson import ObjectId
 from fastapi import Depends
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -13,7 +15,7 @@ from pymongo.database import Database
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.database import get_database
 from inventory_management_system_api.core.exceptions import ChildElementsExistError, MissingRecordError
-from inventory_management_system_api.models.catalogue_item import CatalogueItemIn, CatalogueItemOut
+from inventory_management_system_api.models.catalogue_item import CatalogueItemIn, CatalogueItemOut, PropertyIn
 
 logger = logging.getLogger()
 
@@ -102,7 +104,7 @@ class CatalogueItemRepo:
 
     def list(self, catalogue_category_id: Optional[str], session: ClientSession = None) -> List[CatalogueItemOut]:
         """
-        Retrieve all catalogue items from a MongoDB.
+        Retrieve all catalogue items from a MongoDB database.
 
         :param catalogue_category_id: The ID of the catalogue category to filter catalogue items by.
         :param session: PyMongo ClientSession to use for database operations
@@ -136,3 +138,50 @@ class CatalogueItemRepo:
         logger.info("Checking if catalogue item with ID '%s' has child elements", catalogue_item_id)
         item = self._items_collection.find_one({"catalogue_item_id": catalogue_item_id}, session=session)
         return item is not None
+
+    def list_ids(self, catalogue_category_id: str, session: ClientSession = None) -> List[Dict[str, ObjectId]]:
+        """
+        Retrieve a list of all catalogue item ids with a specific catalogue_category_id from a MongoDB
+        database. Performs a projection to only include _id. (Required for mass updates of properties
+        to reduce memory usage)
+
+        :param catalogue_category_id: The ID of the catalogue category to filter catalogue items by.
+        :param session: PyMongo ClientSession to use for database operations
+        :return: A list of dicts in the form { _id: ObjectId }, or an empty list if no catalogue items are returned by
+                 the database.
+        """
+        logger.info(
+            "Finding the id's of all catalogue items within the catalogue category with ID '%s' in the database",
+            catalogue_category_id,
+        )
+        # Using distinct has a 16MB limit
+        # https://stackoverflow.com/questions/29771192/how-do-i-get-a-list-of-just-the-objectids-using-pymongo
+        # For 100000 documents, using list comprehension takes about 0.85 seconds vs 0.50 seconds for distinct
+
+        return self._catalogue_items_collection.find(
+            {"catalogue_category_id": CustomObjectId(catalogue_category_id)}, {"_id": 1}, session=session
+        ).distinct("_id")
+
+    def insert_property_to_all_matching(
+        self, catalogue_category_id: str, property_in: PropertyIn, session: ClientSession = None
+    ):
+        """
+        Inserts a property into every catalogue item with a given catalogue_category_id via an update_many query
+
+        :param catalogue_category_id: The ID of the catalogue category who's catalogue items to update
+        :param property_in: The property to insert into the catalogue items' properties list
+        :param session: PyMongo ClientSession to use for database operations
+        """
+
+        logger.info(
+            "Inserting property into catalogue item's with a catalogue category: %s in the database",
+            catalogue_category_id,
+        )
+        self._catalogue_items_collection.update_many(
+            {"catalogue_category_id": CustomObjectId(catalogue_category_id)},
+            {
+                "$push": {"properties": property_in.model_dump(by_alias=True)},
+                "$set": {"modified_time": datetime.now(timezone.utc)},
+            },
+            session=session,
+        )

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -154,10 +154,10 @@ class CatalogueItemRepo:
             "Finding the id's of all catalogue items within the catalogue category with ID '%s' in the database",
             catalogue_category_id,
         )
+
         # Using distinct has a 16MB limit
         # https://stackoverflow.com/questions/29771192/how-do-i-get-a-list-of-just-the-objectids-using-pymongo
         # For 100000 documents, using list comprehension takes about 0.85 seconds vs 0.50 seconds for distinct
-
         return self._catalogue_items_collection.find(
             {"catalogue_category_id": CustomObjectId(catalogue_category_id)}, {"_id": 1}, session=session
         ).distinct("_id")
@@ -177,6 +177,7 @@ class CatalogueItemRepo:
             "Inserting property into catalogue item's with a catalogue category: %s in the database",
             catalogue_category_id,
         )
+
         self._catalogue_items_collection.update_many(
             {"catalogue_category_id": CustomObjectId(catalogue_category_id)},
             {

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -4,7 +4,7 @@ Module for providing a repository for managing catalogue items in a MongoDB data
 
 from datetime import datetime, timezone
 import logging
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from bson import ObjectId
 from fastapi import Depends
@@ -139,7 +139,7 @@ class CatalogueItemRepo:
         item = self._items_collection.find_one({"catalogue_item_id": catalogue_item_id}, session=session)
         return item is not None
 
-    def list_ids(self, catalogue_category_id: str, session: ClientSession = None) -> List[Dict[str, ObjectId]]:
+    def list_ids(self, catalogue_category_id: str, session: ClientSession = None) -> List[ObjectId]:
         """
         Retrieve a list of all catalogue item ids with a specific catalogue_category_id from a MongoDB
         database. Performs a projection to only include _id. (Required for mass updates of properties

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -147,7 +147,7 @@ class CatalogueItemRepo:
 
         :param catalogue_category_id: The ID of the catalogue category to filter catalogue items by.
         :param session: PyMongo ClientSession to use for database operations
-        :return: A list of dicts in the form { _id: ObjectId }, or an empty list if no catalogue items are returned by
+        :return: A list object catalogue item ObjectId's or an empty list if no catalogue items are returned by
                  the database.
         """
         logger.info(

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -4,7 +4,7 @@ Module for providing a repository for managing items in a MongoDB database.
 
 import logging
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from bson import ObjectId
 from fastapi import Depends
@@ -130,7 +130,7 @@ class ItemRepo:
         return item
 
     def insert_property_to_all_in(
-        self, catalogue_item_ids: List[Dict[str, ObjectId]], property_in: PropertyIn, session: ClientSession = None
+        self, catalogue_item_ids: List[ObjectId], property_in: PropertyIn, session: ClientSession = None
     ):
         """
         Inserts a property into every item with one of the given catalogue_item_id's using an update_many query

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -221,4 +221,16 @@ def create_catalogue_item_property(
     logger.info("Creating a new catalogue item property at the catalogue category level")
     logger.debug("Catalogue item property data: %s", catalogue_item_property)
 
-    catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)
+    try:
+        return catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)
+    except (MissingRecordError, InvalidObjectIdError) as exc:
+        message = "Catalogue category not found"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+    except DuplicateCatalogueItemPropertyNameError as exc:
+        logger.exception(str(exc))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+    except InvalidActionError as exc:
+        message = str(exc)
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -222,7 +222,9 @@ def create_catalogue_item_property(
     logger.debug("Catalogue item property data: %s", catalogue_item_property)
 
     try:
-        return catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)
+        return CatalogueItemPropertySchema(
+            **catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property).model_dump()
+        )
     except (MissingRecordError, InvalidObjectIdError) as exc:
         message = "Catalogue category not found"
         logger.exception(message)

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -23,8 +23,11 @@ from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueCategoryPatchRequestSchema,
     CatalogueCategoryPostRequestSchema,
     CatalogueCategorySchema,
+    CatalogueItemPropertyPostRequestSchema,
+    CatalogueItemPropertySchema,
 )
 from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
+from inventory_management_system_api.services.catalogue_category_property import CatalogueCategoryPropertyService
 
 logger = logging.getLogger()
 
@@ -201,3 +204,21 @@ def delete_catalogue_category(
         message = "Catalogue category has child elements and cannot be deleted"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+
+
+@router.post(
+    path="/{catalogue_category_id}/properties",
+    summary="Create a new catalogue item property at the catalogue category level",
+    response_description="The created catalogue item property as defined at the catalogue category level",
+    status_code=status.HTTP_201_CREATED,
+)
+def create_catalogue_item_property(
+    catalogue_item_property: CatalogueItemPropertyPostRequestSchema,
+    catalogue_category_id: str = Path(description="The ID of the catalogue category to add a property to"),
+    catalogue_category_property_service: CatalogueCategoryPropertyService = Depends(),
+) -> CatalogueItemPropertySchema:
+    # pylint: disable=missing-function-docstring
+    logger.info("Creating a new catalogue item property at the catalogue category level")
+    logger.debug("Catalogue item property data: %s", catalogue_item_property)
+
+    catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -195,10 +195,10 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
         """
         Validator for the `default_value` field.
 
-        It checks if the `type` of the default value is a valid type and if allowed_properties is defined, ensures
+        It checks if the `type` of the default value is a valid type and if `allowed_values` is defined, ensures
         that the given value is within the list.
 
-        :param allowed_values: The value of the `allowed_values` field.
+        :param default_value: The value of the `default_value` field.
         :param info: Validation info from pydantic.
         :return: The value of the `allowed_values` field.
         """

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -186,3 +186,28 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
         description="Value to populate all child catalogue items and items with. Required if the added field is "
         "mandatory.",
     )
+
+    @field_validator("default_value")
+    @classmethod
+    def validate_default_value(
+        cls, default_value: Optional[Union[str, int, bool]], info: ValidationInfo
+    ) -> Optional[Union[str, int, bool]]:
+        """
+        Validator for the `default_value` field.
+
+        It checks if the `type` of the default value is a valid type and if allowed_properties is defined, ensures
+        that the given value is within the list.
+
+        :param allowed_values: The value of the `allowed_values` field.
+        :param info: Validation info from pydantic.
+        :return: The value of the `allowed_values` field.
+        """
+        if default_value is not None:
+            if not CatalogueCategoryPostRequestPropertySchema.is_valid_property_type(
+                expected_property_type=info.data["type"], property_value=default_value
+            ):
+                raise ValueError("default_value must be the same type as the property itself")
+            if info.data["allowed_values"] and default_value not in info.data["allowed_values"]:
+                raise ValueError("default_value is not one of the allowed_values")
+
+        return default_value

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -216,7 +216,12 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
                 raise ValueError("default_value must be the same type as the property itself")
             if "allowed_values" in info.data and info.data["allowed_values"]:
                 allowed_values = info.data["allowed_values"]
-                if allowed_values.type == "list" and default_value not in info.data["allowed_values"].values:
+
+                # Check the type of allowed_values being used and validate the default value appropriately
+                if (
+                    isinstance(allowed_values, AllowedValuesListSchema)
+                    and default_value not in info.data["allowed_values"].values
+                ):
                     raise ValueError("default_value is not one of the allowed_values")
 
         return default_value

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -207,7 +207,7 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
                 expected_property_type=info.data["type"], property_value=default_value
             ):
                 raise ValueError("default_value must be the same type as the property itself")
-            if info.data["allowed_values"] and default_value not in info.data["allowed_values"]:
+            if info.data["allowed_values"] and default_value not in info.data["allowed_values"].values:
                 raise ValueError("default_value is not one of the allowed_values")
 
         return default_value

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -51,7 +51,9 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
     )
 
     @classmethod
-    def is_valid_property_type(cls, expected_property_type: CatalogueItemPropertyType, property_value: Any) -> bool:
+    def is_valid_property_type(
+        cls, expected_property_type: CatalogueItemPropertyType, property_value: Optional[Union[str, float, bool]]
+    ) -> bool:
         """
         Validates a given value has a type matching a CatalogueItemPropertyType and returns false if they don't
 
@@ -63,6 +65,8 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
         if expected_property_type == CatalogueItemPropertyType.STRING:
             return isinstance(property_value, str)
         if expected_property_type == CatalogueItemPropertyType.NUMBER:
+            # Python cares if there is a decimal or not, so can't just use float for this check, even though
+            # Pydantic & the FastAPI docs shows float as 'number'
             return isinstance(property_value, Number)
         if expected_property_type == CatalogueItemPropertyType.BOOLEAN:
             return isinstance(property_value, bool)
@@ -181,7 +185,7 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
     Schema model for a catalogue item property creation request
     """
 
-    default_value: Optional[Union[str, int, bool]] = Field(
+    default_value: Optional[Union[str, float, bool]] = Field(
         default=None,
         description="Value to populate all child catalogue items and items with. Required if the added field is "
         "mandatory.",
@@ -190,8 +194,8 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
     @field_validator("default_value")
     @classmethod
     def validate_default_value(
-        cls, default_value: Optional[Union[str, int, bool]], info: ValidationInfo
-    ) -> Optional[Union[str, int, bool]]:
+        cls, default_value: Optional[Union[str, float, bool]], info: ValidationInfo
+    ) -> Optional[Union[str, float, bool]]:
         """
         Validator for the `default_value` field.
 

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -4,7 +4,7 @@ Module for defining the API schema models for representing catalogue categories.
 
 from enum import Enum
 from numbers import Number
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field, conlist, field_validator
 from pydantic_core.core_schema import ValidationInfo
@@ -51,9 +51,7 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
     )
 
     @classmethod
-    def is_valid_property_type(
-        cls, expected_property_type: CatalogueItemPropertyType, property_value: Optional[Union[str, float, bool]]
-    ) -> bool:
+    def is_valid_property_type(cls, expected_property_type: CatalogueItemPropertyType, property_value: Any) -> bool:
         """
         Validates a given value has a type matching a CatalogueItemPropertyType and returns false if they don't
 
@@ -188,7 +186,7 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
     Schema model for a catalogue item property creation request
     """
 
-    default_value: Optional[Union[str, float, bool]] = Field(
+    default_value: Any = Field(
         default=None,
         description="Value to populate all child catalogue items and items with. Required if the added field is "
         "mandatory.",
@@ -196,9 +194,7 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
 
     @field_validator("default_value")
     @classmethod
-    def validate_default_value(
-        cls, default_value: Optional[Union[str, float, bool]], info: ValidationInfo
-    ) -> Optional[Union[str, float, bool]]:
+    def validate_default_value(cls, default_value: Any, info: ValidationInfo) -> Any:
         """
         Validator for the `default_value` field.
 

--- a/inventory_management_system_api/schemas/catalogue_item.py
+++ b/inventory_management_system_api/schemas/catalogue_item.py
@@ -2,7 +2,7 @@
 Module for defining the API schema models for representing catalogue items.
 """
 
-from typing import List, Optional, Union
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -15,9 +15,7 @@ class PropertyPostRequestSchema(BaseModel):
     """
 
     id: str = Field(description="The ID of the catalogue item property")
-    value: Optional[Union[str, float, bool]] = Field(
-        default=None, description="The value of the catalogue item property"
-    )
+    value: Any = Field(default=None, description="The value of the catalogue item property")
 
 
 class PropertySchema(PropertyPostRequestSchema):

--- a/inventory_management_system_api/schemas/catalogue_item.py
+++ b/inventory_management_system_api/schemas/catalogue_item.py
@@ -2,7 +2,7 @@
 Module for defining the API schema models for representing catalogue items.
 """
 
-from typing import Any, List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -15,7 +15,9 @@ class PropertyPostRequestSchema(BaseModel):
     """
 
     id: str = Field(description="The ID of the catalogue item property")
-    value: Any = Field(default=None, description="The value of the catalogue item property")
+    value: Optional[Union[str, float, bool]] = Field(
+        default=None, description="The value of the catalogue item property"
+    )
 
 
 class PropertySchema(PropertyPostRequestSchema):

--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -21,7 +21,7 @@ from inventory_management_system_api.schemas.catalogue_category import (
     CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS,
     CatalogueCategoryPatchRequestSchema,
     CatalogueCategoryPostRequestSchema,
-    CatalogueItemPropertyPostRequestSchema,
+    CatalogueCategoryPostRequestPropertySchema,
 )
 from inventory_management_system_api.services import utils
 
@@ -151,7 +151,7 @@ class CatalogueCategoryService:
         )
 
     def _check_duplicate_catalogue_item_property_names(
-        self, catalogue_item_properties: List[CatalogueItemPropertyPostRequestSchema]
+        self, catalogue_item_properties: List[CatalogueCategoryPostRequestPropertySchema]
     ) -> None:
         """
         Go through all the catalogue item properties to check for any duplicate names.

--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -10,7 +10,6 @@ from fastapi import Depends
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
-    DuplicateCatalogueItemPropertyNameError,
     LeafCategoryError,
     MissingRecordError,
 )
@@ -21,10 +20,8 @@ from inventory_management_system_api.schemas.catalogue_category import (
     CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS,
     CatalogueCategoryPatchRequestSchema,
     CatalogueCategoryPostRequestSchema,
-    CatalogueCategoryPostRequestPropertySchema,
 )
 from inventory_management_system_api.services import utils
-
 
 logger = logging.getLogger()
 
@@ -60,7 +57,7 @@ class CatalogueCategoryService:
             raise LeafCategoryError("Cannot add catalogue category to a leaf parent catalogue category")
 
         if catalogue_category.catalogue_item_properties:
-            self._check_duplicate_catalogue_item_property_names(catalogue_category.catalogue_item_properties)
+            utils.check_duplicate_catalogue_item_property_names(catalogue_category.catalogue_item_properties)
 
         code = utils.generate_code(catalogue_category.name, "catalogue category")
         return self._catalogue_category_repository.create(
@@ -144,26 +141,8 @@ class CatalogueCategoryService:
                 raise LeafCategoryError("Cannot add catalogue category to a leaf parent catalogue category")
 
         if catalogue_category.catalogue_item_properties:
-            self._check_duplicate_catalogue_item_property_names(catalogue_category.catalogue_item_properties)
+            utils.check_duplicate_catalogue_item_property_names(catalogue_category.catalogue_item_properties)
 
         return self._catalogue_category_repository.update(
             catalogue_category_id, CatalogueCategoryIn(**{**stored_catalogue_category.model_dump(), **update_data})
         )
-
-    def _check_duplicate_catalogue_item_property_names(
-        self, catalogue_item_properties: List[CatalogueCategoryPostRequestPropertySchema]
-    ) -> None:
-        """
-        Go through all the catalogue item properties to check for any duplicate names.
-        :param catalogue_item_properties: The supplied catalogue item properties
-        :raises DuplicateCatalogueItemPropertyName: If a duplicate catalogue item property name is found.
-        """
-        logger.info("Checking for duplicate catalogue item property names")
-        seen_catalogue_item_property_names = set()
-        for catalogue_item_property in catalogue_item_properties:
-            catalogue_item_property_name = catalogue_item_property.name
-            if catalogue_item_property_name.lower().strip() in seen_catalogue_item_property_names:
-                raise DuplicateCatalogueItemPropertyNameError(
-                    f"Duplicate catalogue item property name: {catalogue_item_property_name.strip()}"
-                )
-            seen_catalogue_item_property_names.add(catalogue_item_property_name.lower().strip())

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -55,7 +55,7 @@ class CatalogueCategoryPropertyService:
         Property will be propagated down through catalogue items and items when there are children.
 
         :param catalogue_category_id: ID of the catalogue category to add the property to
-        :catalogue_item_property: Property to add (with additional info on how to perform the migration if necessary)
+        :param catalogue_item_property: Property to add (with additional info on how to perform the migration if necessary)
         :raises InvalidActionError: If attempting to add a mandatory property without a default_value being specified
                                     or if the catalogue category is not a leaf
         :raises MissingRecordError: If the catalogue category doesn't exist

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -10,7 +10,6 @@ from fastapi import Depends
 from inventory_management_system_api.core.database import mongodb_client
 from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
 from inventory_management_system_api.models.catalogue_category import (
-    CatalogueCategoryIn,
     CatalogueItemPropertyIn,
     CatalogueItemPropertyOut,
 )
@@ -84,16 +83,12 @@ class CatalogueCategoryPropertyService:
 
         catalogue_item_property_in = CatalogueItemPropertyIn(**catalogue_item_property.model_dump())
 
-        # New catalogue category data
-        catalogue_category_in = CatalogueCategoryIn(**stored_catalogue_category.model_dump())
-        catalogue_category_in.catalogue_item_properties.append(catalogue_item_property_in)
-
         # Run all subsequent edits within a transaction to ensure they will all succeed or fail together
         with mongodb_client.start_session() as session:
             with session.start_transaction():
                 # Firstly update the catalogue category
-                self._catalogue_category_repository.update(
-                    catalogue_category_id, catalogue_category_in, session=session
+                catalogue_item_property_out = self._catalogue_category_repository.create_catalogue_item_property(
+                    catalogue_category_id, catalogue_item_property_in, session=session
                 )
 
                 # Property to be added catalogue items and items
@@ -116,4 +111,4 @@ class CatalogueCategoryPropertyService:
                 catalogue_item_ids = self._catalogue_item_repository.list_ids(catalogue_category_id, session=session)
                 self._item_repository.insert_property_to_all_in(catalogue_item_ids, property_in, session=session)
 
-        return CatalogueItemPropertyOut(**catalogue_item_property_in.model_dump())
+        return catalogue_item_property_out

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -1,0 +1,51 @@
+"""
+Module for providing a service for managing properties at the catalogue category level that may also require
+propagation down through their child catalogue items and items using their respective repositories
+"""
+
+from fastapi import Depends
+
+from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
+from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
+from inventory_management_system_api.repositories.item import ItemRepo
+from inventory_management_system_api.schemas.catalogue_category import (
+    CatalogueItemPropertyPostRequestSchema,
+    CatalogueItemPropertySchema,
+)
+
+
+class CatalogueCategoryPropertyService:
+    """
+    Service for managing properties at the catalogue category level downwards
+    """
+
+    def __init__(
+        self,
+        catalogue_category_repository: CatalogueCategoryRepo = Depends(CatalogueCategoryRepo),
+        catalogue_item_repository: CatalogueItemRepo = Depends(CatalogueItemRepo),
+        item_repository: ItemRepo = Depends(ItemRepo),
+    ):
+        """
+        Initialise the `PropertyService` with a `CatalogueCategoryRepo`, `CatalogueItemRepo` and `ItemRepo` repos.
+
+        :param catalogue_category_repository: The `CatalogueCategoryRepo` repository to use.
+        :param catalogue_item_repository: The `CatalogueItemRepo` repository to use.
+        :param item_repository: The `ItemRepo` repository to use.
+        """
+        self._catalogue_category_repository = catalogue_category_repository
+        self._catalogue_item_repository = catalogue_item_repository
+        self._item_repository = item_repository
+
+    def create(
+        self,
+        catalogue_category_id: str,
+        catalogue_item_property: CatalogueItemPropertyPostRequestSchema,
+    ) -> CatalogueItemPropertySchema:
+        """Create a new property at the catalogue category level
+
+        Property will be propagated down through catalogue items and items when there are children.
+
+        :param catalogue_category_id: ID of the catalogue category to add the property to
+        :catalogue_item_property: Property to add (with additional info on how to perform the migration if necessary)
+        :return: The created catalogue item property as defined at the catalogue category level
+        """

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -58,6 +58,8 @@ class CatalogueCategoryPropertyService:
         :param catalogue_category_id: ID of the catalogue category to add the property to
         :catalogue_item_property: Property to add (with additional info on how to perform the migration if necessary)
         :raises InvalidActionError: If attempting to add a mandatory property without a default_value being specified
+                                    or if the catalogue category is not a leaf
+        :raises MissingRecordError: If the catalogue category doesn't exist
         :return: The created catalogue item property as defined at the catalogue category level
         """
 

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -8,18 +8,17 @@ import logging
 from fastapi import Depends
 
 from inventory_management_system_api.core.database import mongodb_client
-from inventory_management_system_api.core.exceptions import (
-    InvalidActionError, MissingRecordError)
+from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
 from inventory_management_system_api.models.catalogue_category import (
-    CatalogueCategoryIn, CatalogueItemPropertyIn, CatalogueItemPropertyOut)
+    CatalogueCategoryIn,
+    CatalogueItemPropertyIn,
+    CatalogueItemPropertyOut,
+)
 from inventory_management_system_api.models.catalogue_item import PropertyIn
-from inventory_management_system_api.repositories.catalogue_category import \
-    CatalogueCategoryRepo
-from inventory_management_system_api.repositories.catalogue_item import \
-    CatalogueItemRepo
+from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
+from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
-from inventory_management_system_api.schemas.catalogue_category import \
-    CatalogueItemPropertyPostRequestSchema
+from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyPostRequestSchema
 from inventory_management_system_api.services import utils
 
 logger = logging.getLogger()

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -3,8 +3,10 @@ Module for providing a service for managing properties at the catalogue category
 propagation down through their child catalogue items and items using their respective repositories
 """
 
+import logging
 from fastapi import Depends
 
+from inventory_management_system_api.core.exceptions import InvalidActionError
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
@@ -12,6 +14,10 @@ from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueItemPropertyPostRequestSchema,
     CatalogueItemPropertySchema,
 )
+from inventory_management_system_api.core.database import mongodb_client
+from inventory_management_system_api.services import utils
+
+logger = logging.getLogger()
 
 
 class CatalogueCategoryPropertyService:
@@ -47,5 +53,24 @@ class CatalogueCategoryPropertyService:
 
         :param catalogue_category_id: ID of the catalogue category to add the property to
         :catalogue_item_property: Property to add (with additional info on how to perform the migration if necessary)
+        :raises InvalidActionError: If attempting to add a mandatory property without a default_value being specified
         :return: The created catalogue item property as defined at the catalogue category level
         """
+
+        # Mandatory properties must have a default value that is not None as they would need to be
+        # populated down the subtree
+        if catalogue_item_property.mandatory and catalogue_item_property.default_value is None:
+            raise InvalidActionError("Cannot add a mandatory property without a default value")
+
+        # Obtain the existing catalogue category to validate against
+        catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
+
+        # Ensure the property is actually valid
+        utils.check_duplicate_catalogue_item_property_names(
+            catalogue_category.catalogue_item_properties + [catalogue_item_property]
+        )
+
+        # Run all subsequent edits within a transaction to ensure they will all succeed or fail together
+        with mongodb_client.start_session() as session:
+            with session.start_transaction():
+                pass

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -17,7 +17,9 @@ from inventory_management_system_api.models.catalogue_item import PropertyIn
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
-from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyPostRequestSchema
+from inventory_management_system_api.schemas.catalogue_category import (
+    CatalogueItemPropertyPostRequestSchema,
+)
 from inventory_management_system_api.services import utils
 
 logger = logging.getLogger()

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -55,7 +55,8 @@ class CatalogueCategoryPropertyService:
         Property will be propagated down through catalogue items and items when there are children.
 
         :param catalogue_category_id: ID of the catalogue category to add the property to
-        :param catalogue_item_property: Property to add (with additional info on how to perform the migration if necessary)
+        :param catalogue_item_property: Property to add (with additional info on how to perform the migration if
+                                        necessary)
         :raises InvalidActionError: If attempting to add a mandatory property without a default_value being specified
                                     or if the catalogue category is not a leaf
         :raises MissingRecordError: If the catalogue category doesn't exist

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -8,20 +8,18 @@ import logging
 from fastapi import Depends
 
 from inventory_management_system_api.core.database import mongodb_client
-from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
+from inventory_management_system_api.core.exceptions import (
+    InvalidActionError, MissingRecordError)
 from inventory_management_system_api.models.catalogue_category import (
-    CatalogueCategoryIn,
-    CatalogueItemPropertyIn,
-    CatalogueItemPropertyOut,
-)
+    CatalogueCategoryIn, CatalogueItemPropertyIn, CatalogueItemPropertyOut)
 from inventory_management_system_api.models.catalogue_item import PropertyIn
-from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
-from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
+from inventory_management_system_api.repositories.catalogue_category import \
+    CatalogueCategoryRepo
+from inventory_management_system_api.repositories.catalogue_item import \
+    CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
-from inventory_management_system_api.schemas.catalogue_category import (
-    CatalogueItemPropertyPostRequestSchema,
-    CatalogueItemPropertySchema,
-)
+from inventory_management_system_api.schemas.catalogue_category import \
+    CatalogueItemPropertyPostRequestSchema
 from inventory_management_system_api.services import utils
 
 logger = logging.getLogger()
@@ -53,7 +51,7 @@ class CatalogueCategoryPropertyService:
         self,
         catalogue_category_id: str,
         catalogue_item_property: CatalogueItemPropertyPostRequestSchema,
-    ) -> CatalogueItemPropertySchema:
+    ) -> CatalogueItemPropertyOut:
         """Create a new property at the catalogue category level
 
         Property will be propagated down through catalogue items and items when there are children.

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -7,6 +7,7 @@ import logging
 from fastapi import Depends
 
 from inventory_management_system_api.core.exceptions import InvalidActionError
+from inventory_management_system_api.models.catalogue_category import CatalogueItemPropertyIn, CatalogueItemPropertyOut
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
@@ -70,7 +71,11 @@ class CatalogueCategoryPropertyService:
             catalogue_category.catalogue_item_properties + [catalogue_item_property]
         )
 
+        catalogue_item_property_in = CatalogueItemPropertyIn(**catalogue_item_property.model_dump())
+
         # Run all subsequent edits within a transaction to ensure they will all succeed or fail together
         with mongodb_client.start_session() as session:
             with session.start_transaction():
                 pass
+
+        return CatalogueItemPropertyOut(**catalogue_item_property_in.model_dump())

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -6,8 +6,12 @@ propagation down through their child catalogue items and items using their respe
 import logging
 from fastapi import Depends
 
-from inventory_management_system_api.core.exceptions import InvalidActionError
-from inventory_management_system_api.models.catalogue_category import CatalogueItemPropertyIn, CatalogueItemPropertyOut
+from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
+from inventory_management_system_api.models.catalogue_category import (
+    CatalogueCategoryIn,
+    CatalogueItemPropertyIn,
+    CatalogueItemPropertyOut,
+)
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
@@ -64,18 +68,64 @@ class CatalogueCategoryPropertyService:
             raise InvalidActionError("Cannot add a mandatory property without a default value")
 
         # Obtain the existing catalogue category to validate against
-        catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
+        stored_catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
+        if not stored_catalogue_category:
+            raise MissingRecordError(f"No catalogue category found with ID: {catalogue_category_id}")
+
+        # Must be a leaf catalogue category in order to have properties
+        if not stored_catalogue_category.is_leaf:
+            raise InvalidActionError("Cannot add a property to a non-leaf catalogue category")
 
         # Ensure the property is actually valid
         utils.check_duplicate_catalogue_item_property_names(
-            catalogue_category.catalogue_item_properties + [catalogue_item_property]
+            stored_catalogue_category.catalogue_item_properties + [catalogue_item_property]
         )
 
         catalogue_item_property_in = CatalogueItemPropertyIn(**catalogue_item_property.model_dump())
 
+        # New catalogue category data
+        catalogue_category_in = CatalogueCategoryIn(**stored_catalogue_category.model_dump())
+        catalogue_category_in.catalogue_item_properties.append(catalogue_item_property_in)
+
         # Run all subsequent edits within a transaction to ensure they will all succeed or fail together
         with mongodb_client.start_session() as session:
             with session.start_transaction():
+                # Firstly update the catalogue category
+                # self._catalogue_category_repository.update(
+                #     catalogue_category_id, catalogue_category_in, session=session
+                # )
+
+                # ids = list(
+                #     self._catalogue_item_repository._catalogue_items_collection.find(
+                #         {"catalogue_category_id": ObjectId(catalogue_category_id)}, {"_id": 1}
+                #     )
+                # )
+                # start_time = time.time()
+                # self._catalogue_item_repository._catalogue_items_collection.update_many(
+                #     {"catalogue_category_id": catalogue_category_id}, {"$set": {"catalogue_item_properties": []}}
+                # )
+                # ids = list(
+                #     self._catalogue_item_repository._catalogue_items_collection.find(
+                #         {"catalogue_category_id": ObjectId(catalogue_category_id)}, {"_id": 1}
+                #     )
+                # )
+                # self._catalogue_item_repository._catalogue_items_collection.update_many(
+                #     {"_id": {"$in": ids}}, {"$set": {"catalogue_item_properties": []}}
+                # )
+                # for id in ids:
+                #     self._catalogue_item_repository._catalogue_items_collection.update_many(
+                #         {"_id": id}, {"$set": {"catalogue_item_properties": []}}
+                #     )
+                # updates = []
+                # for id in ids:
+                #     updates.append(UpdateMany({"_id": id}, {"$set": {"catalogue_item_properties": []}}))
+                # self._catalogue_item_repository._catalogue_items_collection.bulk_write(updates, session=session)
+                # logger.debug(ids)
+                # print(len(ids))
+                # logger.debug("Time taken %s", (time.time() - start_time))
+
+                # Now need to update catalogue items and items
+                # raise InvalidActionError("AVOID ACTUAL UPDATE")
                 pass
 
         return CatalogueItemPropertyOut(**catalogue_item_property_in.model_dump())

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -40,7 +40,7 @@ class ItemService:
         system_repository: SystemRepo = Depends(SystemRepo),
     ) -> None:
         """
-        Initialise the `ItemService` with an `ItemRepo`, `CatalogueCategoryRepo`, and `CatalogueItemRepo` repos.
+        Initialise the `ItemService` with a `ItemRepo`, `CatalogueCategoryRepo`, and `CatalogueItemRepo` repos.
 
         :param item_repository: The `ItemRepo` repository to use.
         :param catalogue_category_repository: The `CatalogueCategoryRepo` repository to use.
@@ -124,7 +124,7 @@ class ItemService:
         The method checks if the item exists in the database and raises a `MissingRecordError` if it does
         not. If the system ID is being updated, it checks if the system ID with such ID exists and raises
         a `MissingRecordError` if it does not. It raises a `ChildElementsExistError` if a catalogue item
-        ID is supplied. When updatimg properties, existing properties must all be supplied, or they will
+        ID is supplied. When updating properties, existing properties must all be supplied, or they will
         be overwritten by the catalogue item properties.
 
         :param item_id: The ID of the item to update.

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -11,7 +11,7 @@ from inventory_management_system_api.core.exceptions import (
     MissingMandatoryCatalogueItemProperty,
 )
 from inventory_management_system_api.models.catalogue_category import CatalogueItemPropertyOut
-from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyPostRequestSchema
+from inventory_management_system_api.schemas.catalogue_category import CatalogueCategoryPostRequestPropertySchema
 from inventory_management_system_api.schemas.catalogue_item import PropertyPostRequestSchema
 
 logger = logging.getLogger()
@@ -149,7 +149,7 @@ def _validate_catalogue_item_property_value(defined_property: Dict, supplied_pro
                 f"Mandatory catalogue item property with ID '{supplied_property_id}' cannot be None."
             )
     else:
-        if not CatalogueItemPropertyPostRequestSchema.is_valid_property_type(
+        if not CatalogueCategoryPostRequestPropertySchema.is_valid_property_type(
             defined_property_type, supplied_property_value
         ):
             raise InvalidCatalogueItemPropertyTypeError(

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -7,6 +7,7 @@ import re
 from typing import Dict, List, Union
 
 from inventory_management_system_api.core.exceptions import (
+    DuplicateCatalogueItemPropertyNameError,
     InvalidCatalogueItemPropertyTypeError,
     MissingMandatoryCatalogueItemProperty,
 )
@@ -32,6 +33,27 @@ def generate_code(name: str, entity_type: str) -> str:
     logger.info("Generating code for the %s based on its name", entity_type)
     name = name.lower().strip()
     return re.sub(r"\s+", "-", name)
+
+
+def check_duplicate_catalogue_item_property_names(
+    catalogue_item_properties: list[CatalogueCategoryPostRequestPropertySchema | CatalogueItemPropertyOut],
+) -> None:
+    """
+    Go through a list of catalogue item properties to check for any duplicate names during creation of a catalogue
+    category or an addition of a property later on.
+
+    :param catalogue_item_properties: The supplied catalogue item properties
+    :raises DuplicateCatalogueItemPropertyName: If a duplicate catalogue item property name is found.
+    """
+    logger.info("Checking for duplicate catalogue item property names")
+    seen_catalogue_item_property_names = set()
+    for catalogue_item_property in catalogue_item_properties:
+        catalogue_item_property_name = catalogue_item_property.name.lower().strip()
+        if catalogue_item_property_name in seen_catalogue_item_property_names:
+            raise DuplicateCatalogueItemPropertyNameError(
+                f"Duplicate catalogue item property name: {catalogue_item_property.name.strip()}"
+            )
+        seen_catalogue_item_property_names.add(catalogue_item_property_name)
 
 
 def process_catalogue_item_properties(

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -297,10 +297,33 @@ class TestCreate(CreateDSL):
             422, "Cannot add a mandatory property without a default value"
         )
 
-    def test_create_mandatory_property_with_invalid_default_value(self):
+    def test_create_mandatory_property_with_invalid_default_value_boolean_int(self):
         """
         Test adding a mandatory property to an already existing catalogue category, catalogue item and item without
-        a default value
+        with a default value that is a boolean value while the type of the property is an int (this can cause an
+        issue if not implemented property as boolean is a subclass of int - technically also applies to other
+        endpoints' type checks but they occur in the same place in code anyway)
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(
+            {
+                "name": "Property B",
+                "type": "number",
+                "unit": "mm",
+                "mandatory": True,
+                "allowed_values": {"type": "list", "values": [1, 2, 3]},
+                "default_value": True,
+            }
+        )
+        self.check_catalogue_item_property_response_failed_with_validation_message(
+            422, "Value error, default_value must be the same type as the property itself"
+        )
+
+    def test_create_mandatory_property_with_invalid_default_value_not_in_allowed(self):
+        """
+        Test adding a mandatory property to an already existing catalogue category, catalogue item and item with a
+        default value that is excluded by the allowed_values
         """
 
         self.post_catalogue_category_and_items()

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -355,6 +355,26 @@ class TestCreate(CreateDSL):
             422, "Value error, default_value must be the same type as the property itself"
         )
 
+    def test_create_mandatory_property_with_boolean_allowed_values(self):
+        """
+        Test adding a mandatory property to an already existing catalogue category, catalogue item and item with
+        a boolean type and allowed values is rejected appropriately
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(
+            {
+                "name": "Property B",
+                "type": "boolean",
+                "mandatory": True,
+                "allowed_values": {"type": "list", "values": [1, 2, 3]},
+                "default_value": False,
+            }
+        )
+        self.check_catalogue_item_property_response_failed_with_validation_message(
+            422, "Value error, allowed_values not allowed for a boolean catalogue item property 'Property B'"
+        )
+
     def test_create_property_non_leaf_catalogue_category(self):
         """
         Test adding a property to an non leaf catalogue category

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -1,0 +1,275 @@
+"""
+End-to-End tests for the properties endpoint of the catalogue category router
+"""
+
+from test.conftest import add_ids_to_properties
+from test.e2e.mock_schemas import SYSTEM_POST_A
+from typing import Optional
+from unittest.mock import ANY
+
+import pytest
+from bson import ObjectId
+from fastapi import Response
+from fastapi.testclient import TestClient
+
+EXISTING_CATALOGUE_CATEGORY_PROPERTY_POST = {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False}
+EXISTING_CATALOGUE_CATEGORY_PROPERTY_EXPECTED = {**EXISTING_CATALOGUE_CATEGORY_PROPERTY_POST, "allowed_values": None}
+EXISTING_PROPERTY_EXPECTED = {"name": "Property A", "unit": "mm", "value": 20}
+
+# pylint:disable=duplicate-code
+CATALOGUE_CATEGORY_POST_A = {
+    "name": "Category A",
+    "is_leaf": True,
+    "catalogue_item_properties": [EXISTING_CATALOGUE_CATEGORY_PROPERTY_POST],
+}
+
+CATALOGUE_ITEM_POST_A = {
+    "name": "Catalogue Item A",
+    "description": "This is Catalogue Item A",
+    "cost_gbp": 129.99,
+    "days_to_replace": 2.0,
+    "drawing_link": "https://drawing-link.com/",
+    "item_model_number": "abc123",
+    "is_obsolete": False,
+    "properties": [{"name": "Property A", "value": 20}],
+}
+
+MANUFACTURER_POST = {
+    "name": "Manufacturer A",
+    "url": "http://example.com/",
+    "address": {
+        "address_line": "1 Example Street",
+        "town": "Oxford",
+        "county": "Oxfordshire",
+        "country": "United Kingdom",
+        "postcode": "OX1 2AB",
+    },
+    "telephone": "0932348348",
+}
+
+ITEM_POST = {
+    "is_defective": False,
+    "usage_status": 0,
+    "warranty_end_date": "2015-11-15T23:59:59Z",
+    "serial_number": "xyz123",
+    "delivered_date": "2012-12-05T12:00:00Z",
+    "notes": "Test notes",
+    "properties": [{"name": "Property A", "value": 20}],
+}
+
+# pylint:enable=duplicate-code
+
+CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY = {"name": "Property B", "type": "number", "unit": "mm", "mandatory": False}
+CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY_EXPECTED = {
+    **CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY,
+    "allowed_values": None,
+}
+
+NEW_CATALOGUE_ITEM_PROPERTY_NON_MANDATORY_EXPECTED = CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY_EXPECTED
+NEW_PROPERTY_NON_MANDATORY_EXPECTED = {"name": "Property B", "unit": "mm", "value": None}
+
+CATALOGUE_ITEM_PROPERTY_POST_MANDATORY = {
+    "name": "Property B",
+    "type": "number",
+    "unit": "mm",
+    "mandatory": True,
+    "default_value": 42,
+}
+CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED = {
+    "name": "Property B",
+    "type": "number",
+    "unit": "mm",
+    "mandatory": True,
+    "allowed_values": None,
+}
+
+NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED = CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED
+NEW_PROPERTY_MANDATORY_EXPECTED = {"name": "Property B", "unit": "mm", "value": 42}
+
+
+class CreateDSL:
+    """Base class for create tests"""
+
+    test_client: TestClient
+    catalogue_category: dict
+    catalogue_item: dict
+    item: dict
+
+    _catalogue_item_post_response: Response
+    catalogue_item_property: dict
+
+    @pytest.fixture(autouse=True)
+    def setup(self, test_client):
+        """Setup fixtures"""
+        self.test_client = test_client
+
+    def post_catalogue_category_and_items(self):
+        """Posts a catalogue category, catalogue item and item for create tests to act on"""
+
+        # pylint:disable=duplicate-code
+        response = self.test_client.post("/v1/catalogue-categories", json=CATALOGUE_CATEGORY_POST_A)
+        self.catalogue_category = response.json()
+
+        response = self.test_client.post("/v1/systems", json=SYSTEM_POST_A)
+        system_id = response.json()["id"]
+
+        response = self.test_client.post("/v1/manufacturers", json=MANUFACTURER_POST)
+        manufacturer_id = response.json()["id"]
+
+        catalogue_item_post = {
+            **CATALOGUE_ITEM_POST_A,
+            "catalogue_category_id": self.catalogue_category["id"],
+            "manufacturer_id": manufacturer_id,
+            "properties": add_ids_to_properties(
+                self.catalogue_category["catalogue_item_properties"], CATALOGUE_ITEM_POST_A["properties"]
+            ),
+        }
+        response = self.test_client.post("/v1/catalogue-items", json=catalogue_item_post)
+        self.catalogue_item = response.json()
+        catalogue_item_id = self.catalogue_item["id"]
+
+        item_post = {
+            **ITEM_POST,
+            "catalogue_item_id": catalogue_item_id,
+            "system_id": system_id,
+            "properties": add_ids_to_properties(
+                self.catalogue_category["catalogue_item_properties"], ITEM_POST["properties"]
+            ),
+        }
+        response = self.test_client.post("/v1/items", json=item_post)
+        self.item = response.json()
+        # pylint:enable=duplicate-code
+
+    def post_non_leaf_catalogue_category(self):
+        """Posts a non leaf catalogue category"""
+        response = self.test_client.post(
+            "/v1/catalogue-categories", json={**CATALOGUE_CATEGORY_POST_A, "is_leaf": False}
+        )
+        self.catalogue_category = response.json()
+
+    def post_catalogue_item_property(self, catalogue_item_property_post, catalogue_category_id: Optional[str] = None):
+        """Posts a catalogue item property to the catalogue category"""
+
+        self._catalogue_item_post_response = self.test_client.post(
+            f"/v1/catalogue-categories/{
+                catalogue_category_id if catalogue_category_id else self.catalogue_category['id']
+            }/properties",
+            json=catalogue_item_property_post,
+        )
+
+    def check_catalogue_item_property_response_success(self, catalogue_item_property_expected):
+        """Checks the response of posting a catalogue item property succeeded as expected"""
+
+        assert self._catalogue_item_post_response.status_code == 201
+        self.catalogue_item_property = self._catalogue_item_post_response.json()
+        assert self.catalogue_item_property == {**catalogue_item_property_expected, "id": ANY}
+
+    def check_catalogue_item_property_response_failed(self, status_code, detail):
+        """Checks the response of posting a catalogue item property failed as expected"""
+        assert self._catalogue_item_post_response.status_code == status_code
+        assert self._catalogue_item_post_response.json()["detail"] == detail
+
+    def check_catalogue_category_updated(self, catalogue_item_property_expected):
+        """Checks the catalogue category is updated correctly with the new property"""
+
+        new_catalogue_category = self.test_client.get(
+            f"/v1/catalogue-categories/{self.catalogue_category['id']}"
+        ).json()
+
+        assert new_catalogue_category["catalogue_item_properties"] == add_ids_to_properties(
+            [*self.catalogue_category["catalogue_item_properties"], self.catalogue_item_property],
+            [EXISTING_CATALOGUE_CATEGORY_PROPERTY_EXPECTED, catalogue_item_property_expected],
+        )
+
+    def check_catalogue_item_updated(self, property_expected):
+        """Checks the catalogue item is updated correctly with the new property"""
+
+        new_catalogue_item = self.test_client.get(f"/v1/catalogue-items/{self.catalogue_item['id']}").json()
+
+        assert new_catalogue_item["properties"] == add_ids_to_properties(
+            [*self.catalogue_category["catalogue_item_properties"], self.catalogue_item_property],
+            [EXISTING_PROPERTY_EXPECTED, property_expected],
+        )
+
+    def check_item_updated(self, property_expected):
+        """Checks the item is updated correctly with the new property"""
+
+        new_item = self.test_client.get(f"/v1/items/{self.item['id']}").json()
+        assert new_item["properties"] == add_ids_to_properties(
+            [*self.catalogue_category["catalogue_item_properties"], self.catalogue_item_property],
+            [EXISTING_PROPERTY_EXPECTED, property_expected],
+        )
+
+
+class TestCreate(CreateDSL):
+    """Tests for creating a property at the catalogue category level"""
+
+    def test_create_non_mandatory_property(self):
+        """
+        Test adding a non-mandatory property to an already existing catalogue category, catalogue item and item
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY)
+
+        self.check_catalogue_item_property_response_success(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY_EXPECTED)
+        self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_NON_MANDATORY_EXPECTED)
+        self.check_catalogue_item_updated(NEW_PROPERTY_NON_MANDATORY_EXPECTED)
+        self.check_item_updated(NEW_PROPERTY_NON_MANDATORY_EXPECTED)
+
+    def test_create_mandatory_property(self):
+        """
+        Test adding a mandatory property to an already existing catalogue category, catalogue item and item
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY)
+
+        self.check_catalogue_item_property_response_success(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED)
+        self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED)
+        self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+        self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+
+    def test_create_property_with_non_existent_catalogue_category_id(self):
+        """Test adding a property when the specified catalogue category doesn't exist"""
+
+        self.post_catalogue_item_property(
+            CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY, catalogue_category_id=str(ObjectId())
+        )
+        self.check_catalogue_item_property_response_failed(404, "Catalogue category not found")
+
+    def test_create_property_with_invalid_catalogue_category_id(self):
+        """Test adding a property when given an invalid catalogue category id"""
+
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY, catalogue_category_id="invalid")
+        self.check_catalogue_item_property_response_failed(404, "Catalogue category not found")
+
+    def test_create_mandatory_property_without_default_value(self):
+        """
+        Test adding a mandatory property to an already existing catalogue category, catalogue item and item without
+        a default value
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(
+            {
+                "name": "Property B",
+                "type": "number",
+                "unit": "mm",
+                "mandatory": True,
+            }
+        )
+        self.check_catalogue_item_property_response_failed(
+            422, "Cannot add a mandatory property without a default value"
+        )
+
+    def test_create_property_non_leaf_catalogue_category(self):
+        """
+        Test adding a property to an non leaf catalogue category
+        """
+
+        self.post_non_leaf_catalogue_category()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY)
+        self.check_catalogue_item_property_response_failed(
+            422, "Cannot add a property to a non-leaf catalogue category"
+        )

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -86,6 +86,18 @@ CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED = {
 NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED = CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED
 NEW_PROPERTY_MANDATORY_EXPECTED = {"name": "Property B", "unit": "mm", "value": 42}
 
+CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES = {
+    **CATALOGUE_ITEM_PROPERTY_POST_MANDATORY,
+    "allowed_values": {"type": "list", "values": [42]},
+}
+CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED = {
+    **NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED,
+    "allowed_values": {"type": "list", "values": [42]},
+}
+NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_ALLOWED_VALUES_EXPECTED = (
+    CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+)
+
 
 class CreateDSL:
     """Base class for create tests"""
@@ -233,6 +245,22 @@ class TestCreate(CreateDSL):
 
         self.check_catalogue_item_property_response_success(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED)
         self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED)
+        self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+        self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+
+    def test_create_mandatory_property_with_allowed_values(self):
+        """
+        Test adding a mandatory property with allowed values to an already existing catalogue category, catalogue item
+        and item (ensures the default_value is allowed)
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+
+        self.check_catalogue_item_property_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+        self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_ALLOWED_VALUES_EXPECTED)
         self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
         self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
 

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -174,7 +174,18 @@ class RepositoryTestHelpers:
         """
         update_one_result_mock = Mock(UpdateResult)
         update_one_result_mock.acknowledged = True
-        collection_mock.insert_one.return_value = update_one_result_mock
+        collection_mock.update_many.return_value = update_one_result_mock
+
+    @staticmethod
+    def mock_update_many(collection_mock: Mock) -> None:
+        """
+        Mock the `update_many` method of the MongoDB database collection mock to return an `UpdateResult` object.
+
+        :param collection_mock: Mocked MongoDB database collection instance.
+        """
+        update_many_result_mock = Mock(UpdateResult)
+        update_many_result_mock.acknowledged = True
+        collection_mock.update_many.return_value = update_many_result_mock
 
 
 @pytest.fixture(name="test_helpers")

--- a/test/unit/repositories/mock_models.py
+++ b/test/unit/repositories/mock_models.py
@@ -11,6 +11,14 @@ MOCK_CREATED_MODIFIED_TIME = {
     "modified_time": datetime(2024, 2, 16, 14, 1, 13, 0, tzinfo=timezone.utc),
 }
 
+MOCK_CATALOGUE_ITEM_PROPERTY_A_INFO = {
+    "id": str(ObjectId()),
+    "name": "Property A",
+    "type": "number",
+    "unit": "mm",
+    "mandatory": False,
+}
+
 MOCK_PROPERTY_A_INFO = {
     "id": str(ObjectId()),
     "name": "Property A",

--- a/test/unit/repositories/mock_models.py
+++ b/test/unit/repositories/mock_models.py
@@ -4,7 +4,16 @@ Mock data for sharing between different repo tests
 
 from datetime import datetime, timezone
 
+from bson import ObjectId
+
 MOCK_CREATED_MODIFIED_TIME = {
     "created_time": datetime(2024, 2, 16, 14, 1, 13, 0, tzinfo=timezone.utc),
     "modified_time": datetime(2024, 2, 16, 14, 1, 13, 0, tzinfo=timezone.utc),
+}
+
+MOCK_PROPERTY_A_INFO = {
+    "id": str(ObjectId()),
+    "name": "Property A",
+    "value": "Test value",
+    "unit": None,
 }

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -2,7 +2,7 @@
 """
 Unit tests for the `CatalogueCategoryRepo` repository.
 """
-from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME
+from test.unit.repositories.mock_models import MOCK_CATALOGUE_ITEM_PROPERTY_A_INFO, MOCK_CREATED_MODIFIED_TIME
 from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
 from test.unit.repositories.test_utils import (
     MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH,
@@ -25,6 +25,7 @@ from inventory_management_system_api.models.catalogue_category import (
     CatalogueCategoryIn,
     CatalogueCategoryOut,
     CatalogueItemPropertyIn,
+    CatalogueItemPropertyOut,
 )
 
 CATALOGUE_CATEGORY_INFO = {
@@ -1145,3 +1146,43 @@ def test_has_child_elements_with_child_catalogue_items(test_helpers, database_mo
     result = catalogue_category_repository.has_child_elements(catalogue_category_id)
 
     assert result
+
+
+@patch("inventory_management_system_api.repositories.catalogue_category.datetime")
+def test_create_catalogue_item_property(datetime_mock, test_helpers, database_mock, catalogue_category_repository):
+    """
+    Test create_catalogue_item_property performs the correct database update query
+    """
+    session = MagicMock()
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_in = CatalogueItemPropertyIn(**MOCK_CATALOGUE_ITEM_PROPERTY_A_INFO)
+
+    # Mock 'update_one'
+    test_helpers.mock_update_one(database_mock.catalogue_categories)
+
+    result = catalogue_category_repository.create_catalogue_item_property(
+        catalogue_category_id, catalogue_item_property_in, session=session
+    )
+
+    database_mock.catalogue_categories.update_one.assert_called_once_with(
+        {"_id": CustomObjectId(catalogue_category_id)},
+        {
+            "$push": {"catalogue_item_properties": catalogue_item_property_in.model_dump(by_alias=True)},
+            "$set": {"modified_time": datetime_mock.now.return_value},
+        },
+        session=session,
+    )
+    assert result == CatalogueItemPropertyOut(**catalogue_item_property_in.model_dump(by_alias=True))
+
+
+def test_create_catalogue_item_property_with_invalid_id(database_mock, catalogue_category_repository):
+    """
+    Test create_catalogue_item_property performs the correct database update query when given an invalid id
+    """
+
+    with pytest.raises(InvalidObjectIdError) as exc:
+        catalogue_category_repository.create_catalogue_item_property(
+            "invalid", CatalogueItemPropertyIn(**MOCK_CATALOGUE_ITEM_PROPERTY_A_INFO)
+        )
+    assert str(exc.value) == "Invalid ObjectId value 'invalid'"
+    database_mock.catalogue_categories.update_one.assert_not_called()

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -2,7 +2,6 @@
 Unit tests for the `ItemRepo` repository.
 """
 
-from datetime import datetime, timezone
 from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME, MOCK_PROPERTY_A_INFO
 from unittest.mock import MagicMock, patch
 
@@ -603,7 +602,6 @@ def test_insert_property_to_all_in(datetime_mock, test_helpers, database_mock, i
     session = MagicMock()
     catalogue_item_ids = [ObjectId(), ObjectId()]
     property_in = PropertyIn(**MOCK_PROPERTY_A_INFO)
-    datetime_mock.now.return_value = datetime(2024, 2, 16, 14, 0, 0, 0, tzinfo=timezone.utc)
 
     # Mock 'update_many'
     test_helpers.mock_update_many(database_mock.items)

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -3,7 +3,6 @@ Unit tests for the `ItemRepo` repository.
 """
 
 from datetime import datetime, timezone
-from inventory_management_system_api.models.catalogue_item import PropertyIn
 from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME, MOCK_PROPERTY_A_INFO
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +11,7 @@ from bson import ObjectId
 
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import InvalidObjectIdError, MissingRecordError
+from inventory_management_system_api.models.catalogue_item import PropertyIn
 from inventory_management_system_api.models.item import ItemIn, ItemOut
 
 # pylint: disable=duplicate-code
@@ -274,7 +274,7 @@ def test_list_with_invalid_system_id_filter(item_repository):
 
 def test_list_with_catalogue_item_id_filter(test_helpers, database_mock, item_repository):
     """
-    Test getting items based on the provided castalogue item ID filter.
+    Test getting items based on the provided catalogue item ID filter.
 
     Verify that the `list` method properly handles the retrieval of items based on
     the provided catalogue item ID filter

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -20,6 +20,7 @@ from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.repositories.unit import UnitRepo
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
 from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
+from inventory_management_system_api.services.catalogue_category_property import CatalogueCategoryPropertyService
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService
 from inventory_management_system_api.services.item import ItemService
 from inventory_management_system_api.services.manufacturer import ManufacturerService
@@ -96,6 +97,24 @@ def fixture_catalogue_category_service(catalogue_category_repository_mock: Mock)
     :return: `CatalogueCategoryService` instance with the mocked dependency.
     """
     return CatalogueCategoryService(catalogue_category_repository_mock)
+
+
+@pytest.fixture(name="catalogue_category_property_service")
+def fixture_catalogue_category_property_service(
+    catalogue_category_repository_mock: Mock, catalogue_item_repository_mock: Mock, item_repository_mock: Mock
+) -> CatalogueCategoryPropertyService:
+    """
+    Fixture to create a `CatalogueCategoryPropertyService` instance with mocked `CatalogueCategoryRepo`,
+    `CatalogueItemRepo`, and `ItemRepo` dependencies.
+
+    :param catalogue_category_repository_mock: Mocked `CatalogueCategoryRepo` instance.
+    :param catalogue_item_repository_mock: Mocked `CatalogueItemRepo` instance.
+    :param item_repository_mock: Mocked `ItemRepo` instance.
+    :return: `CatalogueCategoryPropertyService` instance with the mocked dependencies.
+    """
+    return CatalogueCategoryPropertyService(
+        catalogue_category_repository_mock, catalogue_item_repository_mock, item_repository_mock
+    )
 
 
 @pytest.fixture(name="catalogue_item_service")

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -1,0 +1,337 @@
+"""
+Unit tests for the `CatalogueCategoryPropertyService` service.
+"""
+
+from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW
+from unittest.mock import ANY, patch
+
+import pytest
+from bson import ObjectId
+
+from inventory_management_system_api.core.exceptions import (
+    InvalidActionError, MissingRecordError)
+from inventory_management_system_api.models.catalogue_category import (
+    CatalogueCategoryIn, CatalogueCategoryOut, CatalogueItemPropertyIn,
+    CatalogueItemPropertyOut)
+from inventory_management_system_api.models.catalogue_item import PropertyIn
+from inventory_management_system_api.schemas.catalogue_category import \
+    CatalogueItemPropertyPostRequestSchema
+
+# pylint:disable=too-many-locals
+# pylint:disable=too-many-arguments
+
+
+@patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
+def test_create(
+    mongodb_client_mock,
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test creating a property at the catalogue category level
+
+    Verify that the `create` method properly handles the property to be created and propagates the changes
+    downwards through catalogue items and items for a non-mandatory property
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
+        name="Property A", type="number", unit="mm", mandatory=False
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    created_catalogue_item_property = catalogue_category_property_service.create(
+        catalogue_category_id, catalogue_item_property
+    )
+
+    # Start of transaction
+    session = mongodb_client_mock.start_session.return_value.__enter__.return_value
+    catalogue_category_repository_mock.update.assert_called_once_with(
+        catalogue_category_id,
+        ANY,
+        session=session,
+    )
+
+    expected_catalogue_item_property_in = CatalogueItemPropertyIn(**catalogue_item_property.model_dump())
+    expected_catalogue_item_properties_in = [
+        CatalogueItemPropertyIn(**prop.model_dump()) for prop in stored_catalogue_category.catalogue_item_properties
+    ] + [expected_catalogue_item_property_in]
+    expected_catalogue_category_in = CatalogueCategoryIn(
+        **{**stored_catalogue_category.model_dump(), "catalogue_item_properties": expected_catalogue_item_properties_in}
+    )
+
+    # Catalogue category update
+    update_catalogue_category_in = catalogue_category_repository_mock.update.call_args_list[0][0][1]
+    assert update_catalogue_category_in.model_dump() == {
+        **expected_catalogue_category_in.model_dump(),
+        "catalogue_item_properties": [
+            {**prop.model_dump(), "id": ANY} for prop in expected_catalogue_item_properties_in
+        ],
+    }
+
+    # Property
+    expected_property_in = PropertyIn(
+        id=str(expected_catalogue_item_property_in.id),
+        name=expected_catalogue_item_property_in.name,
+        value=catalogue_item_property.default_value,
+        unit=expected_catalogue_item_property_in.unit,
+    )
+
+    # Catalogue items update
+    catalogue_item_repository_mock.insert_property_to_all_matching.assert_called_once_with(
+        catalogue_category_id, ANY, session=session
+    )
+    insert_property_to_all_matching_property_in = (
+        catalogue_item_repository_mock.insert_property_to_all_matching.call_args_list[0][0][1]
+    )
+    assert insert_property_to_all_matching_property_in.model_dump() == {
+        **expected_property_in.model_dump(),
+        "id": ANY,
+    }
+
+    # Catalogue category update
+    catalogue_item_repository_mock.list_ids.assert_called_once_with(catalogue_category_id, session=session)
+    item_repository_mock.insert_property_to_all_in.assert_called_once_with(
+        catalogue_item_repository_mock.list_ids.return_value, ANY, session=session
+    )
+    insert_property_to_all_in_property_in = item_repository_mock.insert_property_to_all_in.call_args_list[0][0][1]
+    assert insert_property_to_all_in_property_in.model_dump() == {
+        **expected_property_in.model_dump(),
+        "id": ANY,
+    }
+
+    # Final output
+    assert created_catalogue_item_property.model_dump() == {
+        **CatalogueItemPropertyOut(**expected_catalogue_item_property_in.model_dump()).model_dump(),
+        "id": ANY,
+    }
+
+
+@patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
+def test_create_mandatory_property(
+    mongodb_client_mock,
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test creating a property at the catalogue category level
+
+    Verify that the `create` method properly handles the property to be created and propagates the changes
+    downwards through catalogue items and items for a mandatory property with a default value
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
+        name="Property A", type="number", unit="mm", mandatory=True, default_value=40
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    created_catalogue_item_property = catalogue_category_property_service.create(
+        catalogue_category_id, catalogue_item_property
+    )
+
+    # Start of transaction
+    session = mongodb_client_mock.start_session.return_value.__enter__.return_value
+    catalogue_category_repository_mock.update.assert_called_once_with(
+        catalogue_category_id,
+        ANY,
+        session=session,
+    )
+
+    expected_catalogue_item_property_in = CatalogueItemPropertyIn(**catalogue_item_property.model_dump())
+    expected_catalogue_item_properties_in = [
+        CatalogueItemPropertyIn(**prop.model_dump()) for prop in stored_catalogue_category.catalogue_item_properties
+    ] + [expected_catalogue_item_property_in]
+    expected_catalogue_category_in = CatalogueCategoryIn(
+        **{**stored_catalogue_category.model_dump(), "catalogue_item_properties": expected_catalogue_item_properties_in}
+    )
+
+    # Catalogue category update
+    update_catalogue_category_in = catalogue_category_repository_mock.update.call_args_list[0][0][1]
+    assert update_catalogue_category_in.model_dump() == {
+        **expected_catalogue_category_in.model_dump(),
+        "catalogue_item_properties": [
+            {**prop.model_dump(), "id": ANY} for prop in expected_catalogue_item_properties_in
+        ],
+    }
+
+    # Property
+    expected_property_in = PropertyIn(
+        id=str(expected_catalogue_item_property_in.id),
+        name=expected_catalogue_item_property_in.name,
+        value=catalogue_item_property.default_value,
+        unit=expected_catalogue_item_property_in.unit,
+    )
+
+    # Catalogue items update
+    catalogue_item_repository_mock.insert_property_to_all_matching.assert_called_once_with(
+        catalogue_category_id, ANY, session=session
+    )
+    insert_property_to_all_matching_property_in = (
+        catalogue_item_repository_mock.insert_property_to_all_matching.call_args_list[0][0][1]
+    )
+    assert insert_property_to_all_matching_property_in.model_dump() == {
+        **expected_property_in.model_dump(),
+        "id": ANY,
+    }
+
+    # Catalogue category update
+    catalogue_item_repository_mock.list_ids.assert_called_once_with(catalogue_category_id, session=session)
+    item_repository_mock.insert_property_to_all_in.assert_called_once_with(
+        catalogue_item_repository_mock.list_ids.return_value, ANY, session=session
+    )
+    insert_property_to_all_in_property_in = item_repository_mock.insert_property_to_all_in.call_args_list[0][0][1]
+    assert insert_property_to_all_in_property_in.model_dump() == {
+        **expected_property_in.model_dump(),
+        "id": ANY,
+    }
+
+    # Final output
+    assert created_catalogue_item_property.model_dump() == {
+        **CatalogueItemPropertyOut(**expected_catalogue_item_property_in.model_dump()).model_dump(),
+        "id": ANY,
+    }
+
+
+def test_create_mandatory_property_without_default_value(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    catalogue_category_property_service,
+):
+    """
+    Test creating a property at the catalogue category
+
+    Verify that the `create` method raises an InvalidActionError when the property being created is mandatory but
+    doesn't have a default_value
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
+        name="Property A", type="number", unit="mm", mandatory=True
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)
+    assert str(exc.value) == "Cannot add a mandatory property without a default value"
+
+    # Ensure no updates
+    catalogue_category_repository_mock.update.assert_not_called()
+    catalogue_item_repository_mock.insert_property_to_all_matching.assert_not_called()
+    item_repository_mock.insert_property_to_all_in.assert_not_called()
+
+
+def test_create_mandatory_property_with_missing_catalogue_category(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    catalogue_category_property_service,
+):
+    """
+    Test creating a property at the catalogue category
+
+    Verify that the `create` method raises an MissingRecordError when the catalogue category with the given
+    catalogue_category_id doesn't exist
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
+        name="Property A", type="number", unit="mm", mandatory=False
+    )
+    stored_catalogue_category = None
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(MissingRecordError) as exc:
+        catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)
+    assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
+
+    # Ensure no updates
+    catalogue_category_repository_mock.update.assert_not_called()
+    catalogue_item_repository_mock.insert_property_to_all_matching.assert_not_called()
+    item_repository_mock.insert_property_to_all_in.assert_not_called()
+
+
+def test_create_mandatory_property_with_non_leaf_catalogue_category(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    catalogue_category_property_service,
+):
+    """
+    Test creating a property at the catalogue category
+
+    Verify that the `create` method raises an InvalidActionError when the catalogue category for the given id
+    is not a leaf
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
+        name="Property A", type="number", unit="mm", mandatory=False
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=False,
+        parent_id=None,
+        catalogue_item_properties=[],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_property_service.create(catalogue_category_id, catalogue_item_property)
+    assert str(exc.value) == "Cannot add a property to a non-leaf catalogue category"
+
+    # Ensure no updates
+    catalogue_category_repository_mock.update.assert_not_called()
+    catalogue_item_repository_mock.insert_property_to_all_matching.assert_not_called()
+    item_repository_mock.insert_property_to_all_in.assert_not_called()

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -25,7 +25,7 @@ from inventory_management_system_api.schemas.catalogue_category import Catalogue
 @patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
 @pytest.mark.parametrize(
     "mandatory,default_value",
-    [(False, None), (True, "42")],
+    [(False, None), (True, 42)],
     ids=["non_mandatory_without_default_value", "mandatory_with_default_value"],
 )
 def test_create(

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -8,22 +8,30 @@ from unittest.mock import ANY, patch
 import pytest
 from bson import ObjectId
 
-from inventory_management_system_api.core.exceptions import (
-    InvalidActionError, MissingRecordError)
+from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
 from inventory_management_system_api.models.catalogue_category import (
-    CatalogueCategoryIn, CatalogueCategoryOut, CatalogueItemPropertyIn,
-    CatalogueItemPropertyOut)
+    CatalogueCategoryIn,
+    CatalogueCategoryOut,
+    CatalogueItemPropertyIn,
+    CatalogueItemPropertyOut,
+)
 from inventory_management_system_api.models.catalogue_item import PropertyIn
-from inventory_management_system_api.schemas.catalogue_category import \
-    CatalogueItemPropertyPostRequestSchema
+from inventory_management_system_api.schemas.catalogue_category import CatalogueItemPropertyPostRequestSchema
 
 # pylint:disable=too-many-locals
 # pylint:disable=too-many-arguments
 
 
 @patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
+@pytest.mark.parametrize(
+    "mandatory,default_value",
+    [(False, None), (True, "42")],
+    ids=["non_mandatory_without_default_value", "mandatory_with_default_value"],
+)
 def test_create(
     mongodb_client_mock,
+    mandatory,
+    default_value,
     test_helpers,
     catalogue_category_repository_mock,
     catalogue_item_repository_mock,
@@ -35,112 +43,12 @@ def test_create(
     Test creating a property at the catalogue category level
 
     Verify that the `create` method properly handles the property to be created and propagates the changes
-    downwards through catalogue items and items for a non-mandatory property
+    downwards through catalogue items and items for a non-mandatory property without a default value, and a mandatory
+    property with a default value
     """
     catalogue_category_id = str(ObjectId())
     catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
-        name="Property A", type="number", unit="mm", mandatory=False
-    )
-    stored_catalogue_category = CatalogueCategoryOut(
-        id=catalogue_category_id,
-        name="Category A",
-        code="category-a",
-        is_leaf=True,
-        parent_id=None,
-        catalogue_item_properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-
-    # Mock the stored catalogue category to one without a property with the same name
-    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
-
-    created_catalogue_item_property = catalogue_category_property_service.create(
-        catalogue_category_id, catalogue_item_property
-    )
-
-    # Start of transaction
-    session = mongodb_client_mock.start_session.return_value.__enter__.return_value
-    catalogue_category_repository_mock.update.assert_called_once_with(
-        catalogue_category_id,
-        ANY,
-        session=session,
-    )
-
-    expected_catalogue_item_property_in = CatalogueItemPropertyIn(**catalogue_item_property.model_dump())
-    expected_catalogue_item_properties_in = [
-        CatalogueItemPropertyIn(**prop.model_dump()) for prop in stored_catalogue_category.catalogue_item_properties
-    ] + [expected_catalogue_item_property_in]
-    expected_catalogue_category_in = CatalogueCategoryIn(
-        **{**stored_catalogue_category.model_dump(), "catalogue_item_properties": expected_catalogue_item_properties_in}
-    )
-
-    # Catalogue category update
-    update_catalogue_category_in = catalogue_category_repository_mock.update.call_args_list[0][0][1]
-    assert update_catalogue_category_in.model_dump() == {
-        **expected_catalogue_category_in.model_dump(),
-        "catalogue_item_properties": [
-            {**prop.model_dump(), "id": ANY} for prop in expected_catalogue_item_properties_in
-        ],
-    }
-
-    # Property
-    expected_property_in = PropertyIn(
-        id=str(expected_catalogue_item_property_in.id),
-        name=expected_catalogue_item_property_in.name,
-        value=catalogue_item_property.default_value,
-        unit=expected_catalogue_item_property_in.unit,
-    )
-
-    # Catalogue items update
-    catalogue_item_repository_mock.insert_property_to_all_matching.assert_called_once_with(
-        catalogue_category_id, ANY, session=session
-    )
-    insert_property_to_all_matching_property_in = (
-        catalogue_item_repository_mock.insert_property_to_all_matching.call_args_list[0][0][1]
-    )
-    assert insert_property_to_all_matching_property_in.model_dump() == {
-        **expected_property_in.model_dump(),
-        "id": ANY,
-    }
-
-    # Catalogue category update
-    catalogue_item_repository_mock.list_ids.assert_called_once_with(catalogue_category_id, session=session)
-    item_repository_mock.insert_property_to_all_in.assert_called_once_with(
-        catalogue_item_repository_mock.list_ids.return_value, ANY, session=session
-    )
-    insert_property_to_all_in_property_in = item_repository_mock.insert_property_to_all_in.call_args_list[0][0][1]
-    assert insert_property_to_all_in_property_in.model_dump() == {
-        **expected_property_in.model_dump(),
-        "id": ANY,
-    }
-
-    # Final output
-    assert created_catalogue_item_property.model_dump() == {
-        **CatalogueItemPropertyOut(**expected_catalogue_item_property_in.model_dump()).model_dump(),
-        "id": ANY,
-    }
-
-
-@patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
-def test_create_mandatory_property(
-    mongodb_client_mock,
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_property_service,
-):
-    """
-    Test creating a property at the catalogue category level
-
-    Verify that the `create` method properly handles the property to be created and propagates the changes
-    downwards through catalogue items and items for a mandatory property with a default value
-    """
-    catalogue_category_id = str(ObjectId())
-    catalogue_item_property = CatalogueItemPropertyPostRequestSchema(
-        name="Property A", type="number", unit="mm", mandatory=True, default_value=40
+        name="Property A", type="number", unit="mm", mandatory=mandatory, default_value=default_value
     )
     stored_catalogue_category = CatalogueCategoryOut(
         id=catalogue_category_id,

--- a/test/unit/services/test_utils.py
+++ b/test/unit/services/test_utils.py
@@ -70,7 +70,9 @@ class TestDuplicateCatalogueItemPropertyNames:
     """Tests for the `check_duplicate_catalogue_item_property_names` method"""
 
     def test_with_no_duplicate_names(self):
-        """Test `check_duplicate_catalogue_item_property_names` works correctly when there are no duplicate names given"""
+        """
+        Test `check_duplicate_catalogue_item_property_names` works correctly when there are no duplicate names given
+        """
 
         utils.check_duplicate_catalogue_item_property_names(DEFINED_PROPERTIES)
 

--- a/test/unit/services/test_utils.py
+++ b/test/unit/services/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 from bson import ObjectId
 
 from inventory_management_system_api.core.exceptions import (
+    DuplicateCatalogueItemPropertyNameError,
     InvalidCatalogueItemPropertyTypeError,
     MissingMandatoryCatalogueItemProperty,
 )
@@ -53,6 +54,32 @@ EXPECTED_PROCESSED_PROPERTIES = [
     {"id": DEFINED_PROPERTIES[3].id, "name": "Property D", "value": 2, "unit": "mm"},
     {"id": DEFINED_PROPERTIES[4].id, "name": "Property E", "value": "red", "unit": None},
 ]
+
+
+class TestGenerateCode:
+    """Tests for the `generate_code` method"""
+
+    def test_generate_code(self):
+        """Test `generate_code` works correctly"""
+
+        result = utils.generate_code("string with spaces", "entity_type")
+        assert result == "string-with-spaces"
+
+
+class TestDuplicateCatalogueItemPropertyNames:
+    """Tests for the `check_duplicate_catalogue_item_property_names` method"""
+
+    def test_with_no_duplicate_names(self):
+        """Test `check_duplicate_catalogue_item_property_names` works correctly when there are no duplicate names given"""
+
+        utils.check_duplicate_catalogue_item_property_names(DEFINED_PROPERTIES)
+
+    def test_with_duplicate_names(self):
+        """Test `check_duplicate_catalogue_item_property_names` works correctly when there are duplicate names given"""
+
+        with pytest.raises(DuplicateCatalogueItemPropertyNameError) as exc:
+            utils.check_duplicate_catalogue_item_property_names([*DEFINED_PROPERTIES, DEFINED_PROPERTIES[-1]])
+        assert str(exc.value) == f"Duplicate catalogue item property name: {DEFINED_PROPERTIES[-1].name}"
 
 
 class TestProcessCatalogueItemProperties:


### PR DESCRIPTION
## Description
See #245.

This PR should be working with https://github.com/ral-facilities/inventory-management-system/pull/530.

## Notes
- Renames `CatalogueItemPropertyPostRequestSchema` -> `CatalogueCategoryPostRequestPropertySchema` so the new endpoint can use `CatalogueItemPropertyPostRequestSchema` as it requires a slightly different schema. This new name also reflects its location slightly better, although it technically should be `CatalogueCategoryPostRequestCatalogueItemPropertySchema` under the existing naming scheme, but that is very long. Further changes e.g. to `catalogue_item_properties` are left to a future issue
- Should we also change the type of property values to `Union[str, int, bool]` rather than Any?
- As we need the ids of catalogue items to know which items to update we can either use update_many with the catalogue_category_id or find the ids for the catalogue items first and then use $in - performance testing this with 100000 catalogue items showed that the first method took 0.97s, and the 2nd 1.57s. So I went with the former.
- ~For the items update, we could do an iteration in python calling update_many with each catalogue_item_id - a rough test instead using catalogue items (which is not an accurate example due to the test effectively being 100000 update_ones's) made it take 56.1 seconds rather than 1.57 seconds achieved when using $in. Bulk write updates are also another option but it sounds like they should be avoided unless the update data changes in some way. Testing it took 4.60 seconds. So it appears overall the fastest method for items is using `$in` with the ids. The size of the array for this appears to be around 27 MB (using https://code.activestate.com/recipes/577504/), so over time we should be doing this update in batches (although current get requests for such a category would have a much higher memory usage)~. **UPDATE**: Now use distinct, which decreases the memory usage significantly (previous tests stored a dictionary of _id: ObjectId)
- Using multiple workers allows multiple requests to occur at once - adding a time.sleep inside the transaction and then editing on the front end will wait until the transaction is complete before completing the edit request if it is inside of the modified catalogue category. If it is not then the request happens instantly as long as there is another worker available on the api. If the sleep is before any edits within the transaction, the request is handled instantly provided there is a worker.
- Used a class in the e2e tests as they were going to be very nasty without (the unit tests really need something similar as we have too many arguments and locals) obviously may change later anyway but I think it could work nicely with the new test client as well

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #259 
