### PR TITLE
Refactor CatalogueCategoryService unit tests #308

### DIFF
--- a/inventory_management_system_api/services/catalogue_category.py
+++ b/inventory_management_system_api/services/catalogue_category.py
@@ -82,14 +82,6 @@ class CatalogueCategoryService:
             )
         )
 
-    def delete(self, catalogue_category_id: str) -> None:
-        """
-        Delete a catalogue category by its ID.
-
-        :param catalogue_category_id: The ID of the catalogue category to delete.
-        """
-        return self._catalogue_category_repository.delete(catalogue_category_id)
-
     def get(self, catalogue_category_id: str) -> Optional[CatalogueCategoryOut]:
         """
         Retrieve a catalogue category by its ID.
@@ -167,6 +159,14 @@ class CatalogueCategoryService:
         return self._catalogue_category_repository.update(
             catalogue_category_id, CatalogueCategoryIn(**{**stored_catalogue_category.model_dump(), **update_data})
         )
+
+    def delete(self, catalogue_category_id: str) -> None:
+        """
+        Delete a catalogue category by its ID.
+
+        :param catalogue_category_id: The ID of the catalogue category to delete.
+        """
+        return self._catalogue_category_repository.delete(catalogue_category_id)
 
     def _add_property_unit_values(
         self,

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -9,7 +9,7 @@ _POST_DATA - Is for a `PostSchema` schema
 _IN_DATA - Is for an `In` model
 _GET_DATA - Is for an entity schema - Used in assertions for e2e tests
 _DATA - Is none of the above - likely to be used in post requests as they are likely identical, only
-        with the id missing so that they can be added later e.g. for pairing up units that aren't
+        with some ids missing so that they can be added later e.g. for pairing up units that aren't
         known before hand
 """
 

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -33,14 +33,12 @@ CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A = {
     "name": "Category A",
     "is_leaf": False,
     "parent_id": None,
-    "properties": [],
 }
 
 CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B = {
     "name": "Category B",
     "is_leaf": False,
     "parent_id": None,
-    "properties": [],
 }
 
 CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A = {
@@ -96,8 +94,15 @@ CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM = {
     ],
 }
 
+CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES = {
+    "name": "Leaf Category No Parent No Properties",
+    "is_leaf": True,
+    "parent_id": None,
+    "properties": [],
+}
+
 CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM = {
-    "name": "Category A",
+    "name": "Leaf Category No Parent With Properties",
     "is_leaf": True,
     "parent_id": None,
     "properties": [

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -8,9 +8,14 @@ to others.
 _POST_DATA - Is for a `PostSchema` schema
 _IN_DATA - Is for an `In` model
 _GET_DATA - Is for an entity schema - Used in assertions for e2e tests
+_DATA - Is none of the above - likely to be used in post requests as they are likely identical, only
+        with the id missing so that they can be added later e.g. for pairing up units that aren't
+        known before hand
 """
 
 from unittest.mock import ANY
+
+from bson import ObjectId
 
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryPropertyIn
 
@@ -18,22 +23,34 @@ from inventory_management_system_api.models.catalogue_category import CatalogueC
 # at runtime
 CREATED_MODIFIED_GET_DATA_EXPECTED = {"created_time": ANY, "modified_time": ANY}
 
+# --------------------------------- UNITS ---------------------------------
+
+UNIT_IN_DATA_MM = {"value": "mm", "code": "mm"}
+
 # --------------------------------- CATALOGUE CATEGORIES ---------------------------------
 
-CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A = {
+CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A = {
     "name": "Category A",
-    "code": "category-a",
     "is_leaf": False,
     "parent_id": None,
     "properties": [],
 }
 
-CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B = {
+CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B = {
     "name": "Category B",
-    "code": "catagory-b",
     "is_leaf": False,
     "parent_id": None,
     "properties": [],
+}
+
+CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A = {
+    **CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+    "code": "category-a",
+}
+
+CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B = {
+    **CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+    "code": "category-b",
 }
 
 CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES = {
@@ -44,27 +61,48 @@ CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES = {
     "properties": [],
 }
 
-CATALOGUE_CATEGORY_PROPERTY_BOOLEAN_MANDATORY_WITHOUT_UNIT = {
+
+CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT = {
     "name": "Mandatory Boolean Property Without Unit",
     "type": "boolean",
     "mandatory": True,
 }
 
-CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT = {
+CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT = {
     "name": "Non Mandatory Number Property With Unit",
     "type": "number",
     "unit": "mm",
     "mandatory": False,
 }
 
-CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES = {
+CATALOGUE_CATEGORY_PROPERTY_IN_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT = {
+    **CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT
+}
+
+CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT = {
+    **CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
+    "unit_id": str(ObjectId()),
+}
+
+# Put _MM at end to signify what units this data would require
+CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM = {
     "name": "Leaf Category No Parent With Properties",
     "code": "leaf-category-no-parent-with-properties",
     "is_leaf": True,
     "parent_id": None,
     "properties": [
-        CatalogueCategoryPropertyIn(**CATALOGUE_CATEGORY_PROPERTY_BOOLEAN_MANDATORY_WITHOUT_UNIT),
-        CatalogueCategoryPropertyIn(**CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT),
+        CatalogueCategoryPropertyIn(**CATALOGUE_CATEGORY_PROPERTY_IN_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT),
+        CatalogueCategoryPropertyIn(**CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT),
+    ],
+}
+
+CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM = {
+    "name": "Category A",
+    "is_leaf": True,
+    "parent_id": None,
+    "properties": [
+        CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT,
+        CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
     ],
 }
 

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -44,7 +44,7 @@ from inventory_management_system_api.repositories.catalogue_category import Cata
 
 
 class CatalogueCategoryRepoDSL:
-    """Base class for CatalogueCategoryRepo unit tests"""
+    """Base class for `CatalogueCategoryRepo` unit tests"""
 
     # pylint:disable=too-many-instance-attributes
     mock_database: Mock
@@ -109,7 +109,7 @@ class CatalogueCategoryRepoDSL:
 
 
 class CreateDSL(CatalogueCategoryRepoDSL):
-    """Base class for create tests"""
+    """Base class for `create` tests"""
 
     _catalogue_category_in: CatalogueCategoryIn
     _expected_catalogue_category_out: CatalogueCategoryOut
@@ -297,7 +297,7 @@ class TestCreate(CreateDSL):
 
 
 class GetDSL(CatalogueCategoryRepoDSL):
-    """Base class for get tests"""
+    """Base class for `get` tests"""
 
     _obtained_catalogue_category_id: str
     _expected_catalogue_category_out: Optional[CatalogueCategoryOut]
@@ -391,7 +391,7 @@ class TestGet(GetDSL):
 
 
 class GetBreadcrumbsDSL(CatalogueCategoryRepoDSL):
-    """Base class for breadcrumbs tests"""
+    """Base class for `get_breadcrumbs` tests"""
 
     _breadcrumbs_query_result: list[dict]
     _mock_aggregation_pipeline = MagicMock()
@@ -452,7 +452,7 @@ class TestGetBreadcrumbs(GetBreadcrumbsDSL):
 
 
 class ListDSL(CatalogueCategoryRepoDSL):
-    """Base class for list tests"""
+    """Base class for `list` tests"""
 
     _expected_catalogue_categories_out: list[CatalogueCategoryOut]
     _parent_id_filter: Optional[str]
@@ -546,7 +546,7 @@ class TestList(ListDSL):
 
 
 class UpdateDSL(CatalogueCategoryRepoDSL):
-    """Base class for update tests"""
+    """Base class for `update` tests"""
 
     # pylint:disable=too-many-instance-attributes
     _catalogue_category_in: CatalogueCategoryIn
@@ -882,7 +882,7 @@ class TestUpdate(UpdateDSL):
 
 
 class HasChildElementsDSL(CatalogueCategoryRepoDSL):
-    """Base class for has_child_elements tests"""
+    """Base class for `has_child_elements` tests"""
 
     _has_child_elements_catalogue_category_id: str
     _has_child_elements_result: bool
@@ -940,7 +940,7 @@ class TestHasChildElements(HasChildElementsDSL):
 
 
 class DeleteDSL(CatalogueCategoryRepoDSL):
-    """Base class for delete tests"""
+    """Base class for `delete` tests"""
 
     _delete_catalogue_category_id: str
     _delete_exception: pytest.ExceptionInfo
@@ -1054,7 +1054,7 @@ class TestDelete(DeleteDSL):
 
 
 class CreatePropertyDSL(CatalogueCategoryRepoDSL):
-    """Base class for create property tests"""
+    """Base class for `create_property` tests"""
 
     _mock_datetime: Mock
     _property_in: CatalogueCategoryPropertyIn
@@ -1146,7 +1146,7 @@ class TestCreateProperty(CreatePropertyDSL):
 
 
 class UpdatePropertyDSL(CreatePropertyDSL):
-    """Base class for update property tests"""
+    """Base class for `update_property` tests"""
 
     _updated_property: CatalogueCategoryOut
     _property_id: str

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -3,12 +3,15 @@
 Unit tests for the `CatalogueCategoryRepo` repository.
 """
 
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
 from test.mock_data import (
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
-    CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES,
+    CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
     CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
     CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
-    CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT,
+    CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.test_utils import (
@@ -252,7 +255,7 @@ class TestCreate(CreateDSL):
     def test_create_leaf_with_properties(self):
         """Test creating a leaf catalogue category with properties"""
 
-        self.mock_create(CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES)
+        self.mock_create(CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM)
         self.call_create()
         self.check_create_success()
 
@@ -387,7 +390,6 @@ class TestGet(GetDSL):
         self.check_get_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
 
-# pylint: disable=duplicate-code
 class GetBreadcrumbsDSL(CatalogueCategoryRepoDSL):
     """Base class for breadcrumbs tests"""
 
@@ -396,7 +398,6 @@ class GetBreadcrumbsDSL(CatalogueCategoryRepoDSL):
     _expected_breadcrumbs: MagicMock
     _obtained_catalogue_category_id: str
     _obtained_breadcrumbs: MagicMock
-    # pylint: enable=duplicate-code
 
     def mock_breadcrumbs(self, breadcrumbs_query_result: list[dict]):
         """Mocks database methods appropriately to test the 'get_breadcrumbs' repo method
@@ -439,7 +440,6 @@ class GetBreadcrumbsDSL(CatalogueCategoryRepoDSL):
         assert self._obtained_breadcrumbs == self._expected_breadcrumbs
 
 
-# pylint: disable=duplicate-code
 class TestGetBreadcrumbs(GetBreadcrumbsDSL):
     """Tests for getting the breadcrumbs of a catalogue category"""
 
@@ -449,9 +449,6 @@ class TestGetBreadcrumbs(GetBreadcrumbsDSL):
         self.mock_breadcrumbs(MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH)
         self.call_get_breadcrumbs(str(ObjectId()))
         self.check_get_breadcrumbs_success()
-
-
-# pylint: enable=duplicate-code
 
 
 class ListDSL(CatalogueCategoryRepoDSL):
@@ -540,15 +537,12 @@ class TestList(ListDSL):
         self.call_list(parent_id="null")
         self.check_list_success()
 
-    # pylint: disable=duplicate-code
     def test_list_with_parent_id_with_no_results(self):
         """Test listing all Catalogue Categories with a parent_id filter returning no results"""
 
         self.mock_list([])
         self.call_list(parent_id=str(ObjectId()))
         self.check_list_success()
-
-    # pylint: enable=duplicate-code
 
 
 class UpdateDSL(CatalogueCategoryRepoDSL):
@@ -842,13 +836,16 @@ class TestUpdate(UpdateDSL):
         Category"""
 
         catalogue_category_id = str(ObjectId())
-        new_name = "New Duplicate Name"
+        duplicate_name = "New Duplicate Name"
 
         self.mock_update(
             catalogue_category_id,
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "name": new_name},
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "name": duplicate_name},
             CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
-            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            duplicate_catalogue_category_in_data={
+                **CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+                "name": duplicate_name,
+            },
         )
         self.call_update_expecting_error(catalogue_category_id, DuplicateRecordError)
         self.check_update_failed_with_exception(
@@ -1000,7 +997,6 @@ class DeleteDSL(CatalogueCategoryRepoDSL):
         assert str(self._delete_exception.value) == message
 
 
-# pylint: disable=duplicate-code
 class TestDelete(DeleteDSL):
     """Tests for deleting a catalogue category"""
 
@@ -1010,8 +1006,6 @@ class TestDelete(DeleteDSL):
         self.mock_delete(deleted_count=1)
         self.call_delete(str(ObjectId()))
         self.check_delete_success()
-
-    # pylint: enable=duplicate-code
 
     def test_delete_with_child_catalogue_category(self):
         """Test deleting a catalogue category when it has a child catalogue category"""
@@ -1139,14 +1133,14 @@ class TestCreateProperty(CreatePropertyDSL):
     def test_create_property(self):
         """Test creating a property in an existing catalogue category"""
 
-        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT)
         self.call_create_property(str(ObjectId()))
         self.check_create_property_success()
 
     def test_create_property_with_invalid_id(self):
         """Test creating a property in a catalogue category with an invalid id"""
 
-        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT)
         self.call_create_property_expecting_error("invalid-id", InvalidObjectIdError)
         self.check_create_property_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
@@ -1230,14 +1224,14 @@ class TestUpdateProperty(UpdatePropertyDSL):
     def test_update_property(self):
         """Test updating a property in an existing catalogue category"""
 
-        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT)
         self.call_update_property(catalogue_category_id=str(ObjectId()), property_id=str(ObjectId()))
         self.check_update_property_success()
 
     def test_update_property_with_invalid_catalogue_category_id(self):
         """Test updating a property in a catalogue category with an invalid id"""
 
-        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT)
         self.call_update_property_expecting_error(
             catalogue_category_id="invalid-id", property_id=str(ObjectId()), error_type=InvalidObjectIdError
         )
@@ -1246,7 +1240,7 @@ class TestUpdateProperty(UpdatePropertyDSL):
     def test_update_property_with_invalid_property_id(self):
         """Test updating a property with an invalid id in a catalogue category"""
 
-        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT)
         self.call_update_property_expecting_error(
             catalogue_category_id=str(ObjectId()), property_id="invalid-id", error_type=InvalidObjectIdError
         )

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -6,9 +6,9 @@ Unit tests for the `CatalogueCategoryRepo` repository.
 from test.mock_data import (
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES,
-    CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
-    CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
-    CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT,
+    CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+    CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+    CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.test_utils import (
@@ -129,6 +129,7 @@ class CreateDSL(CatalogueCategoryRepoDSL):
         :param duplicate_catalogue_category_in_data: Either None or a dictionary containing catalogue category data
                                                      for a duplicate catalogue category
         """
+
         inserted_catalogue_category_id = CustomObjectId(str(ObjectId()))
 
         # Pass through CatalogueCategoryIn first as need creation and modified times
@@ -139,15 +140,15 @@ class CreateDSL(CatalogueCategoryRepoDSL):
         )
 
         # When a parent_id is given, need to mock the find_one for it too
-        if catalogue_category_in_data["parent_id"]:
+        if self._catalogue_category_in.parent_id:
             # If parent_catalogue_category_data is given as None, then it is intentionally supposed to be, otherwise
             # pass through CatalogueCategoryIn first to ensure it has creation and modified times
             RepositoryTestHelpers.mock_find_one(
                 self.catalogue_categories_collection,
                 (
                     {
-                        **CatalogueCategoryIn(**parent_catalogue_category_in_data).model_dump(),
-                        "_id": catalogue_category_in_data["parent_id"],
+                        **CatalogueCategoryIn(**parent_catalogue_category_in_data).model_dump(by_alias=True),
+                        "_id": self._catalogue_category_in.parent_id,
                     }
                     if parent_catalogue_category_in_data
                     else None
@@ -156,7 +157,10 @@ class CreateDSL(CatalogueCategoryRepoDSL):
         RepositoryTestHelpers.mock_find_one(
             self.catalogue_categories_collection,
             (
-                {**CatalogueCategoryIn(**duplicate_catalogue_category_in_data).model_dump(), "_id": ObjectId()}
+                {
+                    **CatalogueCategoryIn(**duplicate_catalogue_category_in_data).model_dump(by_alias=True),
+                    "_id": ObjectId(),
+                }
                 if duplicate_catalogue_category_in_data
                 else None
             ),
@@ -234,7 +238,7 @@ class TestCreate(CreateDSL):
     def test_create_non_leaf_without_parent(self):
         """Test creating a non-leaf catalogue category without a parent"""
 
-        self.mock_create(CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A)
+        self.mock_create(CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A)
         self.call_create()
         self.check_create_success()
 
@@ -256,8 +260,8 @@ class TestCreate(CreateDSL):
         """Test creating a catalogue category with a parent"""
 
         self.mock_create(
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, "parent_id": str(ObjectId())},
-            parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "parent_id": str(ObjectId())},
+            parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
         )
         self.call_create()
         self.check_create_success()
@@ -268,7 +272,7 @@ class TestCreate(CreateDSL):
         parent_id = str(ObjectId())
 
         self.mock_create(
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, "parent_id": parent_id},
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "parent_id": parent_id},
             parent_catalogue_category_in_data=None,
         )
         self.call_create_expecting_error(MissingRecordError)
@@ -279,9 +283,9 @@ class TestCreate(CreateDSL):
         catalogue category"""
 
         self.mock_create(
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, "parent_id": str(ObjectId())},
-            parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
-            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "parent_id": str(ObjectId())},
+            parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
         )
         self.call_create_expecting_error(DuplicateRecordError)
         self.check_create_failed_with_exception(
@@ -361,7 +365,7 @@ class TestGet(GetDSL):
 
         catalogue_category_id = str(ObjectId())
 
-        self.mock_get(catalogue_category_id, CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A)
+        self.mock_get(catalogue_category_id, CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A)
         self.call_get(catalogue_category_id)
         self.check_get_success()
 
@@ -504,7 +508,10 @@ class TestList(ListDSL):
         """Test listing all Catalogue Categories"""
 
         self.mock_list(
-            [CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B]
+            [
+                CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+                CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+            ]
         )
         self.call_list(parent_id=None)
         self.check_list_success()
@@ -513,7 +520,10 @@ class TestList(ListDSL):
         """Test listing all Catalogue Categories with a given parent_id"""
 
         self.mock_list(
-            [CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B]
+            [
+                CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+                CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+            ]
         )
         self.call_list(parent_id=str(ObjectId()))
         self.check_list_success()
@@ -522,7 +532,10 @@ class TestList(ListDSL):
         """Test listing all Catalogue Categories with a 'null' parent_id"""
 
         self.mock_list(
-            [CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B]
+            [
+                CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+                CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+            ]
         )
         self.call_list(parent_id="null")
         self.check_list_success()
@@ -754,8 +767,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             catalogue_category_id,
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
         )
         self.call_update(catalogue_category_id)
         self.check_update_success()
@@ -767,8 +780,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             catalogue_category_id,
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
         )
         self.call_update(catalogue_category_id)
         self.check_update_success()
@@ -781,11 +794,11 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             catalogue_category_id=catalogue_category_id,
             new_catalogue_category_in_data={
-                **CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+                **CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
                 "parent_id": str(ObjectId()),
             },
-            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
-            new_parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
+            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            new_parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
             duplicate_catalogue_category_in_data=None,
             valid_move_result=True,
         )
@@ -800,11 +813,11 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             catalogue_category_id=catalogue_category_id,
             new_catalogue_category_in_data={
-                **CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+                **CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
                 "parent_id": str(ObjectId()),
             },
-            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
-            new_parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
+            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+            new_parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
             duplicate_catalogue_category_in_data=None,
             valid_move_result=False,
         )
@@ -819,8 +832,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             catalogue_category_id,
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, "parent_id": new_parent_id},
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "parent_id": new_parent_id},
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
             new_parent_catalogue_category_in_data=None,
         )
         self.call_update_expecting_error(catalogue_category_id, MissingRecordError)
@@ -835,9 +848,9 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             catalogue_category_id,
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, "name": new_name},
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
-            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "name": new_name},
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
         )
         self.call_update_expecting_error(catalogue_category_id, DuplicateRecordError)
         self.check_update_failed_with_exception(
@@ -853,10 +866,10 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             catalogue_category_id,
-            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A, "parent_id": new_parent_id},
-            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
-            new_parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_B,
-            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+            {**CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A, "parent_id": new_parent_id},
+            CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            new_parent_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
+            duplicate_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
         )
         self.call_update_expecting_error(catalogue_category_id, DuplicateRecordError)
         self.check_update_failed_with_exception(
@@ -868,7 +881,7 @@ class TestUpdate(UpdateDSL):
 
         catalogue_category_id = "invalid-id"
 
-        self.set_update_data(CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A)
+        self.set_update_data(CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A)
         self.call_update_expecting_error(catalogue_category_id, InvalidObjectIdError)
         self.check_update_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
@@ -912,7 +925,7 @@ class TestHasChildElements(HasChildElementsDSL):
         """Test `has_child_elements` when there is a child catalogue category but no child catalogue items"""
 
         self.mock_has_child_elements(
-            child_catalogue_category_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A,
+            child_catalogue_category_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
             child_catalogue_item_data=None,
         )
         self.call_has_child_elements(catalogue_category_id=str(ObjectId()))
@@ -1007,7 +1020,9 @@ class TestDelete(DeleteDSL):
 
         catalogue_category_id = str(ObjectId())
 
-        self.mock_delete(deleted_count=1, child_catalogue_category_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_A)
+        self.mock_delete(
+            deleted_count=1, child_catalogue_category_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A
+        )
         self.call_delete_expecting_error(catalogue_category_id, ChildElementsExistError)
         self.check_delete_failed_with_exception(
             f"Catalogue category with ID {catalogue_category_id} has child elements and cannot be deleted"
@@ -1126,14 +1141,14 @@ class TestCreateProperty(CreatePropertyDSL):
     def test_create_property(self):
         """Test creating a property in an existing catalogue category"""
 
-        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
         self.call_create_property(str(ObjectId()))
         self.check_create_property_success()
 
     def test_create_property_with_invalid_id(self):
         """Test creating a property in a catalogue category with an invalid id"""
 
-        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_create_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
         self.call_create_property_expecting_error("invalid-id", InvalidObjectIdError)
         self.check_create_property_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
@@ -1217,14 +1232,14 @@ class TestUpdateProperty(UpdatePropertyDSL):
     def test_update_property(self):
         """Test updating a property in an existing catalogue category"""
 
-        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
         self.call_update_property(catalogue_category_id=str(ObjectId()), property_id=str(ObjectId()))
         self.check_update_property_success()
 
     def test_update_property_with_invalid_catalogue_category_id(self):
         """Test updating a property in a catalogue category with an invalid id"""
 
-        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
         self.call_update_property_expecting_error(
             catalogue_category_id="invalid-id", property_id=str(ObjectId()), error_type=InvalidObjectIdError
         )
@@ -1233,7 +1248,7 @@ class TestUpdateProperty(UpdatePropertyDSL):
     def test_update_property_with_invalid_property_id(self):
         """Test updating a property with an invalid id in a catalogue category"""
 
-        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_NUMBER_NON_MANDATORY_WITH_UNIT)
+        self.mock_update_property(CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_UNIT)
         self.call_update_property_expecting_error(
             catalogue_category_id=str(ObjectId()), property_id="invalid-id", error_type=InvalidObjectIdError
         )

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -739,9 +739,7 @@ class UpdateDSL(CatalogueCategoryRepoDSL):
                 "_id": CustomObjectId(self._updated_catalogue_category_id),
             },
             {
-                "$set": {
-                    **self._catalogue_category_in.model_dump(),
-                },
+                "$set": self._catalogue_category_in.model_dump(),
             },
             session=self.mock_session,
         )
@@ -858,8 +856,8 @@ class TestUpdate(UpdateDSL):
         )
 
     def test_update_parent_id_with_duplicate_within_parent(self):
-        """Test updating a catalogue category's parent-id to one contains a catalogue category with a duplicate name
-        within the same parent catalogue category"""
+        """Test updating a catalogue category's parent_id to one that contains a catalogue category with a duplicate
+        name within the same parent catalogue category"""
 
         catalogue_category_id = str(ObjectId())
         new_parent_id = str(ObjectId())

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -618,9 +618,7 @@ class UpdateDSL(SystemRepoDSL):
                 "_id": CustomObjectId(self._updated_system_id),
             },
             {
-                "$set": {
-                    **self._system_in.model_dump(),
-                },
+                "$set": self._system_in.model_dump(),
             },
             session=self.mock_session,
         )
@@ -653,7 +651,7 @@ class TestUpdate(UpdateDSL):
 
         system_id = str(ObjectId())
 
-        self.mock_update(system_id, SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B)
+        self.mock_update(system_id, SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_A)
         self.call_update(system_id)
         self.check_update_success()
 
@@ -720,8 +718,8 @@ class TestUpdate(UpdateDSL):
         self.check_update_failed_with_exception("Duplicate system found within the parent system")
 
     def test_update_parent_id_with_duplicate_within_parent(self):
-        """Test updating a system's parent-id to one contains a system with a duplicate name within the same parent
-        system"""
+        """Test updating a system's parent_id to one that contains a system with a duplicate name within the same
+        parent system"""
 
         system_id = str(ObjectId())
         new_parent_id = str(ObjectId())

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -2,6 +2,9 @@
 Unit tests for the `SystemRepo` repository
 """
 
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
 from test.mock_data import SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.test_utils import (
@@ -706,13 +709,13 @@ class TestUpdate(UpdateDSL):
         """Test updating a system's name to one that is a duplicate within the same parent system"""
 
         system_id = str(ObjectId())
-        new_name = "New Duplicate Name"
+        duplicate_name = "New Duplicate Name"
 
         self.mock_update(
             system_id,
-            {**SYSTEM_IN_DATA_NO_PARENT_A, "name": new_name},
+            {**SYSTEM_IN_DATA_NO_PARENT_A, "name": duplicate_name},
             SYSTEM_IN_DATA_NO_PARENT_A,
-            duplicate_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            duplicate_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_A, "name": duplicate_name},
         )
         self.call_update_expecting_error(system_id, DuplicateRecordError)
         self.check_update_failed_with_exception("Duplicate system found within the parent system")

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -128,7 +128,7 @@ class SystemRepoDSL:
 
 
 class CreateDSL(SystemRepoDSL):
-    """Base class for create tests"""
+    """Base class for `create` tests"""
 
     _system_in: SystemIn
     _expected_system_out: SystemOut
@@ -261,7 +261,7 @@ class TestCreate(CreateDSL):
 
 
 class GetDSL(SystemRepoDSL):
-    """Base class for get tests"""
+    """Base class for `get` tests"""
 
     _obtained_system_id: str
     _expected_system_out: Optional[SystemOut]
@@ -348,7 +348,7 @@ class TestGet(GetDSL):
 
 
 class GetBreadcrumbsDSL(SystemRepoDSL):
-    """Base class for breadcrumbs tests"""
+    """Base class for `get_breadcrumbs` tests"""
 
     _breadcrumbs_query_result: list[dict]
     _mock_aggregation_pipeline = MagicMock()
@@ -404,7 +404,7 @@ class TestGetBreadcrumbs(GetBreadcrumbsDSL):
 
 
 class ListDSL(SystemRepoDSL):
-    """Base class for list tests"""
+    """Base class for `list` tests"""
 
     _expected_systems_out: list[SystemOut]
     _parent_id_filter: Optional[str]
@@ -476,7 +476,7 @@ class TestList(ListDSL):
 
 
 class UpdateDSL(SystemRepoDSL):
-    """Base class for update tests"""
+    """Base class for `update` tests"""
 
     # pylint:disable=too-many-instance-attributes
     _system_in: SystemIn
@@ -748,7 +748,7 @@ class TestUpdate(UpdateDSL):
 
 
 class DeleteDSL(SystemRepoDSL):
-    """Base class for delete tests"""
+    """Base class for `delete` tests"""
 
     _delete_system_id: str
     _delete_exception: pytest.ExceptionInfo

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -13,7 +13,6 @@ from test.mock_data import (
     CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
     CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
-    CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT,
     CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
     UNIT_IN_DATA_MM,
 )
@@ -27,7 +26,6 @@ from bson import ObjectId
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
-    DuplicateCatalogueCategoryPropertyNameError,
     LeafCatalogueCategoryError,
     MissingRecordError,
 )
@@ -280,23 +278,6 @@ class TestCreate(CreateDSL):
         self.mock_create(CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM, units_in_data=[UNIT_IN_DATA_MM])
         self.call_create()
         self.check_create_success()
-
-    def test_create_with_duplicate_properties(self):
-        """Test creating a catalogue category with properties"""
-
-        self.mock_create(
-            {
-                **CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
-                "properties": [
-                    CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT,
-                    CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT,
-                ],
-            },
-        )
-        self.call_create_expecting_error(DuplicateCatalogueCategoryPropertyNameError)
-        self.check_create_failed_with_exception(
-            f"Duplicate property name: {CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY_WITHOUT_UNIT['name']}"
-        )
 
     def test_create_with_properties_with_non_existent_unit_id(self):
         """Test creating a catalogue category with properties with a non-existent unit id"""

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -3,11 +3,12 @@
 Unit tests for the `CatalogueCategoryService` service.
 """
 
-from datetime import timedelta
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
 from test.mock_data import (
     CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
-    CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
     CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
     CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
@@ -16,7 +17,7 @@ from test.mock_data import (
     CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
     UNIT_IN_DATA_MM,
 )
-from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW, ServiceTestHelpers
+from test.unit.services.conftest import ServiceTestHelpers
 from typing import Optional
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
@@ -34,7 +35,6 @@ from inventory_management_system_api.models.catalogue_category import (
     CatalogueCategoryIn,
     CatalogueCategoryOut,
     CatalogueCategoryPropertyIn,
-    CatalogueCategoryPropertyOut,
 )
 from inventory_management_system_api.models.unit import UnitIn, UnitOut
 from inventory_management_system_api.schemas.catalogue_category import (
@@ -159,8 +159,8 @@ class CreateDSL(CatalogueCategoryServiceDSL):
         """Mocks repo methods appropriately to test the 'create' service method
 
         :param catalogue_category_data: Dictionary containing the basic catalogue category data as would be required
-                                        for a CatalogueCategoryPostSchema but without any unit_id's in its properties
-                                        as they will be added automatically
+                                        for a CatalogueCategoryPostSchema but with any unit_id's replaced by the
+                                        'unit' value in its properties as the ids will be added automatically
         :param parent_catalogue_category_in_data: Either None or a dictionary containing the parent catalogue category
                                                   data as would be required for a CatalogueCategoryIn database model
         :param units_in_data: Either None or a list of dictionaries (or None) containing the unit data as would be
@@ -445,6 +445,7 @@ class TestList(ListDSL):
         self.check_list_success()
 
 
+# pylint:disable=too-many-instance-attributes
 class UpdateDSL(CatalogueCategoryServiceDSL):
     """Base class for update tests"""
 
@@ -460,6 +461,7 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
     _moving_catalogue_category: bool
     unit_value_id_dict: dict[str, str]
 
+    # pylint:disable=too-many-arguments
     def mock_update(
         self,
         catalogue_category_id: str,
@@ -473,8 +475,8 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
 
         :param catalogue_category_id: ID of the catalogue category that will be obtained
         :param catalogue_category_update_data: Dictionary containing the basic patch data as would be required for a
-                                               CatalogueCategoryPatchSchema but without any unit_id's in its properties
-                                               as they will be added automatically
+                                               CatalogueCategoryPatchSchema but with any unit_id's replaced by the
+                                               'unit' value in its properties as the ids will be added automatically
         :param stored_catalogue_category_post_data: Dictionary containing the catalogue category data for the existing
                                                stored catalogue category as would be required for a
                                                CatalogueCategoryPostSchema(i.e. no id, code or created and modified
@@ -488,14 +490,12 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
                               required by the given catalogue category properties in the patch data.
         """
 
-        # TODO: Add extra not in systems
-
         # Stored catalogue category
         self._stored_catalogue_category = (
             CatalogueCategoryOut(
                 **CatalogueCategoryIn(
                     **stored_catalogue_category_post_data,
-                    code=utils.generate_code(stored_catalogue_category_post_data["name"], "system"),
+                    code=utils.generate_code(stored_catalogue_category_post_data["name"], "catalogue category"),
                 ).model_dump(),
                 id=CustomObjectId(catalogue_category_id),
             )
@@ -561,7 +561,8 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
         )
 
     def call_update(self, catalogue_category_id: str):
-        """Calls the CatalogueCategoryService `update` method with the appropriate data from a prior call to `mock_update`"""
+        """Calls the CatalogueCategoryService `update` method with the appropriate data from a prior call to
+        `mock_update`"""
 
         self._updated_catalogue_category_id = catalogue_category_id
         self._updated_catalogue_category = self.catalogue_category_service.update(
@@ -569,8 +570,8 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
         )
 
     def call_update_expecting_error(self, catalogue_category_id: str, error_type: type[BaseException]):
-        """Calls the CatalogueCategoryService `update` method with the appropriate data from a prior call to `mock_update`
-        while expecting an error to be raised"""
+        """Calls the CatalogueCategoryService `update` method with the appropriate data from a prior call to
+        `mock_update` while expecting an error to be raised"""
 
         with pytest.raises(error_type) as exc:
             self.catalogue_category_service.update(catalogue_category_id, self._catalogue_category_patch)
@@ -578,8 +579,6 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
 
     def check_update_success(self):
         """Checks that a prior call to `call_update` worked as expected"""
-
-        # TODO: Add extra not in systems
 
         # Obtain a list of expected get calls
         expected_get_calls = []

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -4,8 +4,14 @@ Unit tests for the `CatalogueCategoryService` service.
 """
 
 from datetime import timedelta
-from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW
-from unittest.mock import ANY, MagicMock
+from test.mock_data import (
+    CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
+    CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+    UNIT_IN_DATA_MM,
+)
+from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW, ServiceTestHelpers
+from typing import Optional
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 from bson import ObjectId
@@ -19,1167 +25,1312 @@ from inventory_management_system_api.core.exceptions import (
 from inventory_management_system_api.models.catalogue_category import (
     CatalogueCategoryIn,
     CatalogueCategoryOut,
+    CatalogueCategoryPropertyIn,
     CatalogueCategoryPropertyOut,
 )
-from inventory_management_system_api.models.unit import UnitOut
+from inventory_management_system_api.models.unit import UnitIn, UnitOut
 from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueCategoryPatchSchema,
+    CatalogueCategoryPostPropertySchema,
     CatalogueCategoryPostSchema,
 )
-
-UNIT_A = {
-    "value": "mm",
-    "code": "mm",
-    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-}
+from inventory_management_system_api.services import utils
+from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
 
 
-def test_create(
-    test_helpers,
-    catalogue_category_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test creating a catalogue category.
+class CatalogueCategoryServiceDSL:
+    """Base class for CatalogueCategoryService unit tests"""
 
-    Verify that the `create` method properly handles the catalogue category to be created, generates the code,
-    and calls the repository's create method.
-    """
-    # pylint: disable=duplicate-code
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=False,
-        parent_id=None,
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
+    wrapped_utils: Mock
+    mock_catalogue_category_repository: Mock
+    mock_unit_repository: Mock
+    catalogue_category_service: CatalogueCategoryService
+    unit_value_id_dict: dict[str, str] = {}
 
-    # Mock `create` to return the created catalogue category
-    test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
-
-    created_catalogue_category = catalogue_category_service.create(
-        CatalogueCategoryPostSchema(
-            name=catalogue_category.name,
-            is_leaf=catalogue_category.is_leaf,
-            properties=catalogue_category.properties,
-        )
-    )
-
-    # pylint: disable=duplicate-code
-    catalogue_category_repository_mock.create.assert_called_once_with(
-        CatalogueCategoryIn(
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-        )
-    )
-    # pylint: enable=duplicate-code
-    assert created_catalogue_category == catalogue_category
-
-
-def test_create_with_parent_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    unit_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test creating a catalogue category with a parent ID.
-
-    Verify that the `create` method properly handles a catalogue category with a parent ID.
-    """
-
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-
-    # pylint: disable=duplicate-code
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=True,
-        parent_id=str(ObjectId()),
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()),
-                name="Property A",
-                type="number",
-                unit_id=unit.id,
-                unit=unit.value,
-                mandatory=False,
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return the parent catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
         catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.parent_id,
-            name="Category A",
-            code="category-a",
-            is_leaf=False,
-            parent_id=None,
-            properties=[],
-            created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-            modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        ),
-    )
-    # pylint: enable=duplicate-code
+        unit_repository_mock,
+        catalogue_category_service,
+        # Ensures all created and modified times are mocked throughout
+        # pylint: disable=unused-argument
+        model_mixins_datetime_now_mock,
+    ):
+        """Setup fixtures"""
 
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
+        self.mock_catalogue_category_repository = catalogue_category_repository_mock
+        self.mock_unit_repository = unit_repository_mock
+        self.catalogue_category_service = catalogue_category_service
 
-    # Mock `create` to return the created catalogue category
-    test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
+        with patch("inventory_management_system_api.services.catalogue_category.utils", wraps=utils) as wrapped_utils:
+            self.wrapped_utils = wrapped_utils
+            yield
 
-    created_catalogue_category = catalogue_category_service.create(
-        CatalogueCategoryPostSchema(
-            name=catalogue_category.name,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=[prop.model_dump() for prop in catalogue_category.properties],
-        )
-    )
+    def mock_add_property_unit_values(self, units_in_data: list[dict]):
+        """Mocks database methods appropriately for when the `_add_property_unit_values` repo method will be called
 
-    # pylint: disable=duplicate-code
-    # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
-    # be different
-    catalogue_category_repository_mock.create.assert_called_once()
-    create_catalogue_category_in = catalogue_category_repository_mock.create.call_args_list[0][0][0]
-    assert isinstance(create_catalogue_category_in, CatalogueCategoryIn)
-    assert create_catalogue_category_in.model_dump() == {
-        **(
-            CatalogueCategoryIn(
-                name=catalogue_category.name,
-                code=catalogue_category.code,
-                is_leaf=catalogue_category.is_leaf,
-                parent_id=catalogue_category.parent_id,
-                properties=[prop.model_dump() for prop in catalogue_category.properties],
-            ).model_dump()
-        ),
-        "properties": [{**prop.model_dump(), "id": ANY, "unit_id": ANY} for prop in catalogue_category.properties],
-    }
-    # pylint: enable=duplicate-code
-    assert created_catalogue_category == catalogue_category
+        Also generates unit ids that are stored inside `unit_value_id_dict` for future lookups.
 
+        :param units_in_data: List of dictionaries containing the unit data as would be required for a UnitIn database
+                              model
+        """
 
-def test_create_with_whitespace_name(
-    test_helpers,
-    catalogue_category_repository_mock,
-    unit_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test creating a catalogue category name containing leading/trailing/consecutive whitespaces.
+        for unit_in_data in units_in_data:
+            unit_in = UnitIn(**unit_in_data)
+            unit_id = str(ObjectId())
 
-    Verify that the `create` method trims the whitespace from the category name and handles it correctly.
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+            self.unit_value_id_dict[unit_in.value] = unit_id
 
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="    Category   A         ",
-        code="category-a",
-        is_leaf=True,
-        parent_id=None,
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
+            ServiceTestHelpers.mock_get(self.mock_unit_repository, UnitOut(**unit_in.model_dump(), id=unit_id))
 
-    # Mock `create` to return the created catalogue category
-    test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
+    def check_add_property_unit_values_performed_expected_calls(
+        self, expected_properties: list[CatalogueCategoryPostPropertySchema]
+    ):
+        """Checks that a call to `add_property_unit_values` performed the expected function calls
 
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
+        :param expected_properties: Expected properties the function would have been called with
+        """
 
-    created_catalogue_category = catalogue_category_service.create(
-        CatalogueCategoryPostSchema(
-            name=catalogue_category.name,
-            is_leaf=catalogue_category.is_leaf,
-            properties=[prop.model_dump() for prop in catalogue_category.properties],
-        )
-    )
+        expected_unit_repo_calls = []
+        for prop in expected_properties:
+            if prop.unit_id:
+                expected_unit_repo_calls.append(call(prop.unit_id))
 
-    # pylint: disable=duplicate-code
-    # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
-    # be different
-    catalogue_category_repository_mock.create.assert_called_once()
-    create_catalogue_category_in = catalogue_category_repository_mock.create.call_args_list[0][0][0]
-    assert isinstance(create_catalogue_category_in, CatalogueCategoryIn)
-    assert create_catalogue_category_in.model_dump() == {
-        **(
-            CatalogueCategoryIn(
-                name=catalogue_category.name,
-                code=catalogue_category.code,
-                is_leaf=catalogue_category.is_leaf,
-                parent_id=catalogue_category.parent_id,
-                properties=[prop.model_dump() for prop in catalogue_category.properties],
-            ).model_dump()
-        ),
-        "properties": [{**prop.model_dump(), "id": ANY, "unit_id": ANY} for prop in catalogue_category.properties],
-    }
-    # pylint: enable=duplicate-code
-    assert created_catalogue_category == catalogue_category
+        self.mock_unit_repository.get.assert_has_calls(expected_unit_repo_calls)
 
 
-def test_create_with_leaf_parent_catalogue_category(
-    test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
-):
-    """
-    Test creating a catalogue category in a leaf parent catalogue category.
-    """
-    # pylint: disable=duplicate-code
+class CreateDSL(CatalogueCategoryServiceDSL):
+    """Base class for create tests"""
 
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=False,
-        parent_id=str(ObjectId()),
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
+    _catalogue_category_post: CatalogueCategoryPostSchema
+    _expected_catalogue_category_in: CatalogueCategoryIn
+    _expected_catalogue_category_out: CatalogueCategoryOut
+    _created_catalogue_category: CatalogueCategoryOut
+    _create_exception: pytest.ExceptionInfo
 
-    # Mock `get` to return the parent catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.parent_id,
-            name="Category A",
-            code="category-a",
-            is_leaf=True,
-            parent_id=None,
-            properties=[
-                CatalogueCategoryPropertyOut(
+    def mock_create(
+        self,
+        catalogue_category_data: dict,
+        parent_catalogue_category_in_data: Optional[dict] = None,
+        units_in_data: Optional[list[dict]] = None,
+    ):
+        """Mocks repo methods appropriately to test the 'create' service method
+
+        :param catalogue_category_data: Dictionary containing the basic system data as would be required for a
+                                        CatalogueCategoryPostSchema but without any unit_id's in its properties
+                                        as they will be added automatically
+        :param parent_catalogue_category_in_data: Either None or a dictionary containing the parent catalogue category
+                                                  data as would be required for a CatalogueCategoryIn database model
+        :param units_in_data: Either None or a list of dictionaries containing the unit data as would be required for
+                              a UnitIn database model. These values will be used for any unit look ups required by the
+                              given catalogue category properties
+        """
+
+        # When a parent_id is given need to mock the get for it too
+        if catalogue_category_data["parent_id"]:
+            ServiceTestHelpers.mock_get(
+                self.mock_catalogue_category_repository,
+                CatalogueCategoryOut(
+                    **CatalogueCategoryIn(**parent_catalogue_category_in_data).model_dump(by_alias=True),
                     id=str(ObjectId()),
-                    name="Property A",
-                    type="number",
-                    unit_id=unit.id,
-                    unit=unit.value,
-                    mandatory=False,
                 ),
-                CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-            ],
-            created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-            modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        ),
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-
-    with pytest.raises(LeafCatalogueCategoryError) as exc:
-        catalogue_category_service.create(
-            CatalogueCategoryPostSchema(
-                name=catalogue_category.name,
-                is_leaf=catalogue_category.is_leaf,
-                parent_id=catalogue_category.parent_id,
-                properties=catalogue_category.properties,
             )
+
+        # When properties are given need to mock any units and need to ensure the expected data
+        # inserts the unit values as well
+        property_post_schemas = []
+        expected_properties_in = []
+        if catalogue_category_data["properties"]:
+            self.mock_add_property_unit_values(units_in_data)
+
+            for prop in catalogue_category_data["properties"]:
+                unit_id = None
+                if "unit" in prop and prop["unit"]:
+                    unit_id = self.unit_value_id_dict.get(prop["unit"])
+
+                property_post_schemas.append(CatalogueCategoryPostPropertySchema(**prop, unit_id=unit_id))
+                expected_properties_in.append(CatalogueCategoryPropertyIn(**prop, unit_id=unit_id))
+
+        self._catalogue_category_post = CatalogueCategoryPostSchema(
+            **{**catalogue_category_data, "properties": property_post_schemas}
         )
-    catalogue_category_repository_mock.create.assert_not_called()
-    assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
 
+        self._expected_catalogue_category_in = CatalogueCategoryIn(
+            **{**catalogue_category_data, "properties": expected_properties_in},
+            code=utils.generate_code(catalogue_category_data["name"], "catalogue category"),
+        )
+        self._expected_catalogue_category_out = CatalogueCategoryOut(
+            **self._expected_catalogue_category_in.model_dump(), id=ObjectId()
+        )
 
-def test_create_with_duplicate_property_names(
-    test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
-):
-    """
-    Test trying to create a catalogue category with duplicate property names
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=True,
-        parent_id=None,
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property A", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-    # pylint: enable=duplicate-code
+        ServiceTestHelpers.mock_create(self.mock_catalogue_category_repository, self._expected_catalogue_category_out)
 
-    with pytest.raises(DuplicateCatalogueCategoryPropertyNameError) as exc:
-        # pylint: disable=duplicate-code
-        catalogue_category_service.create(
-            CatalogueCategoryPostSchema(
-                name=catalogue_category.name,
-                is_leaf=catalogue_category.is_leaf,
-                properties=[prop.model_dump() for prop in catalogue_category.properties],
+    def call_create(self):
+        """Calls the CatalogueCategoryService `create` method with the appropriate data from a prior call to
+        `mock_create`"""
+
+        self._created_catalogue_category = self.catalogue_category_service.create(self._catalogue_category_post)
+
+    def check_create_success(self):
+        """Checks that a prior call to `call_create` worked as expected"""
+
+        # This is the get for the parent
+        if self._catalogue_category_post.parent_id:
+            self.mock_catalogue_category_repository.get.assert_called_once_with(self._catalogue_category_post.parent_id)
+
+        # This is the properties duplicate check
+        if self._catalogue_category_post.properties:
+            self.wrapped_utils.check_duplicate_property_names.assert_called_with(
+                self._catalogue_category_post.properties
             )
+
+        # This is for getting the units
+        if self._catalogue_category_post.properties:
+            self.check_add_property_unit_values_performed_expected_calls(self._catalogue_category_post.properties)
+
+        self.wrapped_utils.generate_code.assert_called_once_with(
+            self._expected_catalogue_category_out.name, "catalogue category"
         )
-        # pylint: enable=duplicate-code
-    catalogue_category_repository_mock.create.assert_not_called()
-    assert str(exc.value) == (f"Duplicate property name: {catalogue_category.properties[0].name}")
-
-
-def test_create_properties_with_non_existent_unit_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    unit_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test creating a catalogue category with a non existent unit ID.
-    """
-
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-
-    # pylint: disable=duplicate-code
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=True,
-        parent_id=str(ObjectId()),
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()),
-                name="Property A",
-                type="number",
-                unit_id=unit.id,
-                unit=unit.value,
-                mandatory=False,
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return the parent catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.parent_id,
-            name="Category A",
-            code="category-a",
-            is_leaf=False,
-            parent_id=None,
-            properties=[],
-            created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-            modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        ),
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, None)
-
-    # Mock `create` to return the created catalogue category
-    test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_category_service.create(
-            CatalogueCategoryPostSchema(
-                name=catalogue_category.name,
-                is_leaf=catalogue_category.is_leaf,
-                parent_id=catalogue_category.parent_id,
-                properties=[prop.model_dump() for prop in catalogue_category.properties],
-            )
-        )
-    catalogue_category_repository_mock.create.assert_not_called()
-    assert str(exc.value) == (f"No unit found with ID: {unit.id}")
-
-
-def test_delete(catalogue_category_repository_mock, catalogue_category_service):
-    """
-    Test deleting a catalogue category.
-
-    Verify that the `delete` method properly handles the deletion of a catalogue category by ID.
-    """
-    catalogue_category_id = str(ObjectId())
-
-    catalogue_category_service.delete(catalogue_category_id)
-
-    catalogue_category_repository_mock.delete.assert_called_once_with(catalogue_category_id)
-
-
-def test_get(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-    """
-    Test getting a catalogue category.
-
-    Verify that the `get` method properly handles the retrieval of a catalogue category by ID.
-    """
-    # pylint: disable=duplicate-code
-    catalogue_category_id = str(ObjectId())
-    catalogue_category = MagicMock()
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-    retrieved_catalogue_category = catalogue_category_service.get(catalogue_category_id)
-
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
-    assert retrieved_catalogue_category == catalogue_category
-
-
-def test_get_with_non_existent_id(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-    """
-    Test getting a catalogue category with a non-existent ID.
-
-    Verify that the `get` method properly handles the retrieval of a catalogue category with a non-existent ID.
-    """
-    catalogue_category_id = str(ObjectId())
-
-    # Mock `get` to not return a catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, None)
-
-    retrieved_catalogue_category = catalogue_category_service.get(catalogue_category_id)
-
-    assert retrieved_catalogue_category is None
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
-
-
-def test_get_breadcrumbs(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-    """
-    Test getting breadcrumbs for a catalogue category
-
-    Verify that the `get_breadcrumbs` method properly handles the retrieval of breadcrumbs for a catalogue category
-    """
-    catalogue_category_id = str(ObjectId())
-    breadcrumbs = MagicMock()
-
-    # Mock `get` to return breadcrumbs
-    test_helpers.mock_get_breadcrumbs(catalogue_category_repository_mock, breadcrumbs)
-
-    retrieved_breadcrumbs = catalogue_category_service.get_breadcrumbs(catalogue_category_id)
-
-    catalogue_category_repository_mock.get_breadcrumbs.assert_called_once_with(catalogue_category_id)
-    assert retrieved_breadcrumbs == breadcrumbs
-
-
-def test_list(catalogue_category_repository_mock, catalogue_category_service):
-    """
-    Test listing catalogue categories.
-
-    Verify that the `list` method properly calls the repository function with any passed filters
-    """
-
-    parent_id = MagicMock()
-
-    result = catalogue_category_service.list(parent_id=parent_id)
-
-    catalogue_category_repository_mock.list.assert_called_once_with(parent_id)
-    assert result == catalogue_category_repository_mock.list.return_value
-
-
-def test_update_when_no_child_elements(
-    test_helpers,
-    catalogue_category_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test updating a catalogue category without child elements
-
-    Verify that the `update` method properly handles the catalogue category to be updated when it doesn't have any
-    child elements.
-    """
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=True,
-        parent_id=None,
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name="Category A",
-            code="category-a",
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    updated_catalogue_category = catalogue_category_service.update(
-        catalogue_category.id, CatalogueCategoryPatchSchema(name=catalogue_category.name)
-    )
-
-    # pylint: disable=duplicate-code
-    catalogue_category_repository_mock.update.assert_called_once_with(
-        catalogue_category.id,
-        CatalogueCategoryIn(
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.modified_time,
-        ),
-    )
-    # pylint: enable=duplicate-code
-    assert updated_catalogue_category == catalogue_category
-
-
-def test_update_when_has_child_elements(
-    test_helpers,
-    catalogue_category_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test updating a catalogue category when it has child elements
-
-    Verify that the `update` method properly handles the catalogue category to be updated when it has children.
-    """
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=True,
-        parent_id=None,
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name="Category A",
-            code="category-a",
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-    # Mock so child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = True
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    updated_catalogue_category = catalogue_category_service.update(
-        catalogue_category.id, CatalogueCategoryPatchSchema(name=catalogue_category.name)
-    )
-
-    # pylint: disable=duplicate-code
-    catalogue_category_repository_mock.update.assert_called_once_with(
-        catalogue_category.id,
-        CatalogueCategoryIn(
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.modified_time,
-        ),
-    )
-    # pylint: enable=duplicate-code
-    assert updated_catalogue_category == catalogue_category
-
-
-def test_update_with_non_existent_id(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-    """
-    Test updating a catalogue category with a non-existent ID.
-
-    Verify that the `update` method properly handles the catalogue category to be updated with a non-existent ID.
-    """
-    # Mock `get` to not return a catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, None)
-
-    catalogue_category_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_category_service.update(catalogue_category_id, CatalogueCategoryPatchSchema(properties=[]))
-    catalogue_category_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
-
-
-def test_update_change_parent_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test moving a catalogue category to another parent catalogue category.
-    """
-
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category B",
-        code="category-b",
-        is_leaf=False,
-        parent_id=str(ObjectId()),
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=None,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a parent catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=str(ObjectId()),
-            name="Category A",
-            code="category-a",
-            is_leaf=False,
-            parent_id=None,
-            properties=[],
-            created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-            modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        ),
-    )
-    # pylint: enable=duplicate-code
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    updated_catalogue_category = catalogue_category_service.update(
-        catalogue_category.id, CatalogueCategoryPatchSchema(parent_id=catalogue_category.parent_id)
-    )
-
-    # pylint: disable=duplicate-code
-    catalogue_category_repository_mock.update.assert_called_once_with(
-        catalogue_category.id,
-        CatalogueCategoryIn(
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.modified_time,
-        ),
-    )
-    # pylint: enable=duplicate-code
-    assert updated_catalogue_category == catalogue_category
-
-
-def test_update_change_parent_id_leaf_parent_catalogue_category(
-    test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
-):
-    """
-    Testing moving a catalogue category to a leaf parent catalogue category.
-    """
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category_b_id = str(ObjectId())
-    # Mock `get` to return a catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category_b_id,
-            name="Category B",
-            code="category-b",
-            is_leaf=False,
-            parent_id=None,
-            properties=[],
-            created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-            modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        ),
-    )
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    catalogue_category_a_id = str(ObjectId())
-    # Mock `get` to return a parent catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category_b_id,
-            name="Category A",
-            code="category-a",
-            is_leaf=True,
-            parent_id=None,
-            properties=[
-                CatalogueCategoryPropertyOut(
-                    id=str(ObjectId()),
-                    name="Property A",
-                    type="number",
-                    unit_id=unit.id,
-                    unit=unit.value,
-                    mandatory=False,
-                ),
-                CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-            ],
-            created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-            modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        ),
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-
-    with pytest.raises(LeafCatalogueCategoryError) as exc:
-        catalogue_category_service.update(
-            catalogue_category_b_id, CatalogueCategoryPatchSchema(parent_id=catalogue_category_a_id)
-        )
-    catalogue_category_repository_mock.update.assert_not_called()
-    assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
-
-
-def test_update_change_from_leaf_to_non_leaf_when_no_child_elements(
-    test_helpers,
-    catalogue_category_repository_mock,
-    unit_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test changing a catalogue category from leaf to non-leaf when the category doesn't have any child elements.
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=False,
-        parent_id=None,
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=True,
-            parent_id=catalogue_category.parent_id,
-            properties=[
-                CatalogueCategoryPropertyOut(
-                    id=str(ObjectId()),
-                    name="Property A",
-                    type="number",
-                    unit_id=unit.id,
-                    unit=unit.value,
-                    mandatory=False,
-                ),
-                CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-            ],
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    updated_catalogue_category = catalogue_category_service.update(
-        catalogue_category.id, CatalogueCategoryPatchSchema(is_leaf=False)
-    )
-
-    catalogue_category_repository_mock.update.assert_called_once_with(
-        catalogue_category.id,
-        CatalogueCategoryIn(
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=catalogue_category.properties,
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.modified_time,
-        ),
-    )
-    assert updated_catalogue_category == catalogue_category
-
-
-def test_update_change_properties_when_no_child_elements(
-    test_helpers,
-    catalogue_category_repository_mock,
-    unit_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test updating a catalogue category's item properties when it has no child elements.
-
-    Verify that the `update` method properly handles the catalogue category to be updated.
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=True,
-        parent_id=None,
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=[catalogue_category.properties[1]],
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    # pylint: enable=duplicate-code
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    updated_catalogue_category = catalogue_category_service.update(
-        catalogue_category.id,
-        CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
-    )
-
-    # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
-    # be different
-    catalogue_category_repository_mock.update.assert_called_once_with(catalogue_category.id, ANY)
-    update_catalogue_category_in = catalogue_category_repository_mock.update.call_args_list[0][0][1]
-    assert isinstance(update_catalogue_category_in, CatalogueCategoryIn)
-    assert update_catalogue_category_in.model_dump() == {
-        **(
-            CatalogueCategoryIn(
-                name=catalogue_category.name,
-                code=catalogue_category.code,
-                is_leaf=catalogue_category.is_leaf,
-                parent_id=catalogue_category.parent_id,
-                properties=[prop.model_dump() for prop in catalogue_category.properties],
-                created_time=catalogue_category.created_time,
-                modified_time=catalogue_category.modified_time,
-            ).model_dump()
-        ),
-        "properties": [{**prop.model_dump(), "id": ANY, "unit_id": ANY} for prop in catalogue_category.properties],
-    }
-    assert updated_catalogue_category == catalogue_category
-
-
-def test_update_change_from_leaf_to_non_leaf_when_has_child_elements(
-    test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
-):
-    """
-    Test changing a catalogue category from leaf to non-leaf when the category has child elements.
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=False,
-        parent_id=None,
-        properties=[],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=True,
-            parent_id=catalogue_category.parent_id,
-            properties=[
-                CatalogueCategoryPropertyOut(
-                    id=str(ObjectId()),
-                    name="Property A",
-                    type="number",
-                    unit_id=unit.id,
-                    unit=unit.value,
-                    mandatory=False,
-                ),
-                CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-            ],
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.modified_time,
-        ),
-    )
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-    # Mock so child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = True
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(ChildElementsExistError) as exc:
-        catalogue_category_service.update(catalogue_category.id, CatalogueCategoryPatchSchema(is_leaf=False))
-    catalogue_category_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value)
-        == f"Catalogue category with ID {str(catalogue_category.id)} has child elements and cannot be updated"
-    )
-
-
-def test_update_change_properties_when_has_child_elements(
-    test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
-):
-    """
-    Test updating a catalogue category's item properties when it has child elements.
-
-    Verify that the `update` method properly handles the catalogue category to be updated.
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=True,
-        parent_id=None,
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=[catalogue_category.properties[1]],
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-    # Mock so child elements found
-    catalogue_category_repository_mock.has_child_elements.return_value = True
-    # pylint: enable=duplicate-code
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(ChildElementsExistError) as exc:
-        catalogue_category_service.update(
-            catalogue_category.id,
-            CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
-        )
-    catalogue_category_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value)
-        == f"Catalogue category with ID {str(catalogue_category.id)} has child elements and cannot be updated"
-    )
-
-
-def test_update_properties_to_have_duplicate_names(
-    test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
-):
-    """
-    Test that checks that trying to update properties so that the names are duplicated is not allowed
-
-    Verify the `update` method properly handles the catalogue category to be updated
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=True,
-        parent_id=None,
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()), name="Duplicate", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Duplicate", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=[catalogue_category.properties[1]],
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, unit)
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    # pylint: enable=duplicate-code
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(DuplicateCatalogueCategoryPropertyNameError) as exc:
-        catalogue_category_service.update(
-            catalogue_category.id,
-            CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
-        )
-    catalogue_category_repository_mock.update.assert_not_called()
-    assert str(exc.value) == (f"Duplicate property name: {catalogue_category.properties[0].name}")
-
-
-def test_update_change_properties_with_non_existent_unit_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    unit_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_category_service,
-):
-    """
-    Test updating a catalogue category's properties when it has a non existent unit ID.
-    """
-    # pylint: disable=duplicate-code
-    unit = UnitOut(id=str(ObjectId()), **UNIT_A)
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        name="Category A",
-        code="category-a",
-        is_leaf=True,
-        parent_id=None,
-        properties=[
-            CatalogueCategoryPropertyOut(
-                id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
-            ),
-            CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
-        ],
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category.id,
-            name=catalogue_category.name,
-            code=catalogue_category.code,
-            is_leaf=catalogue_category.is_leaf,
-            parent_id=catalogue_category.parent_id,
-            properties=[catalogue_category.properties[1]],
-            created_time=catalogue_category.created_time,
-            modified_time=catalogue_category.created_time,
-        ),
-    )
-
-    # Mock `get` to return the unit
-    test_helpers.mock_get(unit_repository_mock, None)
-    # Mock so child elements not found
-    catalogue_category_repository_mock.has_child_elements.return_value = False
-    # pylint: enable=duplicate-code
-    # Mock `update` to return the updated catalogue category
-    test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_category_service.update(
-            catalogue_category.id,
-            CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
-        )
-    catalogue_category_repository_mock.update.assert_not_called()
-    assert str(exc.value) == (f"No unit found with ID: {unit.id}")
+
+        # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
+        # be different
+        if self._catalogue_category_post.properties:
+            actual_catalogue_category_in = self.mock_catalogue_category_repository.create.call_args_list[0][0][0]
+            assert isinstance(actual_catalogue_category_in, CatalogueCategoryIn)
+            assert actual_catalogue_category_in.model_dump() == {
+                **self._expected_catalogue_category_in.model_dump(),
+                "properties": [
+                    {**prop.model_dump(), "id": ANY} for prop in self._expected_catalogue_category_in.properties
+                ],
+            }
+        else:
+            self.mock_catalogue_category_repository.create.assert_called_once_with(self._expected_catalogue_category_in)
+
+        assert self._created_catalogue_category == self._expected_catalogue_category_out
+
+
+class TestCreate(CreateDSL):
+    """Tests for creating a catalogue category"""
+
+    def test_create_without_properties(self):
+        """Test creating a catalogue category without properties"""
+
+        self.mock_create(CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A)
+        self.call_create()
+        self.check_create_success()
+
+    def test_create_with_properties(self):
+        """Test creating a catalogue category with properties"""
+
+        self.mock_create(CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM, units_in_data=[UNIT_IN_DATA_MM])
+        self.call_create()
+        self.check_create_success()
+
+
+# UNIT_A = {
+#     "value": "mm",
+#     "code": "mm",
+#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+# }
+
+
+# def test_create_with_parent_id(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     unit_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test creating a catalogue category with a parent ID.
+
+#     Verify that the `create` method properly handles a catalogue category with a parent ID.
+#     """
+
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+
+#     # pylint: disable=duplicate-code
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=True,
+#         parent_id=str(ObjectId()),
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()),
+#                 name="Property A",
+#                 type="number",
+#                 unit_id=unit.id,
+#                 unit=unit.value,
+#                 mandatory=False,
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the parent catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.parent_id,
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=False,
+#             parent_id=None,
+#             properties=[],
+#             created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#             modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+
+#     # Mock `create` to return the created catalogue category
+#     test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
+
+#     created_catalogue_category = catalogue_category_service.create(
+#         CatalogueCategoryPostSchema(
+#             name=catalogue_category.name,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[prop.model_dump() for prop in catalogue_category.properties],
+#         )
+#     )
+
+#     # pylint: disable=duplicate-code
+#     # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
+#     # be different
+#     catalogue_category_repository_mock.create.assert_called_once()
+#     create_catalogue_category_in = catalogue_category_repository_mock.create.call_args_list[0][0][0]
+#     assert isinstance(create_catalogue_category_in, CatalogueCategoryIn)
+#     assert create_catalogue_category_in.model_dump() == {
+#         **(
+#             CatalogueCategoryIn(
+#                 name=catalogue_category.name,
+#                 code=catalogue_category.code,
+#                 is_leaf=catalogue_category.is_leaf,
+#                 parent_id=catalogue_category.parent_id,
+#                 properties=[prop.model_dump() for prop in catalogue_category.properties],
+#             ).model_dump()
+#         ),
+#         "properties": [{**prop.model_dump(), "id": ANY, "unit_id": ANY} for prop in catalogue_category.properties],
+#     }
+#     # pylint: enable=duplicate-code
+#     assert created_catalogue_category == catalogue_category
+
+
+# def test_create_with_whitespace_name(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     unit_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test creating a catalogue category name containing leading/trailing/consecutive whitespaces.
+
+#     Verify that the `create` method trims the whitespace from the category name and handles it correctly.
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="    Category   A         ",
+#         code="category-a",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `create` to return the created catalogue category
+#     test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+
+#     created_catalogue_category = catalogue_category_service.create(
+#         CatalogueCategoryPostSchema(
+#             name=catalogue_category.name,
+#             is_leaf=catalogue_category.is_leaf,
+#             properties=[prop.model_dump() for prop in catalogue_category.properties],
+#         )
+#     )
+
+#     # pylint: disable=duplicate-code
+#     # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
+#     # be different
+#     catalogue_category_repository_mock.create.assert_called_once()
+#     create_catalogue_category_in = catalogue_category_repository_mock.create.call_args_list[0][0][0]
+#     assert isinstance(create_catalogue_category_in, CatalogueCategoryIn)
+#     assert create_catalogue_category_in.model_dump() == {
+#         **(
+#             CatalogueCategoryIn(
+#                 name=catalogue_category.name,
+#                 code=catalogue_category.code,
+#                 is_leaf=catalogue_category.is_leaf,
+#                 parent_id=catalogue_category.parent_id,
+#                 properties=[prop.model_dump() for prop in catalogue_category.properties],
+#             ).model_dump()
+#         ),
+#         "properties": [{**prop.model_dump(), "id": ANY, "unit_id": ANY} for prop in catalogue_category.properties],
+#     }
+#     # pylint: enable=duplicate-code
+#     assert created_catalogue_category == catalogue_category
+
+
+# def test_create_with_leaf_parent_catalogue_category(
+#     test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
+# ):
+#     """
+#     Test creating a catalogue category in a leaf parent catalogue category.
+#     """
+#     # pylint: disable=duplicate-code
+
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=False,
+#         parent_id=str(ObjectId()),
+#         properties=[],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the parent catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.parent_id,
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=True,
+#             parent_id=None,
+#             properties=[
+#                 CatalogueCategoryPropertyOut(
+#                     id=str(ObjectId()),
+#                     name="Property A",
+#                     type="number",
+#                     unit_id=unit.id,
+#                     unit=unit.value,
+#                     mandatory=False,
+#                 ),
+#                 CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#             ],
+#             created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#             modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+
+#     with pytest.raises(LeafCatalogueCategoryError) as exc:
+#         catalogue_category_service.create(
+#             CatalogueCategoryPostSchema(
+#                 name=catalogue_category.name,
+#                 is_leaf=catalogue_category.is_leaf,
+#                 parent_id=catalogue_category.parent_id,
+#                 properties=catalogue_category.properties,
+#             )
+#         )
+#     catalogue_category_repository_mock.create.assert_not_called()
+#     assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
+
+
+# def test_create_with_duplicate_property_names(
+#     test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
+# ):
+#     """
+#     Test trying to create a catalogue category with duplicate property names
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property A", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+#     # pylint: enable=duplicate-code
+
+#     with pytest.raises(DuplicateCatalogueCategoryPropertyNameError) as exc:
+#         # pylint: disable=duplicate-code
+#         catalogue_category_service.create(
+#             CatalogueCategoryPostSchema(
+#                 name=catalogue_category.name,
+#                 is_leaf=catalogue_category.is_leaf,
+#                 properties=[prop.model_dump() for prop in catalogue_category.properties],
+#             )
+#         )
+#         # pylint: enable=duplicate-code
+#     catalogue_category_repository_mock.create.assert_not_called()
+#     assert str(exc.value) == (f"Duplicate property name: {catalogue_category.properties[0].name}")
+
+
+# def test_create_properties_with_non_existent_unit_id(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     unit_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test creating a catalogue category with a non existent unit ID.
+#     """
+
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+
+#     # pylint: disable=duplicate-code
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=True,
+#         parent_id=str(ObjectId()),
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()),
+#                 name="Property A",
+#                 type="number",
+#                 unit_id=unit.id,
+#                 unit=unit.value,
+#                 mandatory=False,
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the parent catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.parent_id,
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=False,
+#             parent_id=None,
+#             properties=[],
+#             created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#             modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, None)
+
+#     # Mock `create` to return the created catalogue category
+#     test_helpers.mock_create(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_category_service.create(
+#             CatalogueCategoryPostSchema(
+#                 name=catalogue_category.name,
+#                 is_leaf=catalogue_category.is_leaf,
+#                 parent_id=catalogue_category.parent_id,
+#                 properties=[prop.model_dump() for prop in catalogue_category.properties],
+#             )
+#         )
+#     catalogue_category_repository_mock.create.assert_not_called()
+#     assert str(exc.value) == (f"No unit found with ID: {unit.id}")
+
+
+# def test_delete(catalogue_category_repository_mock, catalogue_category_service):
+#     """
+#     Test deleting a catalogue category.
+
+#     Verify that the `delete` method properly handles the deletion of a catalogue category by ID.
+#     """
+#     catalogue_category_id = str(ObjectId())
+
+#     catalogue_category_service.delete(catalogue_category_id)
+
+#     catalogue_category_repository_mock.delete.assert_called_once_with(catalogue_category_id)
+
+
+# def test_get(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+#     """
+#     Test getting a catalogue category.
+
+#     Verify that the `get` method properly handles the retrieval of a catalogue category by ID.
+#     """
+#     # pylint: disable=duplicate-code
+#     catalogue_category_id = str(ObjectId())
+#     catalogue_category = MagicMock()
+
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
+
+#     retrieved_catalogue_category = catalogue_category_service.get(catalogue_category_id)
+
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
+#     assert retrieved_catalogue_category == catalogue_category
+
+
+# def test_get_with_non_existent_id(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+#     """
+#     Test getting a catalogue category with a non-existent ID.
+
+#     Verify that the `get` method properly handles the retrieval of a catalogue category with a non-existent ID.
+#     """
+#     catalogue_category_id = str(ObjectId())
+
+#     # Mock `get` to not return a catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, None)
+
+#     retrieved_catalogue_category = catalogue_category_service.get(catalogue_category_id)
+
+#     assert retrieved_catalogue_category is None
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
+
+
+# def test_get_breadcrumbs(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+#     """
+#     Test getting breadcrumbs for a catalogue category
+
+#     Verify that the `get_breadcrumbs` method properly handles the retrieval of breadcrumbs for a catalogue category
+#     """
+#     catalogue_category_id = str(ObjectId())
+#     breadcrumbs = MagicMock()
+
+#     # Mock `get` to return breadcrumbs
+#     test_helpers.mock_get_breadcrumbs(catalogue_category_repository_mock, breadcrumbs)
+
+#     retrieved_breadcrumbs = catalogue_category_service.get_breadcrumbs(catalogue_category_id)
+
+#     catalogue_category_repository_mock.get_breadcrumbs.assert_called_once_with(catalogue_category_id)
+#     assert retrieved_breadcrumbs == breadcrumbs
+
+
+# def test_list(catalogue_category_repository_mock, catalogue_category_service):
+#     """
+#     Test listing catalogue categories.
+
+#     Verify that the `list` method properly calls the repository function with any passed filters
+#     """
+
+#     parent_id = MagicMock()
+
+#     result = catalogue_category_service.list(parent_id=parent_id)
+
+#     catalogue_category_repository_mock.list.assert_called_once_with(parent_id)
+#     assert result == catalogue_category_repository_mock.list.return_value
+
+
+# def test_update_when_no_child_elements(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test updating a catalogue category without child elements
+
+#     Verify that the `update` method properly handles the catalogue category to be updated when it doesn't have any
+#     child elements.
+#     """
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     updated_catalogue_category = catalogue_category_service.update(
+#         catalogue_category.id, CatalogueCategoryPatchSchema(name=catalogue_category.name)
+#     )
+
+#     # pylint: disable=duplicate-code
+#     catalogue_category_repository_mock.update.assert_called_once_with(
+#         catalogue_category.id,
+#         CatalogueCategoryIn(
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.modified_time,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+#     assert updated_catalogue_category == catalogue_category
+
+
+# def test_update_when_has_child_elements(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test updating a catalogue category when it has child elements
+
+#     Verify that the `update` method properly handles the catalogue category to be updated when it has children.
+#     """
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+#     # Mock so child elements found
+#     catalogue_category_repository_mock.has_child_elements.return_value = True
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     updated_catalogue_category = catalogue_category_service.update(
+#         catalogue_category.id, CatalogueCategoryPatchSchema(name=catalogue_category.name)
+#     )
+
+#     # pylint: disable=duplicate-code
+#     catalogue_category_repository_mock.update.assert_called_once_with(
+#         catalogue_category.id,
+#         CatalogueCategoryIn(
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.modified_time,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+#     assert updated_catalogue_category == catalogue_category
+
+
+# def test_update_with_non_existent_id(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
+#     """
+#     Test updating a catalogue category with a non-existent ID.
+
+#     Verify that the `update` method properly handles the catalogue category to be updated with a non-existent ID.
+#     """
+#     # Mock `get` to not return a catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, None)
+
+#     catalogue_category_id = str(ObjectId())
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_category_service.update(catalogue_category_id, CatalogueCategoryPatchSchema(properties=[]))
+#     catalogue_category_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
+
+
+# def test_update_change_parent_id(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test moving a catalogue category to another parent catalogue category.
+#     """
+
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category B",
+#         code="category-b",
+#         is_leaf=False,
+#         parent_id=str(ObjectId()),
+#         properties=[],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=None,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a parent catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=str(ObjectId()),
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=False,
+#             parent_id=None,
+#             properties=[],
+#             created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#             modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     updated_catalogue_category = catalogue_category_service.update(
+#         catalogue_category.id, CatalogueCategoryPatchSchema(parent_id=catalogue_category.parent_id)
+#     )
+
+#     # pylint: disable=duplicate-code
+#     catalogue_category_repository_mock.update.assert_called_once_with(
+#         catalogue_category.id,
+#         CatalogueCategoryIn(
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.modified_time,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+#     assert updated_catalogue_category == catalogue_category
+
+
+# def test_update_change_parent_id_leaf_parent_catalogue_category(
+#     test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
+# ):
+#     """
+#     Testing moving a catalogue category to a leaf parent catalogue category.
+#     """
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category_b_id = str(ObjectId())
+#     # Mock `get` to return a catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category_b_id,
+#             name="Category B",
+#             code="category-b",
+#             is_leaf=False,
+#             parent_id=None,
+#             properties=[],
+#             created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#             modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         ),
+#     )
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     catalogue_category_a_id = str(ObjectId())
+#     # Mock `get` to return a parent catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category_b_id,
+#             name="Category A",
+#             code="category-a",
+#             is_leaf=True,
+#             parent_id=None,
+#             properties=[
+#                 CatalogueCategoryPropertyOut(
+#                     id=str(ObjectId()),
+#                     name="Property A",
+#                     type="number",
+#                     unit_id=unit.id,
+#                     unit=unit.value,
+#                     mandatory=False,
+#                 ),
+#                 CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#             ],
+#             created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#             modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+
+#     with pytest.raises(LeafCatalogueCategoryError) as exc:
+#         catalogue_category_service.update(
+#             catalogue_category_b_id, CatalogueCategoryPatchSchema(parent_id=catalogue_category_a_id)
+#         )
+#     catalogue_category_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == "Cannot add catalogue category to a leaf parent catalogue category"
+
+
+# def test_update_change_from_leaf_to_non_leaf_when_no_child_elements(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     unit_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test changing a catalogue category from leaf to non-leaf when the category doesn't have any child elements.
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category A",
+#         code="category-a",
+#         is_leaf=False,
+#         parent_id=None,
+#         properties=[],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=True,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[
+#                 CatalogueCategoryPropertyOut(
+#                     id=str(ObjectId()),
+#                     name="Property A",
+#                     type="number",
+#                     unit_id=unit.id,
+#                     unit=unit.value,
+#                     mandatory=False,
+#                 ),
+#                 CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#             ],
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     updated_catalogue_category = catalogue_category_service.update(
+#         catalogue_category.id, CatalogueCategoryPatchSchema(is_leaf=False)
+#     )
+
+#     catalogue_category_repository_mock.update.assert_called_once_with(
+#         catalogue_category.id,
+#         CatalogueCategoryIn(
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=catalogue_category.properties,
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.modified_time,
+#         ),
+#     )
+#     assert updated_catalogue_category == catalogue_category
+
+
+# def test_update_change_properties_when_no_child_elements(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     unit_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test updating a catalogue category's item properties when it has no child elements.
+
+#     Verify that the `update` method properly handles the catalogue category to be updated.
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category A",
+#         code="category-a",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[catalogue_category.properties[1]],
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     # pylint: enable=duplicate-code
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     updated_catalogue_category = catalogue_category_service.update(
+#         catalogue_category.id,
+#         CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
+#     )
+
+#     # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
+#     # be different
+#     catalogue_category_repository_mock.update.assert_called_once_with(catalogue_category.id, ANY)
+#     update_catalogue_category_in = catalogue_category_repository_mock.update.call_args_list[0][0][1]
+#     assert isinstance(update_catalogue_category_in, CatalogueCategoryIn)
+#     assert update_catalogue_category_in.model_dump() == {
+#         **(
+#             CatalogueCategoryIn(
+#                 name=catalogue_category.name,
+#                 code=catalogue_category.code,
+#                 is_leaf=catalogue_category.is_leaf,
+#                 parent_id=catalogue_category.parent_id,
+#                 properties=[prop.model_dump() for prop in catalogue_category.properties],
+#                 created_time=catalogue_category.created_time,
+#                 modified_time=catalogue_category.modified_time,
+#             ).model_dump()
+#         ),
+#         "properties": [{**prop.model_dump(), "id": ANY, "unit_id": ANY} for prop in catalogue_category.properties],
+#     }
+#     assert updated_catalogue_category == catalogue_category
+
+
+# def test_update_change_from_leaf_to_non_leaf_when_has_child_elements(
+#     test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
+# ):
+#     """
+#     Test changing a catalogue category from leaf to non-leaf when the category has child elements.
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category A",
+#         code="category-a",
+#         is_leaf=False,
+#         parent_id=None,
+#         properties=[],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=True,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[
+#                 CatalogueCategoryPropertyOut(
+#                     id=str(ObjectId()),
+#                     name="Property A",
+#                     type="number",
+#                     unit_id=unit.id,
+#                     unit=unit.value,
+#                     mandatory=False,
+#                 ),
+#                 CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#             ],
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.modified_time,
+#         ),
+#     )
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+#     # Mock so child elements found
+#     catalogue_category_repository_mock.has_child_elements.return_value = True
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(ChildElementsExistError) as exc:
+#         catalogue_category_service.update(catalogue_category.id, CatalogueCategoryPatchSchema(is_leaf=False))
+#     catalogue_category_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value)
+#         == f"Catalogue category with ID {str(catalogue_category.id)} has child elements and cannot be updated"
+#     )
+
+
+# def test_update_change_properties_when_has_child_elements(
+#     test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
+# ):
+#     """
+#     Test updating a catalogue category's item properties when it has child elements.
+
+#     Verify that the `update` method properly handles the catalogue category to be updated.
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category A",
+#         code="category-a",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[catalogue_category.properties[1]],
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+#     # Mock so child elements found
+#     catalogue_category_repository_mock.has_child_elements.return_value = True
+#     # pylint: enable=duplicate-code
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(ChildElementsExistError) as exc:
+#         catalogue_category_service.update(
+#             catalogue_category.id,
+#             CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
+#         )
+#     catalogue_category_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value)
+#         == f"Catalogue category with ID {str(catalogue_category.id)} has child elements and cannot be updated"
+#     )
+
+
+# def test_update_properties_to_have_duplicate_names(
+#     test_helpers, catalogue_category_repository_mock, unit_repository_mock, catalogue_category_service
+# ):
+#     """
+#     Test that checks that trying to update properties so that the names are duplicated is not allowed
+
+#     Verify the `update` method properly handles the catalogue category to be updated
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category A",
+#         code="category-a",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()), name="Duplicate", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Duplicate", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[catalogue_category.properties[1]],
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, unit)
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     # pylint: enable=duplicate-code
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(DuplicateCatalogueCategoryPropertyNameError) as exc:
+#         catalogue_category_service.update(
+#             catalogue_category.id,
+#             CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
+#         )
+#     catalogue_category_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == (f"Duplicate property name: {catalogue_category.properties[0].name}")
+
+
+# def test_update_change_properties_with_non_existent_unit_id(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     unit_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_category_service,
+# ):
+#     """
+#     Test updating a catalogue category's properties when it has a non existent unit ID.
+#     """
+#     # pylint: disable=duplicate-code
+#     unit = UnitOut(id=str(ObjectId()), **UNIT_A)
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         name="Category A",
+#         code="category-a",
+#         is_leaf=True,
+#         parent_id=None,
+#         properties=[
+#             CatalogueCategoryPropertyOut(
+#                 id=str(ObjectId()), name="Property A", type="number", unit_id=unit.id, unit=unit.value, mandatory=False
+#             ),
+#             CatalogueCategoryPropertyOut(id=str(ObjectId()), name="Property B", type="boolean", mandatory=True),
+#         ],
+#         created_time=MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
+#         modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category.id,
+#             name=catalogue_category.name,
+#             code=catalogue_category.code,
+#             is_leaf=catalogue_category.is_leaf,
+#             parent_id=catalogue_category.parent_id,
+#             properties=[catalogue_category.properties[1]],
+#             created_time=catalogue_category.created_time,
+#             modified_time=catalogue_category.created_time,
+#         ),
+#     )
+
+#     # Mock `get` to return the unit
+#     test_helpers.mock_get(unit_repository_mock, None)
+#     # Mock so child elements not found
+#     catalogue_category_repository_mock.has_child_elements.return_value = False
+#     # pylint: enable=duplicate-code
+#     # Mock `update` to return the updated catalogue category
+#     test_helpers.mock_update(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_category_service.update(
+#             catalogue_category.id,
+#             CatalogueCategoryPatchSchema(properties=[prop.model_dump() for prop in catalogue_category.properties]),
+#         )
+#     catalogue_category_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == (f"No unit found with ID: {unit.id}")

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -48,7 +48,7 @@ from inventory_management_system_api.services.catalogue_category import Catalogu
 
 
 class CatalogueCategoryServiceDSL:
-    """Base class for CatalogueCategoryService unit tests"""
+    """Base class for `CatalogueCategoryService` unit tests"""
 
     wrapped_utils: Mock
     mock_catalogue_category_repository: Mock
@@ -142,7 +142,7 @@ class CatalogueCategoryServiceDSL:
 
 
 class CreateDSL(CatalogueCategoryServiceDSL):
-    """Base class for create tests"""
+    """Base class for `create` tests"""
 
     _catalogue_category_post: CatalogueCategoryPostSchema
     _expected_catalogue_category_in: CatalogueCategoryIn
@@ -327,7 +327,7 @@ class TestCreate(CreateDSL):
 
 
 class GetDSL(CatalogueCategoryServiceDSL):
-    """Base class for get tests"""
+    """Base class for `get` tests"""
 
     _obtained_catalogue_category_id: str
     _expected_catalogue_category: MagicMock
@@ -366,7 +366,7 @@ class TestGet(GetDSL):
 
 
 class GetBreadcrumbsDSL(CatalogueCategoryServiceDSL):
-    """Base class for get_breadcrumbs tests"""
+    """Base class for `get_breadcrumbs` tests"""
 
     _expected_breadcrumbs: MagicMock
     _obtained_breadcrumbs: MagicMock
@@ -407,7 +407,7 @@ class TestGetBreadcrumbs(GetBreadcrumbsDSL):
 
 
 class ListDSL(CatalogueCategoryServiceDSL):
-    """Base class for list tests"""
+    """Base class for `list` tests"""
 
     _parent_id_filter: Optional[str]
     _expected_catalogue_categories: MagicMock
@@ -447,7 +447,7 @@ class TestList(ListDSL):
 
 # pylint:disable=too-many-instance-attributes
 class UpdateDSL(CatalogueCategoryServiceDSL):
-    """Base class for update tests"""
+    """Base class for `update` tests"""
 
     _stored_catalogue_category: Optional[CatalogueCategoryOut]
     _catalogue_category_patch: CatalogueCategoryPatchSchema
@@ -796,7 +796,7 @@ class TestUpdate(UpdateDSL):
 
 
 class DeleteDSL(CatalogueCategoryServiceDSL):
-    """Base class for delete tests"""
+    """Base class for `delete` tests"""
 
     _delete_catalogue_category_id: str
 

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -123,8 +123,8 @@ class CreateDSL(CatalogueCategoryServiceDSL):
     ):
         """Mocks repo methods appropriately to test the 'create' service method
 
-        :param catalogue_category_data: Dictionary containing the basic system data as would be required for a
-                                        CatalogueCategoryPostSchema but without any unit_id's in its properties
+        :param catalogue_category_data: Dictionary containing the basic catalogue category data as would be required
+                                        for a CatalogueCategoryPostSchema but without any unit_id's in its properties
                                         as they will be added automatically
         :param parent_catalogue_category_in_data: Either None or a dictionary containing the parent catalogue category
                                                   data as would be required for a CatalogueCategoryIn database model
@@ -217,8 +217,8 @@ class CreateDSL(CatalogueCategoryServiceDSL):
         )
 
         if self._catalogue_category_post.properties:
-            # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will always
-            # be different
+            # To assert with property ids we must compare as dicts and use ANY here as otherwise the ObjectIds will
+            # always be different
             actual_catalogue_category_in = self.mock_catalogue_category_repository.create.call_args_list[0][0][0]
             assert isinstance(actual_catalogue_category_in, CatalogueCategoryIn)
             assert actual_catalogue_category_in.model_dump() == {
@@ -303,94 +303,161 @@ class TestCreate(CreateDSL):
         self.check_create_failed_with_exception("Cannot add catalogue category to a leaf parent catalogue category")
 
 
+class GetDSL(CatalogueCategoryServiceDSL):
+    """Base class for get tests"""
+
+    _obtained_catalogue_category_id: str
+    _expected_catalogue_category: MagicMock
+    _obtained_catalogue_category: MagicMock
+
+    def mock_get(self):
+        """Mocks repo methods appropriately to test the 'get' service method"""
+
+        # Simply a return currently, so no need to use actual data
+        self._expected_catalogue_category = MagicMock()
+        ServiceTestHelpers.mock_get(self.mock_catalogue_category_repository, self._expected_catalogue_category)
+
+    def call_get(self, catalogue_category_id: str):
+        """Calls the CatalogueCategoryService `get` method"""
+
+        self._obtained_catalogue_category_id = catalogue_category_id
+        self._obtained_catalogue_category = self.catalogue_category_service.get(catalogue_category_id)
+
+    def check_get_success(self):
+        """Checks that a prior call to `call_get` worked as expected"""
+
+        self.mock_catalogue_category_repository.get.assert_called_once_with(self._obtained_catalogue_category_id)
+
+        assert self._obtained_catalogue_category == self._expected_catalogue_category
+
+
+class TestGet(GetDSL):
+    """Tests for getting a catalogue category"""
+
+    def test_get(self):
+        """Test getting a catalogue category"""
+
+        self.mock_get()
+        self.call_get(str(ObjectId()))
+        self.check_get_success()
+
+
+class GetBreadcrumbsDSL(CatalogueCategoryServiceDSL):
+    """Base class for get_breadcrumbs tests"""
+
+    _expected_breadcrumbs: MagicMock
+    _obtained_breadcrumbs: MagicMock
+    _obtained_catalogue_category_id: str
+
+    def mock_get_breadcrumbs(self):
+        """Mocks repo methods appropriately to test the 'get_breadcrumbs' service method"""
+
+        # Simply a return currently, so no need to use actual data
+        self._expected_breadcrumbs = MagicMock()
+        ServiceTestHelpers.mock_get_breadcrumbs(self.mock_catalogue_category_repository, self._expected_breadcrumbs)
+
+    def call_get_breadcrumbs(self, catalogue_category_id: str):
+        """Calls the CatalogueCategoryService `get_breadcrumbs` method"""
+
+        self._obtained_catalogue_category_id = catalogue_category_id
+        self._obtained_breadcrumbs = self.catalogue_category_service.get_breadcrumbs(catalogue_category_id)
+
+    def check_get_breadcrumbs_success(self):
+        """Checks that a prior call to `call_get_breadcrumbs` worked as expected"""
+
+        self.mock_catalogue_category_repository.get_breadcrumbs.assert_called_once_with(
+            self._obtained_catalogue_category_id
+        )
+
+        assert self._obtained_breadcrumbs == self._expected_breadcrumbs
+
+
+class TestGetBreadcrumbs(GetBreadcrumbsDSL):
+    """Tests for getting the breadcrumbs of a catalogue category"""
+
+    def test_get_breadcrumbs(self):
+        """Test getting a catalogue category's breadcrumbs"""
+
+        self.mock_get_breadcrumbs()
+        self.call_get_breadcrumbs(str(ObjectId()))
+        self.check_get_breadcrumbs_success()
+
+
+class ListDSL(CatalogueCategoryServiceDSL):
+    """Base class for list tests"""
+
+    _parent_id_filter: Optional[str]
+    _expected_catalogue_categories: MagicMock
+    _obtained_catalogue_categories: MagicMock
+
+    def mock_list(self):
+        """Mocks repo methods appropriately to test the 'list' service method"""
+
+        # Simply a return currently, so no need to use actual data
+        self._expected_catalogue_categories = MagicMock()
+        ServiceTestHelpers.mock_list(self.mock_catalogue_category_repository, self._expected_catalogue_categories)
+
+    def call_list(self, parent_id: Optional[str]):
+        """Calls the CatalogueCategoryService `list` method"""
+
+        self._parent_id_filter = parent_id
+        self._obtained_catalogue_categories = self.catalogue_category_service.list(parent_id)
+
+    def check_list_success(self):
+        """Checks that a prior call to `call_list` worked as expected"""
+
+        self.mock_catalogue_category_repository.list.assert_called_once_with(self._parent_id_filter)
+
+        assert self._obtained_catalogue_categories == self._expected_catalogue_categories
+
+
+class TestList(ListDSL):
+    """Tests for listing catalogue categories"""
+
+    def test_list(self):
+        """Test listing catalogue categories"""
+
+        self.mock_list()
+        self.call_list(str(ObjectId()))
+        self.check_list_success()
+
+
+# TODO: Add update tests
+
+
+class DeleteDSL(CatalogueCategoryServiceDSL):
+    """Base class for delete tests"""
+
+    _delete_catalogue_category_id: str
+
+    def call_delete(self, catalogue_category_id: str):
+        """Calls the CatalogueCategoryService `delete` method"""
+
+        self._delete_catalogue_category_id = catalogue_category_id
+        self.catalogue_category_service.delete(catalogue_category_id)
+
+    def check_delete_success(self):
+        """Checks that a prior call to `call_delete` worked as expected"""
+
+        self.mock_catalogue_category_repository.delete.assert_called_once_with(self._delete_catalogue_category_id)
+
+
+class TestDelete(DeleteDSL):
+    """Tests for deleting a catalogue category"""
+
+    def test_delete(self):
+        """Test deleting a catalogue category"""
+
+        self.call_delete(str(ObjectId()))
+        self.check_delete_success()
+
+
 # UNIT_A = {
 #     "value": "mm",
 #     "code": "mm",
 #     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
 #     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
 # }
-
-
-# def test_delete(catalogue_category_repository_mock, catalogue_category_service):
-#     """
-#     Test deleting a catalogue category.
-
-#     Verify that the `delete` method properly handles the deletion of a catalogue category by ID.
-#     """
-#     catalogue_category_id = str(ObjectId())
-
-#     catalogue_category_service.delete(catalogue_category_id)
-
-#     catalogue_category_repository_mock.delete.assert_called_once_with(catalogue_category_id)
-
-
-# def test_get(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-#     """
-#     Test getting a catalogue category.
-
-#     Verify that the `get` method properly handles the retrieval of a catalogue category by ID.
-#     """
-#     # pylint: disable=duplicate-code
-#     catalogue_category_id = str(ObjectId())
-#     catalogue_category = MagicMock()
-
-#     # Mock `get` to return a catalogue category
-#     test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-#     retrieved_catalogue_category = catalogue_category_service.get(catalogue_category_id)
-
-#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
-#     assert retrieved_catalogue_category == catalogue_category
-
-
-# def test_get_with_non_existent_id(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-#     """
-#     Test getting a catalogue category with a non-existent ID.
-
-#     Verify that the `get` method properly handles the retrieval of a catalogue category with a non-existent ID.
-#     """
-#     catalogue_category_id = str(ObjectId())
-
-#     # Mock `get` to not return a catalogue category
-#     test_helpers.mock_get(catalogue_category_repository_mock, None)
-
-#     retrieved_catalogue_category = catalogue_category_service.get(catalogue_category_id)
-
-#     assert retrieved_catalogue_category is None
-#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
-
-
-# def test_get_breadcrumbs(test_helpers, catalogue_category_repository_mock, catalogue_category_service):
-#     """
-#     Test getting breadcrumbs for a catalogue category
-
-#     Verify that the `get_breadcrumbs` method properly handles the retrieval of breadcrumbs for a catalogue category
-#     """
-#     catalogue_category_id = str(ObjectId())
-#     breadcrumbs = MagicMock()
-
-#     # Mock `get` to return breadcrumbs
-#     test_helpers.mock_get_breadcrumbs(catalogue_category_repository_mock, breadcrumbs)
-
-#     retrieved_breadcrumbs = catalogue_category_service.get_breadcrumbs(catalogue_category_id)
-
-#     catalogue_category_repository_mock.get_breadcrumbs.assert_called_once_with(catalogue_category_id)
-#     assert retrieved_breadcrumbs == breadcrumbs
-
-
-# def test_list(catalogue_category_repository_mock, catalogue_category_service):
-#     """
-#     Test listing catalogue categories.
-
-#     Verify that the `list` method properly calls the repository function with any passed filters
-#     """
-
-#     parent_id = MagicMock()
-
-#     result = catalogue_category_service.list(parent_id=parent_id)
-
-#     catalogue_category_repository_mock.list.assert_called_once_with(parent_id)
-#     assert result == catalogue_category_repository_mock.list.return_value
 
 
 # def test_update_when_no_child_elements(

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -3,7 +3,6 @@ Unit tests for the `CatalogueCategoryPropertyService` service.
 """
 
 from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW
-from test.unit.services.test_catalogue_category import UNIT_A
 from unittest.mock import ANY, patch
 
 import pytest
@@ -25,6 +24,13 @@ from inventory_management_system_api.schemas.catalogue_category import (
 
 # pylint:disable=too-many-locals
 # pylint:disable=too-many-arguments
+
+UNIT_A = {
+    "value": "mm",
+    "code": "mm",
+    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+}
 
 
 @patch("inventory_management_system_api.services.catalogue_category_property.mongodb_client")

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -154,13 +154,13 @@ class GetBreadcrumbsDSL(SystemServiceDSL):
         ServiceTestHelpers.mock_get_breadcrumbs(self.mock_system_repository, self._expected_breadcrumbs)
 
     def call_get_breadcrumbs(self, system_id: str):
-        """Calls the SystemService `get` method"""
+        """Calls the SystemService `get_breadcrumbs` method"""
 
         self._obtained_system_id = system_id
         self._obtained_breadcrumbs = self.system_service.get_breadcrumbs(system_id)
 
     def check_get_breadcrumbs_success(self):
-        """Checks that a prior call to `call_get` worked as expected"""
+        """Checks that a prior call to `call_get_breadcrumbs` worked as expected"""
 
         self.mock_system_repository.get_breadcrumbs.assert_called_once_with(self._obtained_system_id)
 
@@ -207,7 +207,7 @@ class ListDSL(SystemServiceDSL):
 
 
 class TestList(ListDSL):
-    """Tests for getting a system"""
+    """Tests for listing systems"""
 
     def test_list(self):
         """Test listing systems"""

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -51,7 +51,6 @@ class CreateDSL(SystemServiceDSL):
     _expected_system_in: SystemIn
     _expected_system_out: SystemOut
     _created_system: SystemOut
-    _create_exception: pytest.ExceptionInfo
 
     def mock_create(self, system_post_data: dict):
         """Mocks repo methods appropriately to test the 'create' service method

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -309,8 +309,8 @@ class UpdateDSL(SystemServiceDSL):
 class TestUpdate(UpdateDSL):
     """Tests for updating a system"""
 
-    def test_update_all_fields(self):
-        """Test updating all fields of a system"""
+    def test_update_all_fields_except_parent_id(self):
+        """Test updating all fields of a system except its parent id"""
 
         system_id = str(ObjectId())
 
@@ -322,7 +322,7 @@ class TestUpdate(UpdateDSL):
         self.call_update(system_id)
         self.check_update_success()
 
-    def test_update_description_field_only(self):
+    def test_update_description_only(self):
         """Test updating system's description field only (code should not need regenerating as name doesn't change)"""
 
         system_id = str(ObjectId())

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -48,7 +48,7 @@ class SystemServiceDSL:
 
 
 class CreateDSL(SystemServiceDSL):
-    """Base class for create tests"""
+    """Base class for `create` tests"""
 
     _system_post: SystemPostSchema
     _expected_system_in: SystemIn
@@ -104,7 +104,7 @@ class TestCreate(CreateDSL):
 
 
 class GetDSL(SystemServiceDSL):
-    """Base class for get tests"""
+    """Base class for `get` tests"""
 
     _obtained_system_id: str
     _expected_system: MagicMock
@@ -143,7 +143,7 @@ class TestGet(GetDSL):
 
 
 class GetBreadcrumbsDSL(SystemServiceDSL):
-    """Base class for get_breadcrumbs tests"""
+    """Base class for `get_breadcrumbs` tests"""
 
     _expected_breadcrumbs: MagicMock
     _obtained_breadcrumbs: MagicMock
@@ -182,7 +182,7 @@ class TestGetBreadcrumbs(GetBreadcrumbsDSL):
 
 
 class ListDSL(SystemServiceDSL):
-    """Base class for list tests"""
+    """Base class for `list` tests"""
 
     _parent_id_filter: Optional[str]
     _expected_systems: MagicMock
@@ -221,7 +221,7 @@ class TestList(ListDSL):
 
 
 class UpdateDSL(SystemServiceDSL):
-    """Base class for update tests"""
+    """Base class for `update` tests"""
 
     _stored_system: Optional[SystemOut]
     _system_patch: SystemPatchSchema
@@ -349,7 +349,7 @@ class TestUpdate(UpdateDSL):
 
 
 class DeleteDSL(SystemServiceDSL):
-    """Base class for delete tests"""
+    """Base class for `delete` tests"""
 
     _delete_system_id: str
 

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -2,6 +2,9 @@
 Unit tests for the `SystemService` service
 """
 
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
 from test.mock_data import SYSTEM_POST_DATA_NO_PARENT_A, SYSTEM_POST_DATA_NO_PARENT_B
 from test.unit.services.conftest import ServiceTestHelpers
 from typing import Optional


### PR DESCRIPTION
## Description

### Notes
- Disabled pylint duplicate-code in all new unit test files - It frequently picked up the tests as they are now similar as the logic is abstracted into one place - I think this will be needed in the e2e test files later too
- Addresses some minor comments from Viktor while doing manufacturer tests

Removed the tests:
- `test_create_with_whitespace_name` didn't actually test removing whitespace - it doesn't
- `test_get_with_non_existent_id` - Right now the code just returns whatever comes from the repo, whether none or not, so I didn't think this test was necessary (systems doesn't have one either)
- `test_update_properties_to_have_duplicate_names` logic is in utils, which is tested elsewhere, function call is asserted instead

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #308
