### PR TITLE
Changes to production Docker image

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -24,5 +24,5 @@ RUN set -eux; \
 
 USER inventory-management-system-api
 
-CMD ["uvicorn", "inventory_management_system_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "inventory_management_system_api.main:app", "--app-dir", "/inventory-management-system-api-run", "--host", "0.0.0.0", "--port", "8000"]
 EXPOSE 8000

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,7 +5,6 @@ WORKDIR /inventory-management-system-api-run
 COPY README.md pyproject.toml ./
 # Copy inventory_management_system_api source files
 COPY inventory_management_system_api/ inventory_management_system_api/
-COPY logs/ logs/
 
 RUN set -eux; \
     \
@@ -17,10 +16,7 @@ RUN set -eux; \
     \
     # Create a non-root user to run as \
     addgroup -S inventory-management-system-api; \
-    adduser -S -D -G inventory-management-system-api -H -h /inventory-management-system-api-run inventory-management-system-api; \
-    \
-    # Change ownership of logs/ - app will need to write log files to it \
-    chown -R inventory-management-system-api:inventory-management-system-api logs/;
+    adduser -S -D -G inventory-management-system-api -H -h /inventory-management-system-api-run inventory-management-system-api;
 
 USER inventory-management-system-api
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ production)!
    is only needed if JWT Auth is enabled):
 
    ```bash
-   docker run -p 8000:8000 --name inventory_management_system_api_container -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub -v ./logs:/inventory-management-system-api-run/logs inventory_management_system_api_image
+   docker run -p 8000:8000 --name inventory_management_system_api_container -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub inventory_management_system_api_image
    ```
 
    or with values for the environment variables:
 
    ```bash
-   docker run -p 8000:8000 --name inventory_management_system_api_container --env DATABASE__NAME=test-ims -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub -v ./logs:/inventory-management-system-api-run/logs inventory_management_system_api_image
+   docker run -p 8000:8000 --name inventory_management_system_api_container --env DATABASE__NAME=test-ims -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub inventory_management_system_api_image
    ```
 
    The microservice should now be running inside Docker at http://localhost:8000 and its Swagger UI could be accessed
@@ -93,35 +93,28 @@ production)!
 
 Use the `Dockerfile.prod` to run just the application itself in a container. This can be used for production.
 
-1. While in root of the project directory, change the permissions of the `logs` directory so that it is writable by
-   other users. This allows the container to save the application logs to it.
-
-   ```bash
-   sudo chmod -R 0777 logs/
-   ```
-
-2. Build an image using the `Dockerfile.prod` from the root of the project directory:
+1. Build an image using the `Dockerfile.prod` from the root of the project directory:
 
    ```bash
    docker build -f Dockerfile.prod -t inventory_management_system_api_image .
    ```
 
-3. Start the container using the image built and map it to port `8000` locally:
+2. Start the container using the image built and map it to port `8000` locally:
 
    ```bash
-   docker run -p 8000:8000 --name inventory_management_system_api_container -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub -v ./logs:/inventory-management-system-api-run/logs inventory_management_system_api_image
+   docker run -p 8000:8000 --name inventory_management_system_api_container -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub inventory_management_system_api_image
    ```
 
    or with values for the environment variables:
 
    ```bash
-   docker run -p 8000:8000 --name inventory_management_system_api_container --env DATABASE__NAME=test-ims -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub -v ./logs:/inventory-management-system-api-run/logs inventory_management_system_api_image
+   docker run -p 8000:8000 --name inventory_management_system_api_container --env DATABASE__NAME=test-ims -v ./keys/jwt-key.pub:/inventory-management-system-api-run/keys/jwt-key.pub inventory_management_system_api_image
    ```
 
    The microservice should now be running inside Docker at http://localhost:8000 and its Swagger UI could be accessed
    at http://localhost:8000/docs.
 
-4. Follow the [post setup instructions](#post-setup-instructions)
+3. Follow the [post setup instructions](#post-setup-instructions)
 
 ### Local Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     volumes:
       - ./inventory_management_system_api:/inventory-management-system-api-run/inventory_management_system_api
       - ./keys:/inventory-management-system-api-run/keys
-      - ./logs:/inventory-management-system-api-run/logs
     ports:
       - 8000:8000
     restart: on-failure

--- a/inventory_management_system_api/logging.example.ini
+++ b/inventory_management_system_api/logging.example.ini
@@ -25,6 +25,4 @@ formatter=consoleFormatter
 args=(sys.stdout,)
 
 [formatter_consoleFormatter]
-class=uvicorn.logging.ColourizedFormatter
-format={levelprefix}{message}
-style={
+format=[%(asctime)s]  %(module)s:%(filename)s:%(funcName)s:%(lineno)d  %(levelname)s - %(message)s

--- a/inventory_management_system_api/logging.example.ini
+++ b/inventory_management_system_api/logging.example.ini
@@ -2,35 +2,27 @@
 keys=root,uvicorn.access
 
 [handlers]
-keys=fileHandler,consoleHandler
+keys=consoleHandler
 
 [formatters]
-keys=fileFormatter,consoleFormatter
+keys=consoleFormatter
 
 [logger_root]
 level=DEBUG
-handlers=fileHandler,consoleHandler
+handlers=consoleHandler
 qualname=root
 propagate=0
 
 [logger_uvicorn.access]
 level=INFO
-handlers=fileHandler,consoleHandler
+handlers=consoleHandler
 qualname=uvicorn.access
 propagate=0
-
-[handler_fileHandler]
-class=logging.handlers.TimedRotatingFileHandler
-formatter=fileFormatter
-args=('./logs/inventory-management-system-api.log', 'D', 1, 20,)
 
 [handler_consoleHandler]
 class=StreamHandler
 formatter=consoleFormatter
 args=(sys.stdout,)
-
-[formatter_fileFormatter]
-format=[%(asctime)s]  %(module)s:%(filename)s:%(funcName)s:%(lineno)d  %(levelname)s - %(message)s
 
 [formatter_consoleFormatter]
 class=uvicorn.logging.ColourizedFormatter


### PR DESCRIPTION
## Description
This PR fixes the issue reported in #277 so any custom images created using the prod Docker image from Harbor as the base image while being in a different working directory would not result in any issues now. It also addresses #278 so the default logging in the prod Docker image will be to the console.

## Testing instructions
- [x] Review code
- [x] Check Actions build
- [x] Start a container using prod Docker image from this PR and ensure that it logs to the console only by default
- [x] Start a container using the Dockerfile below and ensure that the fix for #277 is working and app logging can be changed to log to file

```Dockerfile
# Use the Inventory Management System API image on Harbor as the base image
FROM harbor.stfc.ac.uk/inventory-management-system/ims-api:pr-279

WORKDIR /inventory-management-system-api-run

USER root

RUN set -eux; \
    \
    mkdir logs; \
    \
    # Change ownership of logs/ - app will need to write log files to it \
    chown -R inventory-management-system-api:inventory-management-system-api logs/;

WORKDIR /inventory-management-system-api-run/inventory_management_system_api

# Copy the custom logging.ini file
COPY --chown=inventory-management-system-api:inventory-management-system-api logging.ini ./logging.ini

USER inventory-management-system-api
```

## Agile board tracking
closes #277 
closes #278 