### PR TITLE
Add PATCH endpoint for /properties #266

### DIFF
--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -286,7 +286,7 @@ class CatalogueCategoryRepo:
         catalogue_category_id: str,
         catalogue_item_property_id: str,
         catalogue_item_property: CatalogueItemPropertyIn,
-        session: ClientSession,
+        session: ClientSession = None,
     ):
         """
         Updates a catalogue item property given its ID and the ID of the catalogue category it's in
@@ -300,6 +300,13 @@ class CatalogueCategoryRepo:
         # same for duplicate check? Would be extra unnecessary queries though given the checks must happen in
         # the service. Also wont make sense for catalogue items and items. The catalogue_category_id is not
         # actually needed here at the moment.
+
+        logger.info(
+            "Updating property with ID: %s inside catalogue category with ID: %s in the database",
+            catalogue_item_property_id,
+            catalogue_category_id,
+        )
+
         catalogue_item_property_data = catalogue_item_property.model_dump(by_alias=True)
         self._catalogue_categories_collection.update_one(
             {

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -287,7 +287,7 @@ class CatalogueCategoryRepo:
         catalogue_item_property_id: str,
         catalogue_item_property: CatalogueItemPropertyIn,
         session: ClientSession = None,
-    ):
+    ) -> CatalogueItemPropertyOut:
         """
         Updates a catalogue item property given its ID and the ID of the catalogue category it's in
 
@@ -295,6 +295,7 @@ class CatalogueCategoryRepo:
         :param catalogue_item_property_id: The ID of the catalogue item property to update
         :param catalogue_item_property: The catalogue item property containing the update data
         :param session: PyMongo ClientSession to use for database operations
+        :return: The updated catalogue item property
         """
 
         logger.info(

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -296,10 +296,6 @@ class CatalogueCategoryRepo:
         :param catalogue_item_property: The catalogue item property containing the update data
         :param session: PyMongo ClientSession to use for database operations
         """
-        # TODO: Perform checks in here?, perhaps a get_catalogue_item_property method then return the response?
-        # same for duplicate check? Would be extra unnecessary queries though given the checks must happen in
-        # the service. Also wont make sense for catalogue items and items. The catalogue_category_id is not
-        # actually needed here at the moment.
 
         logger.info(
             "Updating property with ID: %s inside catalogue category with ID: %s in the database",

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -189,7 +189,7 @@ class CatalogueItemRepo:
 
     def update_names_of_all_properties_with_id(
         self, property_id: str, new_property_name: str, session: ClientSession = None
-    ):
+    ) -> None:
         """
         Updates the name of a property in every catalogue item it is present in
 

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -174,7 +174,7 @@ class CatalogueItemRepo:
         """
 
         logger.info(
-            "Inserting property into catalogue item's with a catalogue category: %s in the database",
+            "Inserting property into catalogue item's with a catalogue category ID: %s in the database",
             catalogue_category_id,
         )
         self._catalogue_items_collection.update_many(
@@ -183,5 +183,32 @@ class CatalogueItemRepo:
                 "$push": {"properties": property_in.model_dump(by_alias=True)},
                 "$set": {"modified_time": datetime.now(timezone.utc)},
             },
+            session=session,
+        )
+
+    def update_names_of_all_properties_with_id(
+        self, property_id: str, new_property_name: str, session: ClientSession = None
+    ):
+        """
+        Updates the name of a property in every catalogue item it is present in
+
+        Also updates the modified_time to reflect the update
+
+        :param property_id: The ID of the property to update
+        :param new_property_name: The new property name
+        :param session: PyMongo ClientSession to use for database operations
+        """
+
+        logger.info("Updating all properties with ID: %s inside catalogue items in the database", property_id)
+
+        self._catalogue_items_collection.update_many(
+            {"properties._id": CustomObjectId(property_id)},
+            {
+                "$set": {
+                    "properties.$[elem].name": new_property_name,
+                    "modified_time": datetime.now(timezone.utc),
+                }
+            },
+            array_filters=[{"elem._id": CustomObjectId(property_id)}],
             session=session,
         )

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -158,7 +158,7 @@ class ItemRepo:
     # pylint:disable=duplicate-code
     def update_names_of_all_properties_with_id(
         self, property_id: str, new_property_name: str, session: ClientSession = None
-    ):
+    ) -> None:
         """
         Updates the name of a property in every item it is present in
 

--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -154,3 +154,33 @@ class ItemRepo:
             },
             session=session,
         )
+
+    # pylint:disable=duplicate-code
+    def update_names_of_all_properties_with_id(
+        self, property_id: str, new_property_name: str, session: ClientSession = None
+    ):
+        """
+        Updates the name of a property in every item it is present in
+
+        Also updates the modified_time to reflect the update
+
+        :param property_id: The ID of the property to update
+        :param new_property_name: The new property name
+        :param session: PyMongo ClientSession to use for database operations
+        """
+
+        logger.info("Updating all properties with ID: %s inside items in the database", property_id)
+
+        self._items_collection.update_many(
+            {"properties._id": CustomObjectId(property_id)},
+            {
+                "$set": {
+                    "properties.$[elem].name": new_property_name,
+                    "modified_time": datetime.now(timezone.utc),
+                }
+            },
+            array_filters=[{"elem._id": CustomObjectId(property_id)}],
+            session=session,
+        )
+
+    # pylint:enable=duplicate-code

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -273,9 +273,8 @@ def partial_update_catalogue_item_property(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     # pylint:disable=duplicate-code
     except DuplicateCatalogueItemPropertyNameError as exc:
-        message = "A catalogue item property with the same name already exists within the catalogue category"
-        logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+        logger.exception(str(exc))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
     except InvalidActionError as exc:
         message = str(exc)
         logger.exception(message)

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -279,10 +279,6 @@ def partial_update_catalogue_item_property(
         message = str(exc)
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
-    # pylint:enable=duplicate-code
-    # TODO: Replace with RequestValidationError? - currently different to catalogue category post if allowed
-    #       values were wrong, but can't validate in the schema here
-    #       https://github.com/tiangolo/fastapi/issues/471 ?
     except ValueError as exc:
         message = str(exc)
         logger.exception(message)

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -281,4 +281,4 @@ def partial_update_catalogue_item_property(
     except ValueError as exc:
         message = str(exc)
         logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -271,10 +271,16 @@ def partial_update_catalogue_item_property(
             message = "Catalogue category not found"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+    # pylint:disable=duplicate-code
     except DuplicateCatalogueItemPropertyNameError as exc:
         message = "A catalogue item property with the same name already exists within the catalogue category"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except InvalidActionError as exc:
+        message = str(exc)
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
+    # pylint:enable=duplicate-code
     # TODO: Replace with RequestValidationError? - currently different to catalogue category post if allowed
     #       values were wrong, but can't validate in the schema here
     #       https://github.com/tiangolo/fastapi/issues/471 ?

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -275,3 +275,10 @@ def partial_update_catalogue_item_property(
         message = "A catalogue item property with the same name already exists within the catalogue category"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    # TODO: Replace with RequestValidationError? - currently different to catalogue category post if allowed
+    #       values were wrong, but can't validate in the schema here
+    #       https://github.com/tiangolo/fastapi/issues/471 ?
+    except ValueError as exc:
+        message = str(exc)
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -211,3 +211,16 @@ class CatalogueItemPropertyPostRequestSchema(CatalogueCategoryPostRequestPropert
                 raise ValueError("default_value is not one of the allowed_values")
 
         return default_value
+
+
+class CatalogueItemPropertyPatchRequestSchema(BaseModel):
+    """
+    Schema model for a catalogue item property patch request
+    """
+
+    name: Optional[str] = Field(default=None, description="The name of the property")
+    allowed_values: Optional[AllowedValuesSchema] = Field(
+        default=None,
+        description="Definition of the allowed values this property can take. 'null' indicates any value matching the "
+        "type is allowed.",
+    )

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -93,32 +93,31 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
 
     @classmethod
     def check_valid_allowed_values(
-        cls, allowed_values: Optional[AllowedValuesSchema], catalogue_category_data: dict[str, Any]
-    ) -> Optional[AllowedValuesSchema]:
+        cls, allowed_values: Optional[AllowedValuesSchema], catalogue_item_property_data: dict[str, Any]
+    ) -> None:
         """
-        Validator for the `allowed_values` field.
+        Checks allowed_values against its parent catalogue item property raising an error if its invalid
 
         It checks if the `type` of the catalogue item property is a `boolean` and if `allowed_values` has been specified
         and raises a `ValueError` if this is the case. In the case the `allowed_values` is as `list` type, then also
         verifies all of the values are of the same `type` and raises a ValueError if not.
 
         :param allowed_values: The value of the `allowed_values` field.
-        :param info: Validation info from pydantic.
-        :return: The value of the `allowed_values` field.
+        :param catalogue_item_property_data: Catalogue item property data to validate the allowed values against.
         """
-        if allowed_values is not None and "type" in catalogue_category_data:
+        if allowed_values is not None and "type" in catalogue_item_property_data:
             # Ensure the type is not boolean
-            if catalogue_category_data["type"] == CatalogueItemPropertyType.BOOLEAN:
+            if catalogue_item_property_data["type"] == CatalogueItemPropertyType.BOOLEAN:
                 raise ValueError(
                     "allowed_values not allowed for a boolean catalogue item property "
-                    f"'{catalogue_category_data['name']}'"
+                    f"'{catalogue_item_property_data['name']}'"
                 )
             # Check the type of allowed_values being used and validate them appropriately
             if isinstance(allowed_values, AllowedValuesListSchema):
                 # List type should have all values the same type
                 for allowed_value in allowed_values.values:
                     if not CatalogueCategoryPostRequestPropertySchema.is_valid_property_type(
-                        expected_property_type=catalogue_category_data["type"], property_value=allowed_value
+                        expected_property_type=catalogue_item_property_data["type"], property_value=allowed_value
                     ):
                         raise ValueError(
                             "allowed_values of type 'list' must only contain values of the same type as the property "
@@ -133,9 +132,7 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
         """
         Validator for the `allowed_values` field.
 
-        It checks if the `type` of the catalogue item property is a `boolean` and if `allowed_values` has been specified
-        and raises a `ValueError` if this is the case. In the case the `allowed_values` is as `list` type, then also
-        verifies all of the values are of the same `type` and raises a ValueError if not.
+        Ensures the allowed_values are valid given the rest of the property schema.
 
         :param allowed_values: The value of the `allowed_values` field.
         :param info: Validation info from pydantic.

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -121,7 +121,8 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
                         expected_property_type=catalogue_category_data["type"], property_value=allowed_value
                     ):
                         raise ValueError(
-                            "allowed_values must only contain values of the same type as the property itself"
+                            "allowed_values of type 'list' must only contain values of the same type as the property "
+                            "itself"
                         )
 
     @field_validator("allowed_values")

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -18,6 +18,7 @@ from inventory_management_system_api.repositories.catalogue_category import Cata
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.schemas.catalogue_category import (
+    CatalogueCategoryPostRequestPropertySchema,
     CatalogueItemPropertyPatchRequestSchema,
     CatalogueItemPropertyPostRequestSchema,
 )
@@ -159,9 +160,11 @@ class CatalogueCategoryPropertyService:
             existing_property_out.name = update_data["name"]
             utils.check_duplicate_catalogue_item_property_names(stored_catalogue_category.catalogue_item_properties)
 
-        # TODO: Need to perform validation on the allowed_values using the existing property type
-        #       as CatalogueCategoryPostRequestPropertySchema would have done and check that the
-        #       changes are actually allowed e.g. only adding allowed values
+        CatalogueCategoryPostRequestPropertySchema.check_valid_allowed_values(
+            catalogue_item_property.allowed_values, existing_property_out.model_dump()
+        )
+
+        # TODO: Ensure properties are only added
 
         catalogue_item_property_in = CatalogueItemPropertyIn(
             **{**existing_property_out.model_dump(), **catalogue_item_property.model_dump()}

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -135,6 +135,11 @@ class CatalogueCategoryPropertyService:
             - If the type of allowed values is 'list' while modifying the list in any way other than adding extra
               values
         """
+        # Ignore checks if both existing and new allowed_values is None
+        # (as there is no change)
+        if existing_allowed_values is None and new_allowed_values is None:
+            return
+
         # Prevent adding allowed_values to an existing property
         if existing_allowed_values is None and new_allowed_values is not None:
             raise InvalidActionError("Cannot add allowed_values to an existing catalogue item property")

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -160,6 +160,8 @@ class CatalogueCategoryPropertyService:
             existing_property_out.name = update_data["name"]
             utils.check_duplicate_catalogue_item_property_names(stored_catalogue_category.catalogue_item_properties)
 
+        # TODO: Ensure properties are only added
+
         CatalogueCategoryPostRequestPropertySchema.check_valid_allowed_values(
             catalogue_item_property.allowed_values, existing_property_out.model_dump()
         )

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -164,11 +164,9 @@ class CatalogueCategoryPropertyService:
             catalogue_item_property.allowed_values, existing_property_out.model_dump()
         )
 
-        # TODO: Ensure properties are only added
+        # TODO: Ensure allowed values are only added?
 
-        catalogue_item_property_in = CatalogueItemPropertyIn(
-            **{**existing_property_out.model_dump(), **catalogue_item_property.model_dump()}
-        )
+        catalogue_item_property_in = CatalogueItemPropertyIn(**{**existing_property_out.model_dump(), **update_data})
 
         # Run all subsequent edits within a transaction to ensure they will all succeed or fail together
         with mongodb_client.start_session() as session:

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -164,8 +164,6 @@ class CatalogueCategoryPropertyService:
             catalogue_item_property.allowed_values, existing_property_out.model_dump()
         )
 
-        # TODO: Ensure allowed values are only added?
-
         catalogue_item_property_in = CatalogueItemPropertyIn(**{**existing_property_out.model_dump(), **update_data})
 
         # Run all subsequent edits within a transaction to ensure they will all succeed or fail together

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -123,7 +123,7 @@ class CatalogueCategoryPropertyService:
 
     def _check_valid_allowed_values_update(
         self, existing_allowed_values: Optional[AllowedValues], new_allowed_values: Optional[AllowedValuesSchema]
-    ):
+    ) -> None:
         """Validates a potential change of allowed_values
 
         :param existing_allowed_values: Existing allowed_values from the catalogue category database model
@@ -185,7 +185,7 @@ class CatalogueCategoryPropertyService:
             raise MissingRecordError(f"No catalogue category found with ID: {catalogue_category_id}")
 
         # Attempt to locate the property
-        existing_property_out: CatalogueItemPropertyOut = None
+        existing_property_out: Optional[CatalogueItemPropertyOut] = None
         for prop in stored_catalogue_category.catalogue_item_properties:
             if prop.id == catalogue_item_property_id:
                 existing_property_out = prop

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -154,7 +154,7 @@ class CatalogueCategoryPropertyService:
             raise MissingRecordError(f"No catalogue item property found with ID: {catalogue_item_property_id}")
 
         # Modify the name if necessary and check it doesn't cause a conflict
-        updating_name = "name" in update_data and update_data["name"] != stored_catalogue_category.name
+        updating_name = "name" in update_data and update_data["name"] != existing_property_out.name
         if updating_name:
             existing_property_out.name = update_data["name"]
             utils.check_duplicate_catalogue_item_property_names(stored_catalogue_category.catalogue_item_properties)

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -129,8 +129,8 @@ class CatalogueCategoryPropertyService:
         :param existing_allowed_values: Existing allowed_values from the catalogue category database model
         :param new_allowed_values: New definition of allowed values to validate
         :raises InvalidActionError:
-            - If the existing allowed_values is None and the new values are not
-            - If the existing allowed_values is not None and the new values are
+            - If the existing allowed_values is None and the new allowed_values is not
+            - If the existing allowed_values is not None and the new allowed_values is
             - If the type of allowed values is being changed
             - If the type of allowed values is 'list' while modifying the list in any way other than adding extra
               values
@@ -153,7 +153,10 @@ class CatalogueCategoryPropertyService:
         if existing_allowed_values.type == "list":
             for existing_value in existing_allowed_values.values:
                 if existing_value not in new_allowed_values.values:
-                    raise InvalidActionError("Cannot modify existing `allowed_values`, you may only add more")
+                    raise InvalidActionError(
+                        "Cannot modify existing values inside allowed_values of type 'list', you may only add more "
+                        "values"
+                    )
 
     def update(
         self,

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -378,7 +378,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     assert response.status_code == 422
     assert (
         response.json()["detail"][0]["msg"]
-        == "Value error, allowed_values must only contain values of the same type as the property itself"
+        == "Value error, allowed_values of type 'list' must only contain values of the same type as the property itself"
     )
 
 
@@ -405,7 +405,7 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     assert response.status_code == 422
     assert (
         response.json()["detail"][0]["msg"]
-        == "Value error, allowed_values must only contain values of the same type as the property itself"
+        == "Value error, allowed_values of type 'list' must only contain values of the same type as the property itself"
     )
 
 
@@ -1312,7 +1312,7 @@ def test_partial_update_catalogue_category_modify_catalogue_item_property_to_hav
     assert response.status_code == 422
     assert (
         response.json()["detail"][0]["msg"]
-        == "Value error, allowed_values must only contain values of the same type as the property itself"
+        == "Value error, allowed_values of type 'list' must only contain values of the same type as the property itself"
     )
 
 
@@ -1341,7 +1341,7 @@ def test_partial_update_catalogue_category_modify_catalogue_item_property_to_hav
     assert response.status_code == 422
     assert (
         response.json()["detail"][0]["msg"]
-        == "Value error, allowed_values must only contain values of the same type as the property itself"
+        == "Value error, allowed_values of type 'list' must only contain values of the same type as the property itself"
     )
 
 

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -506,6 +506,30 @@ class TestUpdate(UpdateDSL):
         self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
         self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
 
+    def test_update_category_no_changes_allowed_values_none(self):
+        """
+        Test updating a property at the catalogue category level but with an update that shouldn't change anything
+        (in this case also passing allowed_values as None and keeping it None on the patch request)
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY)
+        self.check_catalogue_item_property_post_response_success(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED)
+
+        # Patch the property
+        self.patch_catalogue_item_property(
+            {"name": CATALOGUE_ITEM_PROPERTY_POST_MANDATORY["name"], "allowed_values": None}
+        )
+
+        # Check updated correctly
+        self.check_catalogue_item_property_patch_response_success(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED)
+        # These are testing values are the same as they should have been prior to the patch (NEW_ is only there from
+        # the create tests)
+        self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED)
+        self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+        self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+
     def test_update_non_existent_catalogue_category_id(self):
         """
         Test updating a property at the catalogue category level when the specified catalogue category doesn't exist

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -98,6 +98,27 @@ NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_ALLOWED_VALUES_EXPECTED = (
     CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
 )
 
+CATALOGUE_ITEM_PROPERTY_PATCH = {
+    "name": "New property name",
+    "allowed_values": {"type": "list", "values": [42, 24]},
+}
+
+CATALOGUE_ITEM_PROPERTY_PATCH_EXPECTED = {
+    **CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED,
+    **CATALOGUE_ITEM_PROPERTY_PATCH,
+}
+
+NEW_CATALOGUE_ITEM_PROPERTY_PATCH_EXPECTED = CATALOGUE_ITEM_PROPERTY_PATCH_EXPECTED
+NEW_PROPERTY_PATCH_EXPECTED = {"name": "New property name", "unit": "mm", "value": 42}
+
+CATALOGUE_ITEM_PROPERTY_PATCH_ALLOWED_VALUES_ONLY = {
+    "allowed_values": {"type": "list", "values": [42, 24]},
+}
+CATALOGUE_ITEM_PROPERTY_PATCH_ALLOWED_VALUES_ONLY_EXPECTED = {
+    **CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED,
+    **CATALOGUE_ITEM_PROPERTY_PATCH_ALLOWED_VALUES_ONLY,
+}
+
 
 class CreateDSL:
     """Base class for create tests"""
@@ -113,6 +134,7 @@ class CreateDSL:
     @pytest.fixture(autouse=True)
     def setup(self, test_client):
         """Setup fixtures"""
+
         self.test_client = test_client
 
     def post_catalogue_category_and_items(self):
@@ -154,6 +176,7 @@ class CreateDSL:
 
     def post_non_leaf_catalogue_category(self):
         """Posts a non leaf catalogue category"""
+
         response = self.test_client.post(
             "/v1/catalogue-categories", json={**CATALOGUE_CATEGORY_POST_A, "is_leaf": False}
         )
@@ -163,27 +186,28 @@ class CreateDSL:
         """Posts a catalogue item property to the catalogue category"""
 
         self._catalogue_item_post_response = self.test_client.post(
-            f"/v1/catalogue-categories/{
-                catalogue_category_id if catalogue_category_id else self.catalogue_category['id']
-            }/properties",
+            "/v1/catalogue-categories/"
+            f"{catalogue_category_id if catalogue_category_id else self.catalogue_category['id']}/properties",
             json=catalogue_item_property_post,
         )
 
-    def check_catalogue_item_property_response_success(self, catalogue_item_property_expected):
+    def check_catalogue_item_property_post_response_success(self, catalogue_item_property_expected):
         """Checks the response of posting a catalogue item property succeeded as expected"""
 
         assert self._catalogue_item_post_response.status_code == 201
         self.catalogue_item_property = self._catalogue_item_post_response.json()
         assert self.catalogue_item_property == {**catalogue_item_property_expected, "id": ANY}
 
-    def check_catalogue_item_property_response_failed_with_message(self, status_code, detail):
+    def check_catalogue_item_property_post_response_failed_with_message(self, status_code, detail):
         """Checks the response of posting a catalogue item property failed as expected"""
+
         assert self._catalogue_item_post_response.status_code == status_code
         assert self._catalogue_item_post_response.json()["detail"] == detail
 
-    def check_catalogue_item_property_response_failed_with_validation_message(self, status_code, message):
+    def check_catalogue_item_property_post_response_failed_with_validation_message(self, status_code, message):
         """Checks the response of posting a catalogue item property failed as expected with a pydantic validation
         message"""
+
         assert self._catalogue_item_post_response.status_code == status_code
         assert self._catalogue_item_post_response.json()["detail"][0]["msg"] == message
 
@@ -230,7 +254,7 @@ class TestCreate(CreateDSL):
         self.post_catalogue_category_and_items()
         self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY)
 
-        self.check_catalogue_item_property_response_success(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY_EXPECTED)
+        self.check_catalogue_item_property_post_response_success(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY_EXPECTED)
         self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_NON_MANDATORY_EXPECTED)
         self.check_catalogue_item_updated(NEW_PROPERTY_NON_MANDATORY_EXPECTED)
         self.check_item_updated(NEW_PROPERTY_NON_MANDATORY_EXPECTED)
@@ -243,7 +267,7 @@ class TestCreate(CreateDSL):
         self.post_catalogue_category_and_items()
         self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY)
 
-        self.check_catalogue_item_property_response_success(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED)
+        self.check_catalogue_item_property_post_response_success(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_EXPECTED)
         self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_EXPECTED)
         self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
         self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
@@ -257,7 +281,7 @@ class TestCreate(CreateDSL):
         self.post_catalogue_category_and_items()
         self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
 
-        self.check_catalogue_item_property_response_success(
+        self.check_catalogue_item_property_post_response_success(
             CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
         )
         self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_MANDATORY_ALLOWED_VALUES_EXPECTED)
@@ -265,18 +289,18 @@ class TestCreate(CreateDSL):
         self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
 
     def test_create_property_with_non_existent_catalogue_category_id(self):
-        """Test adding a property when the specified catalogue category doesn't exist"""
+        """Test adding a property when the specified catalogue category id is invalid"""
 
         self.post_catalogue_item_property(
             CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY, catalogue_category_id=str(ObjectId())
         )
-        self.check_catalogue_item_property_response_failed_with_message(404, "Catalogue category not found")
+        self.check_catalogue_item_property_post_response_failed_with_message(404, "Catalogue category not found")
 
     def test_create_property_with_invalid_catalogue_category_id(self):
         """Test adding a property when given an invalid catalogue category id"""
 
         self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY, catalogue_category_id="invalid")
-        self.check_catalogue_item_property_response_failed_with_message(404, "Catalogue category not found")
+        self.check_catalogue_item_property_post_response_failed_with_message(404, "Catalogue category not found")
 
     def test_create_mandatory_property_without_default_value(self):
         """
@@ -293,7 +317,7 @@ class TestCreate(CreateDSL):
                 "mandatory": True,
             }
         )
-        self.check_catalogue_item_property_response_failed_with_message(
+        self.check_catalogue_item_property_post_response_failed_with_message(
             422, "Cannot add a mandatory property without a default value"
         )
 
@@ -316,7 +340,7 @@ class TestCreate(CreateDSL):
                 "default_value": True,
             }
         )
-        self.check_catalogue_item_property_response_failed_with_validation_message(
+        self.check_catalogue_item_property_post_response_failed_with_validation_message(
             422, "Value error, default_value must be the same type as the property itself"
         )
 
@@ -337,7 +361,7 @@ class TestCreate(CreateDSL):
                 "default_value": 42,
             }
         )
-        self.check_catalogue_item_property_response_failed_with_validation_message(
+        self.check_catalogue_item_property_post_response_failed_with_validation_message(
             422, "Value error, default_value is not one of the allowed_values"
         )
 
@@ -351,7 +375,7 @@ class TestCreate(CreateDSL):
         self.post_catalogue_item_property(
             {"name": "Property B", "type": "number", "unit": "mm", "mandatory": True, "default_value": "wrong_type"}
         )
-        self.check_catalogue_item_property_response_failed_with_validation_message(
+        self.check_catalogue_item_property_post_response_failed_with_validation_message(
             422, "Value error, default_value must be the same type as the property itself"
         )
 
@@ -371,7 +395,7 @@ class TestCreate(CreateDSL):
                 "default_value": False,
             }
         )
-        self.check_catalogue_item_property_response_failed_with_validation_message(
+        self.check_catalogue_item_property_post_response_failed_with_validation_message(
             422, "Value error, allowed_values not allowed for a boolean catalogue item property 'Property B'"
         )
 
@@ -382,6 +406,193 @@ class TestCreate(CreateDSL):
 
         self.post_non_leaf_catalogue_category()
         self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_NON_MANDATORY)
-        self.check_catalogue_item_property_response_failed_with_message(
+        self.check_catalogue_item_property_post_response_failed_with_message(
             422, "Cannot add a property to a non-leaf catalogue category"
+        )
+
+    def test_create_property_with_duplicate_name(self):
+        """
+        Test adding a mandatory property with a name equal to one already existing
+        """
+
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(EXISTING_CATALOGUE_CATEGORY_PROPERTY_POST)
+        self.check_catalogue_item_property_post_response_failed_with_message(
+            422, "Duplicate catalogue item property name: Property A"
+        )
+
+
+class UpdateDSL(CreateDSL):
+    """Base class for update tests (inherits CreateDSL to gain access to posts)"""
+
+    _catalogue_item_patch_response: Response
+
+    def patch_catalogue_item_property(
+        self,
+        catalogue_item_property_patch,
+        catalogue_category_id: Optional[str] = None,
+        catalogue_item_property_id: Optional[str] = None,
+    ):
+        """Patches a posted catalogue item property"""
+        self._catalogue_item_patch_response = self.test_client.patch(
+            "/v1/catalogue-categories/"
+            f"{catalogue_category_id if catalogue_category_id else self.catalogue_category['id']}"
+            "/properties/"
+            f"{catalogue_item_property_id if catalogue_item_property_id else self.catalogue_item_property['id']}",
+            json=catalogue_item_property_patch,
+        )
+
+    def check_catalogue_item_property_patch_response_success(self, catalogue_item_property_expected):
+        """Checks the response of patching a catalogue item property succeeded as expected"""
+
+        assert self._catalogue_item_patch_response.status_code == 200
+        self.catalogue_item_property = self._catalogue_item_patch_response.json()
+        assert self.catalogue_item_property == {**catalogue_item_property_expected, "id": ANY}
+
+    def check_catalogue_item_property_patch_response_failed_with_message(self, status_code, detail):
+        """Checks the response of patching a catalogue item property failed as expected"""
+
+        assert self._catalogue_item_patch_response.status_code == status_code
+        assert self._catalogue_item_patch_response.json()["detail"] == detail
+
+
+class TestUpdate(UpdateDSL):
+    """Tests for updating a property at the catalogue category level"""
+
+    def test_update(self):
+        """
+        Test updating a property at the catalogue category level
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_PATCH)
+
+        # Check updated correctly down the tree
+        self.check_catalogue_item_property_patch_response_success(CATALOGUE_ITEM_PROPERTY_PATCH_EXPECTED)
+        self.check_catalogue_category_updated(NEW_CATALOGUE_ITEM_PROPERTY_PATCH_EXPECTED)
+        self.check_catalogue_item_updated(NEW_PROPERTY_PATCH_EXPECTED)
+        self.check_item_updated(NEW_PROPERTY_PATCH_EXPECTED)
+
+    def test_update_category_only(self):
+        """
+        Test updating a property at the catalogue category level but with an update that should leave the catalogue
+        items and items alone (i.e. only updating the allowed values)
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_PATCH_ALLOWED_VALUES_ONLY)
+
+        # Check updated correctly
+        self.check_catalogue_item_property_patch_response_success(
+            CATALOGUE_ITEM_PROPERTY_PATCH_ALLOWED_VALUES_ONLY_EXPECTED
+        )
+        self.check_catalogue_category_updated(CATALOGUE_ITEM_PROPERTY_PATCH_ALLOWED_VALUES_ONLY_EXPECTED)
+        # These are testing values are the same as they should have been prior to the patch (NEW_ is only there from
+        # the create tests)
+        self.check_catalogue_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+        self.check_item_updated(NEW_PROPERTY_MANDATORY_EXPECTED)
+
+    def test_update_non_existent_catalogue_category_id(self):
+        """
+        Test updating a property at the catalogue category level when the specified catalogue category doesn't exist
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_PATCH, catalogue_category_id=str(ObjectId()))
+
+        # Check
+        self.check_catalogue_item_property_patch_response_failed_with_message(404, "Catalogue category not found")
+
+    def test_update_invalid_catalogue_category_id(self):
+        """
+        Test updating a property at the catalogue category level when the specified catalogue category id is invalid
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_PATCH, catalogue_category_id="invalid")
+
+        # Check
+        self.check_catalogue_item_property_patch_response_failed_with_message(404, "Catalogue category not found")
+
+    def test_update_non_existent_catalogue_item_property_id(self):
+        """
+        Test updating a property at the catalogue category level when the specified catalogue item property doesn't
+        exist in the specified catalogue category
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_PATCH, catalogue_item_property_id=str(ObjectId()))
+
+        # Check
+        self.check_catalogue_item_property_patch_response_failed_with_message(404, "Catalogue item property not found")
+
+    def test_update_invalid_catalogue_item_property_id(self):
+        """
+        Test updating a property at the catalogue category level when the specified catalogue item id is invalid
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_PATCH, catalogue_item_property_id="invalid")
+
+        # Check
+        self.check_catalogue_item_property_patch_response_failed_with_message(404, "Catalogue item property not found")
+
+    def test_updating_property_to_have_duplicate_name(self):
+        """
+        Test updating a property to have a name matching another already existing one
+        """
+
+        # Setup by creating a property to update
+        self.post_catalogue_category_and_items()
+        self.post_catalogue_item_property(CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES)
+        self.check_catalogue_item_property_post_response_success(
+            CATALOGUE_ITEM_PROPERTY_POST_MANDATORY_ALLOWED_VALUES_EXPECTED
+        )
+
+        # Patch the property
+        self.patch_catalogue_item_property({"name": EXISTING_CATALOGUE_CATEGORY_PROPERTY_POST["name"]})
+        self.check_catalogue_item_property_patch_response_failed_with_message(
+            422, "Duplicate catalogue item property name: Property A"
         )

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -2,7 +2,6 @@
 Unit tests for the `CatalogueItemRepo` repository.
 """
 
-from datetime import datetime, timezone
 from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME, MOCK_PROPERTY_A_INFO
 from test.unit.repositories.test_item import FULL_ITEM_INFO
 from unittest.mock import MagicMock, patch
@@ -516,7 +515,6 @@ def test_insert_property_to_all_matching(datetime_mock, test_helpers, database_m
     session = MagicMock()
     catalogue_category_id = str(ObjectId())
     property_in = PropertyIn(**MOCK_PROPERTY_A_INFO)
-    datetime_mock.now.return_value = datetime(2024, 2, 16, 14, 0, 0, 0, tzinfo=timezone.utc)
 
     # Mock 'update_many'
     test_helpers.mock_update_many(database_mock.catalogue_items)
@@ -544,7 +542,6 @@ def test_update_names_of_all_properties_with_id(datetime_mock, test_helpers, dat
     session = MagicMock()
     property_id = str(ObjectId())
     new_property_name = "new property name"
-    datetime_mock.now.return_value = datetime(2024, 2, 16, 14, 0, 0, 0, tzinfo=timezone.utc)
 
     # Mock 'update_many'
     test_helpers.mock_update_many(database_mock.catalogue_items)

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -531,3 +531,31 @@ def test_insert_property_to_all_matching(datetime_mock, test_helpers, database_m
         },
         session=session,
     )
+
+
+@patch("inventory_management_system_api.repositories.catalogue_item.datetime")
+def test_update_names_of_all_properties_with_id(datetime_mock, test_helpers, database_mock, catalogue_item_repository):
+    """
+    Test updating the names of all properties with a given id
+
+    Verify that the `update_names_of_all_properties_with_id` method properly handles the update of
+    property names
+    """
+    session = MagicMock()
+    property_id = str(ObjectId())
+    new_property_name = "new property name"
+    datetime_mock.now.return_value = datetime(2024, 2, 16, 14, 0, 0, 0, tzinfo=timezone.utc)
+
+    # Mock 'update_many'
+    test_helpers.mock_update_many(database_mock.catalogue_items)
+
+    catalogue_item_repository.update_names_of_all_properties_with_id(property_id, new_property_name, session=session)
+
+    database_mock.catalogue_items.update_many.assert_called_once_with(
+        {"properties._id": CustomObjectId(property_id)},
+        {
+            "$set": {"properties.$[elem].name": new_property_name, "modified_time": datetime_mock.now.return_value},
+        },
+        array_filters=[{"elem._id": CustomObjectId(property_id)}],
+        session=session,
+    )

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -618,3 +618,37 @@ def test_insert_property_to_all_in(datetime_mock, test_helpers, database_mock, i
         },
         session=session,
     )
+
+
+# pylint:disable=duplicate-code
+
+
+@patch("inventory_management_system_api.repositories.item.datetime")
+def test_update_names_of_all_properties_with_id(datetime_mock, test_helpers, database_mock, item_repository):
+    """
+    Test updating the names of all properties with a given id
+
+    Verify that the `update_names_of_all_properties_with_id` method properly handles the update of
+    property names
+    """
+    session = MagicMock()
+    property_id = str(ObjectId())
+    new_property_name = "new property name"
+    datetime_mock.now.return_value = datetime(2024, 2, 16, 14, 0, 0, 0, tzinfo=timezone.utc)
+
+    # Mock 'update_many'
+    test_helpers.mock_update_many(database_mock.items)
+
+    item_repository.update_names_of_all_properties_with_id(property_id, new_property_name, session=session)
+
+    database_mock.items.update_many.assert_called_once_with(
+        {"properties._id": CustomObjectId(property_id)},
+        {
+            "$set": {"properties.$[elem].name": new_property_name, "modified_time": datetime_mock.now.return_value},
+        },
+        array_filters=[{"elem._id": CustomObjectId(property_id)}],
+        session=session,
+    )
+
+
+# pylint:enable=duplicate-code

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -632,7 +632,6 @@ def test_update_names_of_all_properties_with_id(datetime_mock, test_helpers, dat
     session = MagicMock()
     property_id = str(ObjectId())
     new_property_name = "new property name"
-    datetime_mock.now.return_value = datetime(2024, 2, 16, 14, 0, 0, 0, tzinfo=timezone.utc)
 
     # Mock 'update_many'
     test_helpers.mock_update_many(database_mock.items)

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -10,6 +10,7 @@ from bson import ObjectId
 
 from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
 from inventory_management_system_api.models.catalogue_category import (
+    AllowedValues,
     CatalogueCategoryOut,
     CatalogueItemPropertyIn,
     CatalogueItemPropertyOut,
@@ -263,7 +264,12 @@ def test_update(
         name="Property Name", allowed_values={"type": "list", "values": [100, 500, 1000, 2000]}
     )
     stored_catalogue_item_property = CatalogueItemPropertyOut(
-        id=catalogue_item_property_id, name="Property A", type="number", unit="mm", mandatory=True
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100]),
     )
     stored_catalogue_category = CatalogueCategoryOut(
         id=catalogue_category_id,

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -624,7 +624,10 @@ def test_update_allowed_values_removing_element(
         catalogue_category_property_service.update(
             catalogue_category_id, catalogue_item_property_id, catalogue_item_property
         )
-    assert str(exc.value) == "Cannot modify existing `allowed_values`, you may only add more"
+    assert (
+        str(exc.value)
+        == "Cannot modify existing values inside allowed_values of type 'list', you may only add more values"
+    )
 
     # Ensure no updates actually called
     catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
@@ -677,7 +680,10 @@ def test_update_allowed_values_modifying_element(
         catalogue_category_property_service.update(
             catalogue_category_id, catalogue_item_property_id, catalogue_item_property
         )
-    assert str(exc.value) == "Cannot modify existing `allowed_values`, you may only add more"
+    assert (
+        str(exc.value)
+        == "Cannot modify existing values inside allowed_values of type 'list', you may only add more values"
+    )
 
     # Ensure no updates actually called
     catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -315,3 +315,439 @@ def test_update(
         updated_catalogue_item_property
         == catalogue_category_repository_mock.update_catalogue_item_property.return_value
     )
+
+
+@patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
+def test_update_category_only(
+    mongodb_client_mock,
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method properly handles an update that doesn't require any propagation through
+    catalogue items and items (in this case only modifying the allowed_values)
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        allowed_values={"type": "list", "values": [100, 500, 1000, 2000]}
+    )
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100]),
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    updated_catalogue_item_property = catalogue_category_property_service.update(
+        catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+    )
+
+    # Start of transaction
+    session = mongodb_client_mock.start_session.return_value.__enter__.return_value
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_called_once_with(
+        catalogue_category_id,
+        catalogue_item_property_id,
+        CatalogueItemPropertyIn(
+            **{**stored_catalogue_item_property.model_dump(), **catalogue_item_property.model_dump(exclude_unset=True)}
+        ),
+        session=session,
+    )
+
+    # Ensure changes aren't propagated
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+    # Final output
+    assert (
+        updated_catalogue_item_property
+        == catalogue_category_repository_mock.update_catalogue_item_property.return_value
+    )
+
+
+def test_update_with_missing_catalogue_category(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method raises a MissingRecordError when the catalogue category with the given
+    catalogue_category_id doesn't exist
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        name="Property Name", allowed_values={"type": "list", "values": [100, 500, 1000, 2000]}
+    )
+    stored_catalogue_category = None
+
+    # Mock the stored catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(MissingRecordError) as exc:
+        catalogue_category_property_service.update(
+            catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+        )
+    assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
+
+    # Ensure no updates actually called
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+
+def test_update_with_missing_catalogue_item_property(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method raises a MissingRecordError when the catalogue item property with the given
+    catalogue_item_property_id doesn't exist
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        name="Property Name", allowed_values={"type": "list", "values": [100, 500, 1000, 2000]}
+    )
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=str(ObjectId()),
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100]),
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(MissingRecordError) as exc:
+        catalogue_category_property_service.update(
+            catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+        )
+    assert str(exc.value) == f"No catalogue item property found with ID: {catalogue_item_property_id}"
+
+    # Ensure no updates actually called
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+
+def test_update_allowed_values_from_none_to_value(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method raises a InvalidActionError when attempting to change a properties' allowed_values
+    from None to a value
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        name="Property Name", allowed_values={"type": "list", "values": [100, 500, 1000, 2000]}
+    )
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=None,
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_property_service.update(
+            catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+        )
+    assert str(exc.value) == "Cannot add allowed_values to an existing catalogue item property"
+
+    # Ensure no updates actually called
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+
+def test_update_allowed_values_from_value_to_none(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method raises a InvalidActionError when attempting to change a properties' allowed_values
+    from a value to None
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(name="Property Name", allowed_values=None)
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100]),
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_property_service.update(
+            catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+        )
+    assert str(exc.value) == "Cannot remove allowed_values from an existing catalogue item property"
+
+    # Ensure no updates actually called
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+
+def test_update_allowed_values_removing_element(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method raises a InvalidActionError when attempting to change a properties' allowed_values
+    to have one fewer element
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        name="Property Name", allowed_values={"type": "list", "values": [100, 500, 1000]}
+    )
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100, 500, 1000, 2000]),
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_property_service.update(
+            catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+        )
+    assert str(exc.value) == "Cannot modify existing `allowed_values`, you may only add more"
+
+    # Ensure no updates actually called
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+
+def test_update_allowed_values_modifying_element(
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method raises a InvalidActionError when attempting to change a properties' allowed_values
+    by changing one element
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        name="Property Name", allowed_values={"type": "list", "values": [100, 500, 1000, 2000]}
+    )
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100, 500, 1200, 2000]),
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    with pytest.raises(InvalidActionError) as exc:
+        catalogue_category_property_service.update(
+            catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+        )
+    assert str(exc.value) == "Cannot modify existing `allowed_values`, you may only add more"
+
+    # Ensure no updates actually called
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_not_called()
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+
+@patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")
+def test_update_adding_allowed_values(
+    mongodb_client_mock,
+    test_helpers,
+    catalogue_category_repository_mock,
+    catalogue_item_repository_mock,
+    item_repository_mock,
+    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+    catalogue_category_property_service,
+):
+    """
+    Test updating a property at the catalogue category level
+
+    Verify that the `update` method allows an allowed_values list to be extended
+    """
+    catalogue_category_id = str(ObjectId())
+    catalogue_item_property_id = str(ObjectId())
+    catalogue_item_property = CatalogueItemPropertyPatchRequestSchema(
+        allowed_values={"type": "list", "values": [100, 500, 1000, 2000, 3000, 4000]}
+    )
+    stored_catalogue_item_property = CatalogueItemPropertyOut(
+        id=catalogue_item_property_id,
+        name="Property A",
+        type="number",
+        unit="mm",
+        mandatory=True,
+        allowed_values=AllowedValues(type="list", values=[100]),
+    )
+    stored_catalogue_category = CatalogueCategoryOut(
+        id=catalogue_category_id,
+        name="Category A",
+        code="category-a",
+        is_leaf=True,
+        parent_id=None,
+        catalogue_item_properties=[stored_catalogue_item_property],
+        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+    )
+
+    # Mock the stored catalogue category to one without a property with the same name
+    test_helpers.mock_get(catalogue_category_repository_mock, stored_catalogue_category)
+
+    updated_catalogue_item_property = catalogue_category_property_service.update(
+        catalogue_category_id, catalogue_item_property_id, catalogue_item_property
+    )
+
+    # Start of transaction
+    session = mongodb_client_mock.start_session.return_value.__enter__.return_value
+    catalogue_category_repository_mock.update_catalogue_item_property.assert_called_once_with(
+        catalogue_category_id,
+        catalogue_item_property_id,
+        CatalogueItemPropertyIn(
+            **{**stored_catalogue_item_property.model_dump(), **catalogue_item_property.model_dump(exclude_unset=True)}
+        ),
+        session=session,
+    )
+
+    # Ensure changes aren't propagated
+    catalogue_item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+    item_repository_mock.update_names_of_all_properties_with_id.assert_not_called()
+
+    # Final output
+    assert (
+        updated_catalogue_item_property
+        == catalogue_category_repository_mock.update_catalogue_item_property.return_value
+    )


### PR DESCRIPTION
## Description
Adds a patch endpoint for properties at the catalogue category level at
`/v1/catalogue-categories/{catalogue_category_id}/properties/{catalogue_item_property_id}`.

Changes to name are propagated through catalogue items and items, an allowed values list is only allowed to add items not change its type, remove them or add them if they weren't already (matches current front end implementation). All `modified_time`'s of the modified entities are are also updated.

Should just be missing e2e tests now.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #266
