### PR TITLE
Bump python from 3.12.3-alpine3.19 to 3.12.3-alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.3-alpine3.19@sha256:ef097620baf1272e38264207003b0982285da3236a20ed829bf6bbf1e85fe3cb
+FROM python:3.12.3-alpine3.20@sha256:53cab1eabac71d6160eeabe09fd3144de789f75de62b9833e49f67534edc547e
 
 WORKDIR /inventory-management-system-api-run
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.12.3-alpine3.19@sha256:ef097620baf1272e38264207003b0982285da3236a20ed829bf6bbf1e85fe3cb
+FROM python:3.12.3-alpine3.20@sha256:53cab1eabac71d6160eeabe09fd3144de789f75de62b9833e49f67534edc547e
 
 WORKDIR /inventory-management-system-api-run
 


### PR DESCRIPTION
## Description
Bumps python from 3.12.3-alpine3.19 to 3.12.3-alpine3.20.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build