### PR TITLE
Add check for duplicate values in an allowed_values list #272

### DIFF
--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -114,8 +114,11 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
                 )
             # Check the type of allowed_values being used and validate them appropriately
             if isinstance(allowed_values, AllowedValuesListSchema):
-                # List type should have all values the same type
+                # List type should have all values the same type and no duplicate values
+                seen_values = set()
+
                 for allowed_value in allowed_values.values:
+                    # Ensure the value is the correct type
                     if not CatalogueCategoryPostRequestPropertySchema.is_valid_property_type(
                         expected_property_type=catalogue_item_property_data["type"], property_value=allowed_value
                     ):
@@ -123,6 +126,16 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
                             "allowed_values of type 'list' must only contain values of the same type as the property "
                             "itself"
                         )
+
+                    # Ensure the value isn't duplicated
+                    seen_value = (
+                        allowed_value
+                        if catalogue_item_property_data["type"] != CatalogueItemPropertyType.STRING
+                        else allowed_value.lower()
+                    )
+                    if seen_value in seen_values:
+                        raise ValueError(f"allowed_values of type 'list' contains a duplicate value: {allowed_value}")
+                    seen_values.add(seen_value)
 
     @field_validator("allowed_values")
     @classmethod

--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -98,12 +98,13 @@ class CatalogueCategoryPostRequestPropertySchema(BaseModel):
         """
         Checks allowed_values against its parent catalogue item property raising an error if its invalid
 
-        It checks if the `type` of the catalogue item property is a `boolean` and if `allowed_values` has been specified
-        and raises a `ValueError` if this is the case. In the case the `allowed_values` is as `list` type, then also
-        verifies all of the values are of the same `type` and raises a ValueError if not.
-
         :param allowed_values: The value of the `allowed_values` field.
         :param catalogue_item_property_data: Catalogue item property data to validate the allowed values against.
+        :raises ValueError:
+            - If the allowed_values has been given a value and the catalogue item property type is a `boolean`
+            - If the allowed_values is of type 'list' and 'values' contains any with a different type to the catalogue
+              item property type
+            - If the allowed_values is of type 'list' and 'values' contains any duplicates
         """
         if allowed_values is not None and "type" in catalogue_item_property_data:
             # Ensure the type is not boolean

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -409,6 +409,60 @@ def test_create_catalogue_category_with_properties_with_invalid_allowed_values_l
     )
 
 
+def test_create_catalogue_category_with_properties_with_invalid_allowed_values_list_duplicate_number(test_client):
+    """
+    Test creating a catalogue category with a number property containing an allowed_values list with a duplicate
+    number value in it
+    """
+    response = test_client.post(
+        "/v1/catalogue-categories",
+        json={
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
+            "catalogue_item_properties": [
+                {
+                    "name": "Property A",
+                    "type": "number",
+                    "mandatory": False,
+                    "allowed_values": {"type": "list", "values": [42, 10.2, 12, 42]},
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Value error, allowed_values of type 'list' contains a duplicate value: 42"
+    )
+
+
+def test_create_catalogue_category_with_properties_with_invalid_allowed_values_list_duplicate_string(test_client):
+    """
+    Test creating a catalogue category with a string property containing an allowed_values list with a duplicate
+    string value in it
+    """
+    response = test_client.post(
+        "/v1/catalogue-categories",
+        json={
+            **CATALOGUE_CATEGORY_POST_ALLOWED_VALUES,
+            "catalogue_item_properties": [
+                {
+                    "name": "Property A",
+                    "type": "string",
+                    "mandatory": False,
+                    "allowed_values": {"type": "list", "values": ["value1", "value2", "value3", "Value2"]},
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Value error, allowed_values of type 'list' contains a duplicate value: Value2"
+    )
+
+
 def test_create_catalogue_category_with_properties_with_invalid_allowed_values_list_boolean(test_client):
     """
     Test creating a catalogue category with a boolean property containing an allowed_values list
@@ -1342,6 +1396,67 @@ def test_partial_update_catalogue_category_modify_catalogue_item_property_to_hav
     assert (
         response.json()["detail"][0]["msg"]
         == "Value error, allowed_values of type 'list' must only contain values of the same type as the property itself"
+    )
+
+
+def test_partial_update_catalogue_category_modify_property_to_have_invalid_allowed_values_list_duplicate_number(
+    test_client,
+):
+    """
+    Test modifying catalogue item properties to have a number property containing an allowed_values list with a
+    duplicate number value
+    """
+    catalogue_item_properties = [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "string", "unit": None, "mandatory": False},
+    ]
+    catalogue_category_post = {
+        **CATALOGUE_CATEGORY_POST_B,
+        "catalogue_item_properties": catalogue_item_properties,
+    }
+    response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
+
+    catalogue_item_properties[0]["allowed_values"] = {"type": "list", "values": [42, 10.2, 12, 42]}
+    catalogue_item_properties[1]["allowed_values"] = {"type": "list", "values": ["red", "green"]}
+    catalogue_category_patch = {"catalogue_item_properties": catalogue_item_properties}
+    response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Value error, allowed_values of type 'list' contains a duplicate value: 42"
+    )
+
+
+def test_partial_update_catalogue_category_modify_property_to_have_invalid_allowed_values_list_duplicate_string(
+    test_client,
+):
+    """
+    Test modifying catalogue item properties to have a string property containing an allowed_values list with a
+    duplicate string value
+    """
+    catalogue_item_properties = [
+        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+        {"name": "Property B", "type": "string", "unit": None, "mandatory": False},
+    ]
+    catalogue_category_post = {
+        **CATALOGUE_CATEGORY_POST_B,
+        "catalogue_item_properties": catalogue_item_properties,
+    }
+    response = test_client.post("/v1/catalogue-categories", json=catalogue_category_post)
+
+    catalogue_item_properties[0]["allowed_values"] = {"type": "list", "values": [2, 4, 6]}
+    catalogue_item_properties[1]["allowed_values"] = {
+        "type": "list",
+        "values": ["value1", "value2", "value3", "value2"],
+    }
+    catalogue_category_patch = {"catalogue_item_properties": catalogue_item_properties}
+    response = test_client.patch(f"/v1/catalogue-categories/{response.json()['id']}", json=catalogue_category_patch)
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"][0]["msg"]
+        == "Value error, allowed_values of type 'list' contains a duplicate value: value2"
     )
 
 


### PR DESCRIPTION
## Description
Checks for catalogue category post and patch, and the new properties post and patch. String values are converted to lower case first like the front end check so two values with different capitalisation are treated as duplicates.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #272 
