### PR TITLE
Handling sensitive config values

### DIFF
--- a/inventory_management_system_api/core/config.py
+++ b/inventory_management_system_api/core/config.py
@@ -5,7 +5,7 @@ Module for the overall configuration for the application.
 from pathlib import Path
 from typing import Optional, List
 
-from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import SettingsConfigDict, BaseSettings
 
@@ -63,6 +63,8 @@ class DatabaseConfig(BaseModel):
     port: SecretStr
     name: SecretStr
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
 
 class Config(BaseSettings):
     """
@@ -77,7 +79,10 @@ class Config(BaseSettings):
     authentication: AuthenticationConfig
     database: DatabaseConfig
     model_config = SettingsConfigDict(
-        env_file=Path(__file__).parent.parent / ".env", env_file_encoding="utf-8", env_nested_delimiter="__"
+        env_file=Path(__file__).parent.parent / ".env",
+        env_file_encoding="utf-8",
+        env_nested_delimiter="__",
+        hide_input_in_errors=True,
     )
 
 

--- a/inventory_management_system_api/core/config.py
+++ b/inventory_management_system_api/core/config.py
@@ -5,7 +5,7 @@ Module for the overall configuration for the application.
 from pathlib import Path
 from typing import Optional, List
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import SettingsConfigDict, BaseSettings
 
@@ -56,12 +56,12 @@ class DatabaseConfig(BaseModel):
     Configuration model for the database.
     """
 
-    protocol: str
-    username: str
-    password: str
-    hostname: str
-    port: int
-    name: str
+    protocol: SecretStr
+    username: SecretStr
+    password: SecretStr
+    hostname: SecretStr
+    port: SecretStr
+    name: SecretStr
 
 
 class Config(BaseSettings):

--- a/inventory_management_system_api/core/database.py
+++ b/inventory_management_system_api/core/database.py
@@ -9,7 +9,9 @@ from inventory_management_system_api.core.config import config
 
 db_config = config.database
 mongodb_client = MongoClient(
-    f"{db_config.protocol}://{db_config.username}:{db_config.password}@{db_config.hostname}:{db_config.port}",
+    f"{db_config.protocol.get_secret_value()}://{db_config.username.get_secret_value()}"
+    f":{db_config.password.get_secret_value()}@{db_config.hostname.get_secret_value()}"
+    f":{db_config.port.get_secret_value()}",
     tz_aware=True,
 )
 
@@ -20,4 +22,4 @@ def get_database() -> Database:
 
     :return: The MongoDB database object.
     """
-    return mongodb_client[db_config.name]
+    return mongodb_client[db_config.name.get_secret_value()]

--- a/inventory_management_system_api/main.py
+++ b/inventory_management_system_api/main.py
@@ -5,7 +5,7 @@ Main module contains the API entrypoint.
 import logging
 
 from fastapi import Depends, FastAPI, Request, status
-from fastapi.encoders import jsonable_encoder
+from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -44,7 +44,7 @@ async def custom_general_exception_handler(_: Request, exc: Exception) -> JSONRe
 
 
 @app.exception_handler(RequestValidationError)
-async def custom_validation_exception_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
+async def custom_validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     """
     Custom exception handler for FastAPI to handle `RequestValidationError`.
 
@@ -52,15 +52,12 @@ async def custom_validation_exception_handler(_: Request, exc: RequestValidation
     `RequestValidationError` is raised during request parsing or validation, this handler will be triggered to log the
     error and call `request_validation_exception_handler` to return an appropriate response.
 
-    :param _: Unused
+    :param request: The incoming HTTP request that caused the validation error.
     :param exc: The exception object representing the validation error.
     :return: A JSON response with validation error details.
     """
-    # Exclude input as it may contain sensitive information which we do not want to log or return back to user
-    detail = {"detail": jsonable_encoder(exc.errors(), exclude={"input"})}
-    # The traceback here contains the exception message which includes the input hence it is been excluded.
-    logger.exception(detail, exc_info=False)
-    return JSONResponse(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=detail)
+    logger.exception(exc)
+    return await request_validation_exception_handler(request, exc)
 
 
 def get_router_dependencies() -> list:


### PR DESCRIPTION
## Description
This PR changes the types of the `DatabaseConfig` Pydantic class fields from `str` to `SecretStr`. This means that they will be serialised to ``**********`` when accessing their values, or using `.model_dump()`, `.dict()`, or `.json()` (more info [here](https://docs.pydantic.dev/latest/examples/secrets/)). `get_secret_value()` should be used to access the secret value.

It also sets `hide_input_in_errors` on the models to `True` so that the input values can be hidden when `ValidationError` is raised during the validation.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Ensure that input values are not part of the error messages and logs (A validation error can be triggered by supplying a wrong type of value for a config or not supplying a value for a mandatory config)