### PR TITLE
Refactor manufacturer tests

### DIFF
--- a/inventory_management_system_api/repositories/manufacturer.py
+++ b/inventory_management_system_api/repositories/manufacturer.py
@@ -21,9 +21,7 @@ logger = logging.getLogger()
 
 
 class ManufacturerRepo:
-    """
-    Repository for managing manufacturers in a MongoDb database.
-    """
+    """Repository for managing manufacturers in a MongoDb database."""
 
     def __init__(self, database: DatabaseDep) -> None:
         """
@@ -89,8 +87,8 @@ class ManufacturerRepo:
         :param manufacturer_id: The ID of the manufacturer to update.
         :param manufacturer: The manufacturer containing the update data.
         :param session: PyMongo ClientSession to use for database operations.
-        :raises: DuplicateRecordError: if a duplicate manufacturer is found.
-        :return: the updated manufacturer.
+        :raises DuplicateRecordError: If a duplicate manufacturer is found.
+        :return: The updated manufacturer.
         """
         manufacturer_id = CustomObjectId(manufacturer_id)
 
@@ -111,13 +109,13 @@ class ManufacturerRepo:
         """
         Delete a manufacturer by its ID from a MongoDB database.
 
-        The method Checks if the manufacturer is part of a catalogue item, and raises a `PartOfCatalogueItemError` if it
+        The method checks if the manufacturer is part of a catalogue item, and raises a `PartOfCatalogueItemError` if it
         is.
 
         :param manufacturer_id: The ID of the manufacturer to delete.
         :param session: PyMongo ClientSession to use for database operations.
-        :raises PartOfCatalogueItemError: if the manufacturer is part of a catalogue item.
-        :raises MissingRecordError: if the manufacturer doesn't exist.
+        :raises PartOfCatalogueItemError: If the manufacturer is part of a catalogue item.
+        :raises MissingRecordError: If the manufacturer doesn't exist.
         """
         manufacturer_id = CustomObjectId(manufacturer_id)
         if self._is_manufacturer_in_catalogue_item(str(manufacturer_id), session=session):
@@ -137,7 +135,7 @@ class ManufacturerRepo:
         :param code: The code of the manufacturer to check for duplicates.
         :param manufacturer_id: The ID of the manufacturer to check if the duplicate manufacturer found is itself.
         :param session: PyMongo ClientSession to use for database operations.
-        :return `True` if a duplicate manufacturer is found, `False` otherwise.
+        :return: `True` if a duplicate manufacturer is found, `False` otherwise.
         """
         logger.info("Checking if manufacturer with code '%s' already exists", code)
         manufacturer = self._manufacturers_collection.find_one(
@@ -151,7 +149,7 @@ class ManufacturerRepo:
 
         :param manufacturer_id: The ID of the manufacturer to check.
         :param session: PyMongo ClientSession to use for database operations.
-        :return: Returns `True` if the manufacturer is part of a catalogue item, `False` otherwise.
+        :return: `True` if the manufacturer is part of a catalogue item, `False` otherwise.
         """
         manufacturer_id = CustomObjectId(manufacturer_id)
         return (

--- a/inventory_management_system_api/routers/v1/manufacturer.py
+++ b/inventory_management_system_api/routers/v1/manufacturer.py
@@ -1,6 +1,6 @@
 """
-Module for providing an API router which defines routes for managing manufacturer using the
-`Manufacturer` service.
+Module for providing an API router which defines routes for managing manufacturer using the `ManufacturerService`
+service.
 """
 
 import logging
@@ -30,8 +30,8 @@ ManufacturerServiceDep = Annotated[ManufacturerService, Depends(ManufacturerServ
 
 @router.post(
     path="",
-    summary="Create new manufacturer",
-    response_description="The new manufacturer",
+    summary="Create a new manufacturer",
+    response_description="The created manufacturer",
     status_code=status.HTTP_201_CREATED,
 )
 def create_manufacturer(
@@ -40,26 +40,23 @@ def create_manufacturer(
     # pylint: disable=missing-function-docstring
     logger.info("Creating a new manufacturer")
     logger.debug("Manufacturer data is %s", manufacturer)
-
     try:
         manufacturer = manufacturer_service.create(manufacturer)
         return ManufacturerSchema(**manufacturer.model_dump())
-
     except DuplicateRecordError as exc:
-        message = "A manufacturer with the same name has been found"
+        message = "A manufacturer with the same name already exists"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
 
 
 @router.get(
     path="",
-    summary="Get all manufacturers",
+    summary="Get manufacturers",
     response_description="List of manufacturers",
 )
-def get_all_manufacturers(manufacturer_service: ManufacturerServiceDep) -> List[ManufacturerSchema]:
+def get_manufacturers(manufacturer_service: ManufacturerServiceDep) -> List[ManufacturerSchema]:
     # pylint: disable=missing-function-docstring
     logger.info("Getting manufacturers")
-
     manufacturers = manufacturer_service.list()
     return [ManufacturerSchema(**manufacturer.model_dump()) for manufacturer in manufacturers]
 
@@ -69,52 +66,51 @@ def get_all_manufacturers(manufacturer_service: ManufacturerServiceDep) -> List[
     summary="Get a manufacturer by ID",
     response_description="Single manufacturer",
 )
-def get_one_manufacturer(
+def get_manufacturer(
     manufacturer_id: Annotated[str, Path(description="The ID of the manufacturer to be retrieved")],
     manufacturer_service: ManufacturerServiceDep,
 ) -> ManufacturerSchema:
     # pylint: disable=missing-function-docstring
-    logger.info("Getting manufacturer with ID %s", manufacturer_id)
+    logger.info("Getting manufacturer with ID: %s", manufacturer_id)
     message = "Manufacturer not found"
     try:
         manufacturer = manufacturer_service.get(manufacturer_id)
         if not manufacturer:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message)
+        return ManufacturerSchema(**manufacturer.model_dump())
     except InvalidObjectIdError as exc:
-        logger.exception("The ID is not a valid object value")
+        logger.exception("The ID is not a valid ObjectId value")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
-
-    return ManufacturerSchema(**manufacturer.model_dump())
 
 
 @router.patch(
     path="/{manufacturer_id}",
-    summary="Update a manufacturer by its ID",
+    summary="Update a manufacturer partially by ID",
     response_description="Manufacturer updated successfully",
 )
-def edit_manufacturer(
+def partial_update_manufacturer(
     manufacturer: ManufacturerPatchSchema,
     manufacturer_id: Annotated[str, Path(description="The ID of the manufacturer that is to be updated")],
     manufacturer_service: ManufacturerServiceDep,
 ) -> ManufacturerSchema:
     # pylint: disable=missing-function-docstring
-    logger.info("Updating manufacturer with ID %s", manufacturer_id)
+    logger.info("Partially updating manufacturer with ID: %s", manufacturer_id)
     try:
         updated_manufacturer = manufacturer_service.update(manufacturer_id, manufacturer)
         return ManufacturerSchema(**updated_manufacturer.model_dump())
     except (MissingRecordError, InvalidObjectIdError) as exc:
-        message = "The specified manufacturer does not exist"
+        message = "Manufacturer not found"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except DuplicateRecordError as exc:
-        message = "A manufacturer with the same name has been found"
+        message = "A manufacturer with the same name already exists"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
 
 
 @router.delete(
     path="/{manufacturer_id}",
-    summary="Delete a manufacturer by its ID",
+    summary="Delete a manufacturer by ID",
     response_description="Manufacturer deleted successfully",
     status_code=status.HTTP_204_NO_CONTENT,
 )
@@ -127,10 +123,10 @@ def delete_manufacturer(
     try:
         manufacturer_service.delete(manufacturer_id)
     except (MissingRecordError, InvalidObjectIdError) as exc:
-        message = "The specified manufacturer does not exist"
+        message = "Manufacturer not found"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except PartOfCatalogueItemError as exc:
-        message = "The specified manufacturer is a part of a Catalogue Item"
+        message = "The specified manufacturer is a part of a catalogue item"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc

--- a/inventory_management_system_api/services/manufacturer.py
+++ b/inventory_management_system_api/services/manufacturer.py
@@ -19,23 +19,25 @@ logger = logging.getLogger()
 
 
 class ManufacturerService:
-    """Service for managing manufacturers"""
+    """
+    Service for managing manufacturers.
+    """
 
     def __init__(
         self,
         manufacturer_repository: Annotated[ManufacturerRepo, Depends(ManufacturerRepo)],
     ) -> None:
         """
-        Initialise the manufacturer service with a ManufacturerRepo
+        Initialise the `ManufacturerService` with a `ManufacturerRepo` repository.
 
         :param manufacturer_repository: The `ManufacturerRepo` repository to use.
         """
-
         self._manufacturer_repository = manufacturer_repository
 
     def create(self, manufacturer: ManufacturerPostSchema) -> ManufacturerOut:
         """
         Create a new manufacturer.
+
         :param manufacturer: The manufacturer to be created.
         :return: The created manufacturer.
         """
@@ -52,35 +54,36 @@ class ManufacturerService:
 
     def get(self, manufacturer_id: str) -> Optional[ManufacturerOut]:
         """
-        Get manufacturer by its ID.
+        Retrieve a manufacturer by its ID.
 
-        :param: manufacturer_id: The ID of the requested manufacturer
-        :return: The retrieved manufacturer, or None if not found
+        :param manufacturer_id: The ID of the manufacturer to retrieve.
+        :return: The retrieved manufacturer, or `None` if not found.
         """
         return self._manufacturer_repository.get(manufacturer_id)
 
     def list(self) -> List[ManufacturerOut]:
-        """Get all manufacturers
+        """
+        Retrieve all manufacturers.
 
-        :return: list of all manufacturers
+        :return: List of manufacturers, or empty list if no manufacturers.
         """
         return self._manufacturer_repository.list()
 
     def update(self, manufacturer_id: str, manufacturer: ManufacturerPatchSchema) -> ManufacturerOut:
-        """Update a manufacturer by its ID
-
-
-        :params: manufacturer_id: The ID of the manufacturer to be updated
-        :return: The updated manufacturer
-        :raises MissingRecordError: If manufacturer does not exist in database
         """
-        update_data = manufacturer.model_dump(exclude_unset=True)
+        Update a manufacturer by its ID.
 
+        :params: manufacturer_id: The ID of the manufacturer to be updated.
+        :raises MissingRecordError: If the manufacturer with the given ID does not exist.
+        :return: The updated manufacturer.
+        """
         stored_manufacturer = self.get(manufacturer_id)
         if not stored_manufacturer:
-            raise MissingRecordError(f"No manufacturer found with ID {manufacturer_id}")
+            raise MissingRecordError(f"No manufacturer found with ID: {manufacturer_id}")
 
-        if "name" in update_data and update_data["name"] != stored_manufacturer.name:
+        update_data = manufacturer.model_dump(exclude_unset=True)
+
+        if "name" in update_data and manufacturer.name != stored_manufacturer.name:
             update_data["code"] = utils.generate_code(manufacturer.name, "manufacturer")
 
         stored_manufacturer = stored_manufacturer.model_copy(
@@ -91,9 +94,8 @@ class ManufacturerService:
 
     def delete(self, manufacturer_id: str) -> None:
         """
-        Delete a manufacturer by its ID
+        Delete a manufacturer by its ID.
 
-        :param manufacturer_id: The ID of the manufacturer to delete
-
+        :param manufacturer_id: The ID of the manufacturer to delete.
         """
         return self._manufacturer_repository.delete(manufacturer_id)

--- a/inventory_management_system_api/services/manufacturer.py
+++ b/inventory_management_system_api/services/manufacturer.py
@@ -19,9 +19,7 @@ logger = logging.getLogger()
 
 
 class ManufacturerService:
-    """
-    Service for managing manufacturers.
-    """
+    """Service for managing manufacturers."""
 
     def __init__(
         self,

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -2052,6 +2052,7 @@ def test_partial_update_catalogue_item_change_manufacturer_id_when_no_child_item
     response = test_client.post("/v1/manufacturers", json=MANUFACTURER)
     manufacturer_d_id = response.json()["id"]
 
+    # pylint: disable=duplicate-code
     manufacturer_e_post = {
         "name": "Manufacturer E",
         "url": "http://example.com/",
@@ -2064,6 +2065,7 @@ def test_partial_update_catalogue_item_change_manufacturer_id_when_no_child_item
         },
         "telephone": "07384723948",
     }
+    # pylint: enable=duplicate-code
     response = test_client.post("/v1/manufacturers", json=manufacturer_e_post)
     manufacturer_e_id = response.json()["id"]
 

--- a/test/e2e/test_manufacturer.py
+++ b/test/e2e/test_manufacturer.py
@@ -1,4 +1,6 @@
-"""End-to-End tests for the manufacturer router."""
+"""
+End-to-End tests for the manufacturer router.
+"""
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code

--- a/test/e2e/test_manufacturer.py
+++ b/test/e2e/test_manufacturer.py
@@ -1,6 +1,4 @@
-"""
-End-to-End tests for the manufacturer router.
-"""
+"""End-to-End tests for the manufacturer router."""
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code
@@ -36,7 +34,8 @@ class CreateDSL:
         """
         Posts a manufacturer with the given data, returns the ID of the created manufacturer if successful.
 
-        :param manufacturer_post_data: Dictionary containing the manufacturer data that should be posted.
+        :param manufacturer_post_data: Dictionary containing the manufacturer data as would be required for a
+            `ManufacturerPostSchema`.
         :return: ID of the created manufacturer (or `None` if not successful).
         """
         self._post_response = self.test_client.post("/v1/manufacturers", json=manufacturer_post_data)
@@ -46,8 +45,8 @@ class CreateDSL:
         """
         Checks that a prior call to `post_manufacturer` gave a successful response with the expected data returned.
 
-        :param expected_manufacturer_get_data: Dictionary containing the expected manufacturer data that should be
-            returned.
+        :param expected_manufacturer_get_data: Dictionary containing the expected manufacturer data as would be required
+            for a `ManufacturerSchema`.
         """
         assert self._post_response.status_code == 201
         assert self._post_response.json() == expected_manufacturer_get_data
@@ -77,7 +76,7 @@ class CreateDSL:
 class TestCreate(CreateDSL):
     """Tests for creating a manufacturer."""
 
-    def test_create_with_only_require_values_provided(self):
+    def test_create_with_only_required_values_provided(self):
         """Test creating a manufacturer with only required values provided."""
         self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
         self.check_post_manufacturer_success(MANUFACTURER_GET_DATA_REQUIRED_VALUES_ONLY)
@@ -111,8 +110,8 @@ class GetDSL(CreateDSL):
         """
         Checks that a prior call to `get_manufacturer` gave a successful response with the expected data returned.
 
-        :param expected_manufacturer_get_data: Dictionary containing the expected manufacturer data that should be
-            returned.
+        :param expected_manufacturer_get_data: Dictionary containing the expected manufacturer data as would be required
+            for a `ManufacturerSchema`.
         """
         assert self._get_response.status_code == 200
         assert self._get_response.json() == expected_manufacturer_get_data
@@ -159,8 +158,8 @@ class ListDSL(GetDSL):
         """
         Checks that a prior call to `get_manufacturers` gave a successful response with the expected data returned.
 
-        :param expected_manufacturers_get_data: List of dictionaries containing the expected manufacturer data that
-            should be returned.
+        :param expected_manufacturers_get_data: List of dictionaries containing the expected manufacturer data as would
+            be required for a `ManufacturerSchema`.
         """
         assert self._get_response.status_code == 200
         assert self._get_response.json() == expected_manufacturers_get_data
@@ -194,7 +193,8 @@ class UpdateDSL(ListDSL):
         Updates a manufacturer with the given ID.
 
         :param manufacturer_id: ID of the manufacturer to be updated.
-        :param manufacturer_patch_data: Dictionary containing the manufacturer patch data.
+        :param manufacturer_patch_data: Dictionary containing the manufacturer patch data as would be required for a
+            `ManufacturerPatchSchema`.
         """
         self._patch_response = self.test_client.patch(
             f"/v1/manufacturers/{manufacturer_id}", json=manufacturer_patch_data
@@ -204,8 +204,8 @@ class UpdateDSL(ListDSL):
         """
         Checks that a prior call to `patch_manufacturer` gave a successful response with the expected data returned.
 
-        :param expected_manufacturer_get_data: Dictionaries containing the expected manufacturer data that should be
-            returned.
+        :param expected_manufacturer_get_data: Dictionaries containing the expected manufacturer data as would be
+            required for a `ManufacturerSchema`.
         """
         assert self._patch_response.status_code == 200
         assert self._patch_response.json() == expected_manufacturer_get_data
@@ -232,7 +232,6 @@ class TestUpdate(UpdateDSL):
 
     def test_partial_update_name_to_duplicate(self):
         """Test updating the name of a manufacturer to conflict with a pre-existing one."""
-
         self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
         system_id = self.post_manufacturer(MANUFACTURER_POST_DATA_ALL_VALUES)
         self.patch_manufacturer(system_id, {"name": MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY["name"]})
@@ -251,7 +250,6 @@ class TestUpdate(UpdateDSL):
 
     def test_partial_update_with_non_existent_id(self):
         """Test updating a non-existent manufacturer."""
-
         self.patch_manufacturer(str(ObjectId()), {})
         self.check_patch_manufacturer_failed_with_detail(404, "Manufacturer not found")
 
@@ -280,7 +278,7 @@ class DeleteDSL(UpdateDSL):
 
     def check_delete_manufacturer_failed_with_detail(self, status_code: int, detail: str) -> None:
         """
-        Checks that a prior call to 'delete_manufacturer' gave a failed response with the expected code and detail.
+        Checks that a prior call to `delete_manufacturer` gave a failed response with the expected code and detail.
 
         :param status_code: Expected status code to be returned.
         :param detail: Expected detail to be returned.

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -25,8 +25,8 @@ MANUFACTURER_POST_DATA_A = {
         "address_line": "1 Example Street",
         "town": "Oxford",
         "county": "Oxfordshire",
-        "postcode": "OX1 2AB",
         "country": "United Kingdom",
+        "postcode": "OX1 2AB",
     },
     "telephone": "0932348348",
 }
@@ -38,8 +38,8 @@ MANUFACTURER_POST_DATA_B = {
         "address_line": "2 Example Street",
         "town": "Oxford",
         "county": "Oxfordshire",
-        "postcode": "OX1 2AB",
         "country": "United Kingdom",
+        "postcode": "OX1 2AB",
     },
     "telephone": "073434394",
 }

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -20,7 +20,7 @@ CREATED_MODIFIED_GET_DATA_EXPECTED = {"created_time": ANY, "modified_time": ANY}
 
 MANUFACTURER_POST_DATA_A = {
     "name": "Manufacturer A",
-    "url": "http://testUrl.co.uk",
+    "url": "http://testurl.co.uk/",
     "address": {
         "address_line": "1 Example Street",
         "town": "Oxford",
@@ -33,7 +33,7 @@ MANUFACTURER_POST_DATA_A = {
 
 MANUFACTURER_POST_DATA_B = {
     "name": "Manufacturer B",
-    "url": "http://example.co.uk",
+    "url": "http://example.co.uk/",
     "address": {
         "address_line": "2 Example Street",
         "town": "Oxford",
@@ -52,6 +52,37 @@ MANUFACTURER_IN_DATA_A = {
 MANUFACTURER_IN_DATA_B = {
     **MANUFACTURER_POST_DATA_B,
     "code": "manufacturer-b",
+}
+
+MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY = {
+    "name": "Manufacturer Test Required Values Only",
+    "address": {
+        "address_line": "1 Example Street",
+        "country": "United Kingdom",
+        "postcode": "OX1 2AB",
+    },
+}
+
+MANUFACTURER_GET_DATA_REQUIRED_VALUES_ONLY = {
+    **MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY,
+    **CREATED_MODIFIED_GET_DATA_EXPECTED,
+    "address": {**MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY["address"], "town": None, "county": None},
+    "id": ANY,
+    "code": "manufacturer-test-required-values-only",
+    "url": None,
+    "telephone": None,
+}
+
+MANUFACTURER_POST_DATA_ALL_VALUES = {
+    **MANUFACTURER_POST_DATA_A,
+    "name": "Manufacturer Test All Values",
+}
+
+MANUFACTURER_GET_DATA_ALL_VALUES = {
+    **MANUFACTURER_POST_DATA_ALL_VALUES,
+    **CREATED_MODIFIED_GET_DATA_EXPECTED,
+    "id": ANY,
+    "code": "manufacturer-test-all-values",
 }
 
 # --------------------------------- SYSTEMS ---------------------------------

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -16,6 +16,45 @@ from unittest.mock import ANY
 # at runtime
 CREATED_MODIFIED_GET_DATA_EXPECTED = {"created_time": ANY, "modified_time": ANY}
 
+# --------------------------------- MANUFACTURERS ---------------------------------
+
+MANUFACTURER_POST_DATA_A = {
+    "name": "Manufacturer A",
+    "url": "http://testUrl.co.uk",
+    "address": {
+        "address_line": "1 Example Street",
+        "town": "Oxford",
+        "county": "Oxfordshire",
+        "postcode": "OX1 2AB",
+        "country": "United Kingdom",
+    },
+    "telephone": "0932348348",
+}
+
+MANUFACTURER_POST_DATA_B = {
+    "name": "Manufacturer B",
+    "url": "http://example.co.uk",
+    "address": {
+        "address_line": "2 Example Street",
+        "town": "Oxford",
+        "county": "Oxfordshire",
+        "postcode": "OX1 2AB",
+        "country": "United Kingdom",
+    },
+    "telephone": "073434394",
+}
+
+MANUFACTURER_IN_DATA_A = {
+    **MANUFACTURER_POST_DATA_A,
+    "code": "manufacturer-a",
+}
+
+MANUFACTURER_IN_DATA_B = {
+    **MANUFACTURER_POST_DATA_B,
+    "code": "manufacturer-b",
+}
+
+# --------------------------------- SYSTEMS ---------------------------------
 
 SYSTEM_POST_DATA_NO_PARENT_A = {
     "parent_id": None,

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -68,7 +68,7 @@ MANUFACTURER_IN_DATA_A = {
 
 MANUFACTURER_POST_DATA_B = {
     **MANUFACTURER_POST_DATA_ALL_VALUES,
-    "address": {**MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY["address"], "address_line": "2 Example Street"},
+    "address": {**MANUFACTURER_POST_DATA_ALL_VALUES["address"], "address_line": "2 Example Street"},
     "name": "Manufacturer B",
     "url": "http://example.co.uk/",
     "telephone": "073434394",

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -18,41 +18,7 @@ CREATED_MODIFIED_GET_DATA_EXPECTED = {"created_time": ANY, "modified_time": ANY}
 
 # --------------------------------- MANUFACTURERS ---------------------------------
 
-MANUFACTURER_POST_DATA_A = {
-    "name": "Manufacturer A",
-    "url": "http://testurl.co.uk/",
-    "address": {
-        "address_line": "1 Example Street",
-        "town": "Oxford",
-        "county": "Oxfordshire",
-        "country": "United Kingdom",
-        "postcode": "OX1 2AB",
-    },
-    "telephone": "0932348348",
-}
-
-MANUFACTURER_POST_DATA_B = {
-    "name": "Manufacturer B",
-    "url": "http://example.co.uk/",
-    "address": {
-        "address_line": "2 Example Street",
-        "town": "Oxford",
-        "county": "Oxfordshire",
-        "country": "United Kingdom",
-        "postcode": "OX1 2AB",
-    },
-    "telephone": "073434394",
-}
-
-MANUFACTURER_IN_DATA_A = {
-    **MANUFACTURER_POST_DATA_A,
-    "code": "manufacturer-a",
-}
-
-MANUFACTURER_IN_DATA_B = {
-    **MANUFACTURER_POST_DATA_B,
-    "code": "manufacturer-b",
-}
+# Required values only
 
 MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY = {
     "name": "Manufacturer Test Required Values Only",
@@ -73,9 +39,14 @@ MANUFACTURER_GET_DATA_REQUIRED_VALUES_ONLY = {
     "telephone": None,
 }
 
+# All values
+
 MANUFACTURER_POST_DATA_ALL_VALUES = {
-    **MANUFACTURER_POST_DATA_A,
+    **MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY,
+    "address": {**MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY["address"], "town": "Oxford", "county": "Oxfordshire"},
     "name": "Manufacturer Test All Values",
+    "url": "http://testurl.co.uk/",
+    "telephone": "0932348348",
 }
 
 MANUFACTURER_GET_DATA_ALL_VALUES = {
@@ -83,6 +54,29 @@ MANUFACTURER_GET_DATA_ALL_VALUES = {
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
     "code": "manufacturer-test-all-values",
+}
+
+MANUFACTURER_POST_DATA_A = {
+    **MANUFACTURER_POST_DATA_ALL_VALUES,
+    "name": "Manufacturer A",
+}
+
+MANUFACTURER_IN_DATA_A = {
+    **MANUFACTURER_POST_DATA_A,
+    "code": "manufacturer-a",
+}
+
+MANUFACTURER_POST_DATA_B = {
+    **MANUFACTURER_POST_DATA_ALL_VALUES,
+    "address": {**MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY["address"], "address_line": "2 Example Street"},
+    "name": "Manufacturer B",
+    "url": "http://example.co.uk/",
+    "telephone": "073434394",
+}
+
+MANUFACTURER_IN_DATA_B = {
+    **MANUFACTURER_POST_DATA_B,
+    "code": "manufacturer-b",
 }
 
 # --------------------------------- SYSTEMS ---------------------------------

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -2,8 +2,14 @@
 Unit tests for the `ManufacturerRepo` repository.
 """
 
-from unittest.mock import MagicMock, call
-from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
+from typing import Optional
+from unittest.mock import MagicMock, call, Mock
+
+from test.mock_data import MANUFACTURER_IN_DATA_A, MANUFACTURER_IN_DATA_B
+from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.test_catalogue_item import FULL_CATALOGUE_ITEM_A_INFO
 import pytest
 from bson import ObjectId
@@ -16,588 +22,652 @@ from inventory_management_system_api.core.exceptions import (
     PartOfCatalogueItemError,
 )
 from inventory_management_system_api.models.manufacturer import ManufacturerIn, ManufacturerOut
-from inventory_management_system_api.schemas.manufacturer import AddressSchema
+from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
 
 
-def test_create(test_helpers, database_mock, manufacturer_repository):
+class ManufacturerRepoDSL:
     """
-    Test creating a manufacturer.
-
-    Verify that the `create` method properly handles the manufacturer to be created, checks that there is not a
-    duplicate manufacturer, and creates the manufacturer.
+    Base class form `ManufacturerRepo` unit tests.
     """
-    # pylint: disable=duplicate-code
-    manufacturer_in = ManufacturerIn(
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-    )
-    manufacturer_info = manufacturer_in.model_dump()
-    manufacturer_out = ManufacturerOut(
-        **manufacturer_info,
-        id=str(ObjectId()),
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
 
-    # Mock `find_one` to return no duplicate manufacturers found
-    test_helpers.mock_find_one(database_mock.manufacturers, None)
-    # Mock 'insert one' to return object for inserted manufacturer
-    test_helpers.mock_insert_one(database_mock.manufacturers, CustomObjectId(manufacturer_out.id))
-    # Mock 'find_one' to return the inserted manufacturer document
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **manufacturer_info,
-            "_id": CustomObjectId(manufacturer_out.id),
-        },
-    )
+    mock_database: Mock
+    manufacturer_repository: ManufacturerRepo
+    manufacturers_collection: Mock
+    catalogue_items_collection: Mock
 
-    created_manufacturer = manufacturer_repository.create(manufacturer_in, session=session)
+    mock_session = MagicMock()
 
-    database_mock.manufacturers.insert_one.assert_called_once_with(manufacturer_in.model_dump(), session=session)
-    database_mock.manufacturers.find_one.assert_has_calls(
-        [
-            call(
-                {
-                    "code": manufacturer_out.code,
-                    "_id": {"$ne": None},
-                },
-                session=session,
+    @pytest.fixture(autouse=True)
+    def setup(self, database_mock):
+        """Setup fixtures"""
+        self.mock_database = database_mock
+        self.manufacturer_repository = ManufacturerRepo(database_mock)
+        self.manufacturers_collection = database_mock.manufacturers
+        self.catalogue_items_collection = database_mock.catalogue_items
+
+        self.mock_session = MagicMock()
+        yield
+
+    def mock_is_duplicate_manufacturer(self, duplicate_manufacturer_in_data: Optional[dict] = None) -> None:
+        """
+        Mocks database methods appropriately for when the '_is_duplicate_manufacturer' repo method will be called.
+
+        :param duplicate_manufacturer_in_data: Either `None` or a dictionary containing manufacturer data for a
+            duplicate manufacturer.
+        """
+        RepositoryTestHelpers.mock_find_one(
+            self.manufacturers_collection,
+            (
+                {**ManufacturerIn(**duplicate_manufacturer_in_data).model_dump(), "_id": ObjectId()}
+                if duplicate_manufacturer_in_data
+                else None
             ),
-            call({"_id": CustomObjectId(manufacturer_out.id)}, session=session),
+        )
+
+    def get_is_duplicate_manufacturer_expected_find_one_call(
+        self, manufacturer_in: ManufacturerIn, expected_manufacturer_id: Optional[CustomObjectId]
+    ):
+        """
+        Returns the expected `find_one` calls that should occur when `_is_duplicate_manufacturer` is called.
+
+        :param manufacturer_in: `ManufacturerIn` model containing the data about the manufacturer.
+        :param expected_manufacturer_id: Expected `manufacturer_id` provided to `_is_duplicate_manufacturer`
+        :return: Expected `find_one` calls.
+        """
+        return call({"code": manufacturer_in.code, "_id": {"$ne": expected_manufacturer_id}}, session=self.mock_session)
+
+
+class CreateDSL(ManufacturerRepoDSL):
+    """
+    Base class for create tests.
+    """
+
+    _manufacturer_in: ManufacturerIn
+    _expected_manufacturer_out: ManufacturerOut
+    _created_manufacturer: ManufacturerOut
+    _create_exception: pytest.ExceptionInfo
+
+    def mock_create(self, manufacturer_in_data: dict, duplicate_manufacturer_in_data: Optional[dict] = None) -> None:
+        """
+        Mocks database methods appropriately to test the `create` repo method.
+
+        :param manufacturer_in_data: Dictionary containing the manufacturer data as would be required for a
+            `ManufacturerIn` database model (i.e. no id or created and modified times required).
+        :param duplicate_manufacturer_in_data: Either `None` or a dictionary containing manufacturer data for a
+            duplicate manufacturer.
+        """
+        inserted_manufacturer_id = CustomObjectId(str(ObjectId()))
+
+        # Pass through ManufacturerIn first as need creation and modified times
+        self._manufacturer_in = ManufacturerIn(**manufacturer_in_data)
+
+        self._expected_manufacturer_out = ManufacturerOut(
+            **self._manufacturer_in.model_dump(), id=inserted_manufacturer_id
+        )
+        #
+        self.mock_is_duplicate_manufacturer(duplicate_manufacturer_in_data)
+        # Mock 'insert one' to return object for inserted manufacturer
+        RepositoryTestHelpers.mock_insert_one(self.manufacturers_collection, inserted_manufacturer_id)
+        # Mock 'find_one' to return the inserted manufacturer document
+        RepositoryTestHelpers.mock_find_one(
+            self.manufacturers_collection, {**self._manufacturer_in.model_dump(), "_id": inserted_manufacturer_id}
+        )
+
+    def call_create(self) -> None:
+        """
+        Calls the `ManufacturerRepo` `create` method with the appropriate data from a prior call to `mock_create`.
+        """
+        self._created_manufacturer = self.manufacturer_repository.create(
+            self._manufacturer_in, session=self.mock_session
+        )
+
+    def call_create_expecting_error(self, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ManufacturerRepo` `create` method with the appropriate data from a prior call to `mock_create` while
+        expecting an error to be raised.
+
+        :param error_type: Expected exception to be raised.
+        """
+        with pytest.raises(error_type) as exc:
+            self.manufacturer_repository.create(self._manufacturer_in, session=self.mock_session)
+        self._create_exception = exc
+
+    def check_create_success(self) -> None:
+        """
+        Checks that a prior call to `call_create` worked as expected.
+        """
+        manufacturer_in_data = self._manufacturer_in.model_dump()
+
+        # Obtain a list of expected find_one calls
+        expected_find_one_calls = [
+            # This is the check for the duplicate
+            self.get_is_duplicate_manufacturer_expected_find_one_call(self._manufacturer_in, None),
+            # This is the check for the newly inserted manufacturer get
+            call({"_id": CustomObjectId(self._expected_manufacturer_out.id)}, session=self.mock_session),
         ]
-    )
-    assert created_manufacturer == manufacturer_out
+        self.manufacturers_collection.find_one.assert_has_calls(expected_find_one_calls)
+
+        self.manufacturers_collection.insert_one.assert_called_once_with(
+            manufacturer_in_data, session=self.mock_session
+        )
+        assert self._created_manufacturer == self._expected_manufacturer_out
+
+    def check_create_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_create_expecting_error` worked as expected, raising an exception with the
+        correct message.
+
+        :param message: Message of the raised exception.
+        """
+        self.manufacturers_collection.insert_one.assert_not_called()
+        assert str(self._create_exception.value) == message
 
 
-def test_create_manufacturer_duplicate(test_helpers, database_mock, manufacturer_repository):
+class TestCreate(CreateDSL):
     """
-    Test creating a manufacturer with a duplicate code
-
-    Verify that the `create` method properly handles a manufacturer with a duplicate name, finds that there is a
-    duplicate manufacturer, and does not create the manufacturer.
+    Tests for creating a manufacturer.
     """
-    manufacturer_in = ManufacturerIn(
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-    )
-    manufacturer_info = manufacturer_in.model_dump()
-    manufacturer_out = ManufacturerOut(
-        **manufacturer_info,
-        id=str(ObjectId()),
-    )
 
-    # Mock `find_one` to return duplicate manufacturer found
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **manufacturer_info,
-            "_id": CustomObjectId(manufacturer_out.id),
-        },
-    )
+    def test_create(self):
+        """
+        Test creating a system.
+        """
+        self.mock_create(MANUFACTURER_IN_DATA_A)
+        self.call_create()
+        self.check_create_success()
 
-    with pytest.raises(DuplicateRecordError) as exc:
-        manufacturer_repository.create(manufacturer_out)
-    assert str(exc.value) == "Duplicate manufacturer found"
+    def test_create_with_duplicate_name(self):
+        """
+        Test creating a manufacturer with a duplicate manufacturer being found.
+        """
+        self.mock_create(MANUFACTURER_IN_DATA_A, duplicate_manufacturer_in_data=MANUFACTURER_IN_DATA_A)
+        self.call_create_expecting_error(DuplicateRecordError)
+        self.check_create_failed_with_exception("Duplicate manufacturer found")
 
 
-def test_list(test_helpers, database_mock, manufacturer_repository):
-    """Test getting all manufacturers"""
-    manufacturer_1 = ManufacturerOut(
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-    )
+class GetDSL(ManufacturerRepoDSL):
+    """
+    Base class for get tests.
+    """
 
-    manufacturer_2 = ManufacturerOut(
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        name="Manufacturer B",
-        code="manufacturer-b",
-        url="http://example.co.uk",
-        address=AddressSchema(
-            address_line="2 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 3AB",
-            country="United Kingdom",
-        ),
-        telephone="073434394",
-    )
-    session = MagicMock()
+    _obtained_manufacturer_id: str
+    _expected_manufacturer_out: Optional[ManufacturerOut]
+    _obtained_manufacturer_out: ManufacturerOut
+    _get_exception: pytest.ExceptionInfo
 
-    test_helpers.mock_find(
-        database_mock.manufacturers,
-        [
-            {
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(manufacturer_1.id),
-                "code": manufacturer_1.code,
-                "name": manufacturer_1.name,
-                "url": manufacturer_1.url,
-                "address": manufacturer_1.address,
-                "telephone": manufacturer_1.telephone,
+    def mock_get(self, manufacturer_id: str, manufacturer_in_data: Optional[dict]) -> None:
+        """
+        Mocks database methods appropriately to test the `get` repo method.
+
+        :param manufacturer_id: ID of the manufacturer that will be obtained.
+        :param manufacturer_in_data: Either `None` or a dictionary containing the manufacturer data as would be required
+            for a `ManufacturerIn` database model (i.e. no ID or created and modified times required).
+        """
+        self._expected_manufacturer_out = (
+            ManufacturerOut(**ManufacturerIn(**manufacturer_in_data).model_dump(), id=CustomObjectId(manufacturer_id))
+            if manufacturer_in_data
+            else None
+        )
+
+        RepositoryTestHelpers.mock_find_one(
+            self.manufacturers_collection,
+            self._expected_manufacturer_out.model_dump() if self._expected_manufacturer_out else None,
+        )
+
+    def call_get(self, manufacturer_id: str) -> None:
+        """
+        Calls the `ManufacturerRepo` `get` method with the appropriate data from a prior call to `mock_get`.
+
+        :param manufacturer_id: ID of the manufacturer to be obtained.
+        """
+        self._obtained_manufacturer_id = manufacturer_id
+        self._obtained_manufacturer_out = self.manufacturer_repository.get(manufacturer_id, session=self.mock_session)
+
+    def call_get_expecting_error(self, manufacturer_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ManufacturerRepo` `get` method with the appropriate data from a prior call to `mock_get` while
+        expecting an error to be raised.
+
+        :param manufacturer_id: ID of the manufacturer to be obtained.
+        :param error_type: Expected exception to be raised.
+        """
+        with pytest.raises(error_type) as exc:
+            self.manufacturer_repository.get(manufacturer_id, session=self.mock_session)
+        self._get_exception = exc
+
+    def check_get_success(self) -> None:
+        """
+        Checks that a prior call to `call_get` worked as expected.
+        """
+        self.manufacturers_collection.find_one.assert_called_once_with(
+            {"_id": CustomObjectId(self._obtained_manufacturer_id)}, session=self.mock_session
+        )
+        assert self._obtained_manufacturer_out == self._expected_manufacturer_out
+
+    def check_get_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_get_expecting_error` worked as expected, raising an exception with the correct
+        message.
+
+        :param message: Message of the raised exception.
+        """
+        self.manufacturers_collection.find_one.assert_not_called()
+        assert str(self._get_exception.value) == message
+
+
+class TestGet(GetDSL):
+    """
+    Tests for getting a manufacturer.
+    """
+
+    def test_get(self):
+        """
+        Test getting a system.
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_get(manufacturer_id, MANUFACTURER_IN_DATA_A)
+        self.call_get(manufacturer_id)
+        self.check_get_success()
+
+    def test_get_with_non_existent_id(self):
+        """
+        Testing getting a manufacturer with a non-existent ID.
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_get(manufacturer_id, None)
+        self.call_get(manufacturer_id)
+        self.check_get_success()
+
+    def test_get_with_invalid_id(self):
+        """
+        Test getting a manufacturer with an invalid ID.
+        """
+        manufacturer_id = "invalid-id"
+
+        self.call_get_expecting_error(manufacturer_id, InvalidObjectIdError)
+        self.check_get_failed_with_exception(f"Invalid ObjectId value '{manufacturer_id}'")
+
+
+class ListDSL(ManufacturerRepoDSL):
+    """
+    Base class for list tests.
+    """
+
+    _expected_manufacturers_out: list[ManufacturerOut]
+    _obtained_manufacturers_out: list[ManufacturerOut]
+
+    def mock_list(self, manufacturers_in_data: list[dict]) -> None:
+        """
+        Mocks database methods appropriately to test the `list` repo method.
+
+        :param manufacturers_in_data: List of dictionaries containing the manufacturer data as would be required for a
+            `ManufacturerIn` database model (i.e. no ID or created and modified times required).
+        """
+        self._expected_manufacturers_out = [
+            ManufacturerOut(**ManufacturerIn(**manufacturer_in_data).model_dump(), id=ObjectId())
+            for manufacturer_in_data in manufacturers_in_data
+        ]
+
+        RepositoryTestHelpers.mock_find(
+            self.manufacturers_collection,
+            [manufacturer_out.model_dump() for manufacturer_out in self._expected_manufacturers_out],
+        )
+
+    def call_list(self) -> None:
+        """
+        Calls the `ManufacturerRepo` `list method` method.
+        """
+        self._obtained_manufacturers_out = self.manufacturer_repository.list(session=self.mock_session)
+
+    def check_list_success(self) -> None:
+        """
+        Checks that a prior call to `call_list` worked as expected.
+        """
+        self.manufacturers_collection.find.assert_called_once_with(session=self.mock_session)
+        assert self._obtained_manufacturers_out == self._expected_manufacturers_out
+
+
+class TestList(ListDSL):
+    """
+    Tests for listing manufacturers.
+    """
+
+    def test_list(self):
+        """
+        Test listing all manufacturers.
+        """
+        self.mock_list([MANUFACTURER_IN_DATA_A, MANUFACTURER_IN_DATA_B])
+        self.call_list()
+        self.check_list_success()
+
+    def test_list_with_no_results(self):
+        """
+        Test listing all manufacturers returning no results.
+        """
+        self.mock_list([])
+        self.call_list()
+        self.check_list_success()
+
+
+class UpdateDSL(ManufacturerRepoDSL):
+    """
+    Base class for update tests.
+    """
+
+    _manufacturer_in: ManufacturerIn
+    _stored_manufacturer_out: Optional[ManufacturerOut]
+    _expected_manufacturer_out: ManufacturerOut
+    _updated_manufacturer_id: str
+    _updated_manufacturer: ManufacturerOut
+    _update_exception: pytest.ExceptionInfo
+
+    def set_update_data(self, new_manufacturer_in_data: dict) -> None:
+        """
+        Assigns the update data to use during a call to `call_update`.
+        :param new_manufacturer_in_data: New manufacturer data as would be required for a `ManufacturerIn` database
+            model to supply to the `SystemRepo` `update` method.
+        """
+        self._manufacturer_in = ManufacturerIn(**new_manufacturer_in_data)
+
+    def mock_update(
+        self,
+        manufacturer_id: str,
+        new_manufacturer_in_data: dict,
+        stored_manufacturer_in_data: Optional[dict],
+        duplicate_manufacturer_in_data: Optional[dict] = None,
+    ) -> None:
+        """
+        Mocks database methods appropriately to test the `update` repo method.
+
+        :param manufacturer_id: ID of the manufacturer to be updated.
+        :param new_manufacturer_in_data: Dictionary containing the new manufacturer data as would be required for a
+            `ManufacturerIn` database model (i.e. no ID or created and modified times required).
+        :param stored_manufacturer_in_data: Dictionary containing the data of the existing stored manufacturer as would
+            be required for a `ManufacturerIn` database model.
+        :param duplicate_manufacturer_in_data: Either `None` or a dictionary containing the data for a duplicate
+            manufacturer as would be required for a `ManufacturerIn` database model.
+        """
+        self.set_update_data(new_manufacturer_in_data)
+
+        # Stored manufacturer
+        self._stored_manufacturer_out = (
+            ManufacturerOut(
+                **ManufacturerIn(**stored_manufacturer_in_data).model_dump(), id=CustomObjectId(manufacturer_id)
+            )
+            if stored_manufacturer_in_data
+            else None
+        )
+        RepositoryTestHelpers.mock_find_one(
+            self.manufacturers_collection,
+            self._stored_manufacturer_out.model_dump() if self._stored_manufacturer_out else None,
+        )
+
+        # Duplicate check
+        if self._stored_manufacturer_out and (self._manufacturer_in.name != self._stored_manufacturer_out.name):
+            self.mock_is_duplicate_manufacturer(duplicate_manufacturer_in_data)
+
+        # Final manufacturer after update
+        self._expected_manufacturer_out = ManufacturerOut(
+            **self._manufacturer_in.model_dump(), id=CustomObjectId(manufacturer_id)
+        )
+        RepositoryTestHelpers.mock_find_one(self.manufacturers_collection, self._expected_manufacturer_out.model_dump())
+
+    def call_update(self, manufacturer_id: str) -> None:
+        """
+        Calls the `ManufacturerRepo` `update` method with the appropriate data from a prior call to `mock_update` (or
+        `set_update_data`).
+
+        :param manufacturer_id: ID of the manufacturer to be updated.
+        """
+        self._updated_manufacturer_id = manufacturer_id
+        self._updated_manufacturer = self.manufacturer_repository.update(
+            manufacturer_id, self._manufacturer_in, session=self.mock_session
+        )
+
+    def call_update_expecting_error(self, manufacturer_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ManufacturerRepo` `update` method with the appropriate data from a prior call to `mock_update` (or
+        `set_update_data`) while expecting an error to be raised.
+        :param manufacturer_id: ID of the manufacturer to be updated.
+        :param error_type: Expected exception to be raised.
+        """
+
+        with pytest.raises(error_type) as exc:
+            self.manufacturer_repository.update(manufacturer_id, self._manufacturer_in)
+        self._update_exception = exc
+
+    def check_update_success(self) -> None:
+        """
+        Checks that a prior call to `call_update` worked as expected.
+        """
+        # Obtain a list of expected `find_one` calls
+        expected_find_one_calls = [
+            # Stored manufacturer
+            call({"_id": CustomObjectId(self._expected_manufacturer_out.id)}, session=self.mock_session)
+        ]
+
+        # Duplicate check (which only runs if changing the name)
+        if self._stored_manufacturer_out and (self._manufacturer_in.name != self._stored_manufacturer_out.name):
+            expected_find_one_calls.append(
+                self.get_is_duplicate_manufacturer_expected_find_one_call(
+                    self._manufacturer_in, CustomObjectId(self._updated_manufacturer_id)
+                )
+            )
+        self.manufacturers_collection.find_one.assert_has_calls(expected_find_one_calls)
+
+        self.manufacturers_collection.update_one.assert_called_once_with(
+            {"_id": CustomObjectId(self._updated_manufacturer_id)},
+            {"$set": self._manufacturer_in.model_dump()},
+            session=self.mock_session,
+        )
+
+        print(self._updated_manufacturer)
+        print(self._expected_manufacturer_out)
+        assert self._updated_manufacturer == self._expected_manufacturer_out
+
+    def check_update_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_update_expecting_error` worked as expected, raising an exception with the
+        correct message.
+
+        :param message: Message of the raised exception.
+        """
+        self.manufacturers_collection.update_one.assert_not_called()
+        assert str(self._update_exception.value) == message
+
+
+class TestUpdate(UpdateDSL):
+    """
+    Tests for updating a manufacturer.
+    """
+
+    def test_update(self):
+        """
+        Test updating a manufacturer.
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_update(manufacturer_id, MANUFACTURER_IN_DATA_A, MANUFACTURER_IN_DATA_B)
+        self.call_update(manufacturer_id)
+        self.check_update_success()
+
+    def test_update_name_capitalisation(self):
+        """
+        Test updating the name capitalisation of a manufacturer.
+        """
+        manufacturer_id = str(ObjectId())
+        new_name = "manufacturer a"
+
+        self.mock_update(manufacturer_id, {**MANUFACTURER_IN_DATA_A, "name": new_name}, MANUFACTURER_IN_DATA_A)
+        self.call_update(manufacturer_id)
+        self.check_update_success()
+
+    def test_update_name_to_duplicate(self):
+        """
+        Test updating the name of a manufacturer to one that is a duplicate.
+        """
+        manufacturer_id = str(ObjectId())
+        duplicate_name = "Duplicate name"
+
+        self.mock_update(
+            manufacturer_id,
+            {**MANUFACTURER_IN_DATA_A, "name": duplicate_name},
+            MANUFACTURER_IN_DATA_A,
+            duplicate_manufacturer_in_data={**MANUFACTURER_IN_DATA_A, "name": duplicate_name},
+        )
+
+    def test_update_with_invalid_id(self):
+        """
+        Test updating a manufacturer with an invalid ID.
+        """
+        manufacturer_id = "invalid-id"
+
+        self.set_update_data(MANUFACTURER_IN_DATA_A)
+        self.call_update_expecting_error(manufacturer_id, InvalidObjectIdError)
+        self.check_update_failed_with_exception(f"Invalid ObjectId value '{manufacturer_id}'")
+
+
+class DeleteDSL(ManufacturerRepoDSL):
+    """
+    Base class for delete tests.
+    """
+
+    _delete_manufacturer_id: str
+    _delete_exception: pytest.ExceptionInfo
+    _mock_catalogue_item_data: Optional[dict]
+
+    def mock_delete(self, deleted_count: int, catalogue_item_data: Optional[dict] = None):
+        """
+        Mocks database methods appropriately to test the `delete` repo method.
+
+        :param deleted_count: Number of documents deleted successfully.
+        :param catalogue_item_data: Dictionary containing a catalogue item's data (or `None`).
+        :return:
+        """
+        self.mock_is_manufacturer_in_catalogue_item(catalogue_item_data)
+        RepositoryTestHelpers.mock_delete_one(self.manufacturers_collection, deleted_count)
+
+    def call_delete(self, manufacturer_id: str) -> None:
+        """
+        Calls the `ManufacturerRepo` `delete` method with the appropriate data from a prior call to `mock_delete`.
+
+        :param manufacturer_id: ID of the manufacturer to be deleted.
+        """
+        self._delete_manufacturer_id = manufacturer_id
+        self.manufacturer_repository.delete(manufacturer_id, session=self.mock_session)
+
+    def call_delete_expecting_error(self, manufacturer_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ManufacturerRepo` `delete` method with the appropriate data from a prior call to `mock_delete` while
+        expecting an error to be raised.
+
+        :param manufacturer_id: ID of the manufacturer to be obtained.
+        :param error_type: Expected exception to be raised.
+        """
+        self._delete_manufacturer_id = manufacturer_id
+        with pytest.raises(error_type) as exc:
+            self.manufacturer_repository.delete(manufacturer_id, session=self.mock_session)
+        self._delete_exception = exc
+
+    def check_delete_success(self) -> None:
+        """
+        Checks that a prior call to `call_delete` worked as expected.
+        """
+        self.check_is_manufacturer_in_catalogue_item_performed_expected_calls(self._delete_manufacturer_id)
+        self.manufacturers_collection.delete_one.assert_called_once_with(
+            {"_id": CustomObjectId(self._delete_manufacturer_id)}, session=self.mock_session
+        )
+
+    def check_delete_failed_with_exception(self, message: str, expecting_delete_one_called: bool = False) -> None:
+        """
+        Checks that a prior call to `call_delete_expecting_error` worked as expected, raising an exception with the
+        correct message.
+
+        :param message: Message of the raised exception.
+        :param expecting_delete_one_called: Whether the `delete_one` method is expected to be called or not.
+        """
+
+        if not expecting_delete_one_called:
+            self.manufacturers_collection.delete_one.assert_not_called()
+        else:
+            self.manufacturers_collection.delete_one.assert_called_once_with(
+                {"_id": CustomObjectId(self._delete_manufacturer_id)}, session=self.mock_session
+            )
+
+        assert str(self._delete_exception.value) == message
+
+    def mock_is_manufacturer_in_catalogue_item(self, catalogue_item_data: Optional[dict] = None) -> None:
+        """
+        Mocks database methods appropriately for when the '_is_manufacturer_in_catalogue_item' repo method will be
+        called.
+
+        :param catalogue_item_data: Dictionary containing a catalogue item's data (or `None`)
+        """
+        self._mock_catalogue_item_data = catalogue_item_data
+        RepositoryTestHelpers.mock_find_one(self.catalogue_items_collection, catalogue_item_data)
+
+    def check_is_manufacturer_in_catalogue_item_performed_expected_calls(self, expected_manufacturer_id: str) -> None:
+        """Checks that a call to `_is_manufacturer_in_catalogue_item` performed the expected method calls.
+
+        :param expected_manufacturer_id: Expected manufacturer ID used in the database calls.
+        """
+
+        self.catalogue_items_collection.find_one.assert_called_once_with(
+            {"manufacturer_id": CustomObjectId(expected_manufacturer_id)}, session=self.mock_session
+        )
+
+
+class TestDelete(DeleteDSL):
+    """
+    Tests for deleting a manufacturer.
+    """
+
+    def test_delete(self):
+        """
+        Test deleting a manufacturer.
+        """
+        self.mock_delete(deleted_count=1)
+        self.call_delete(str(ObjectId()))
+        self.check_delete_success()
+
+    def test_delete_when_part_of_catalogue_item(self):
+        """
+        Test deleting a manufacturer when it is part of a catalogue item.
+        """
+        manufacturer_id = str(ObjectId())
+
+        # pylint:disable=fixme
+        # TODO: Replace FULL_CATALOGUE_ITEM_A_INFO once catalogue item tests have been refactored
+        self.mock_delete(
+            deleted_count=1,
+            catalogue_item_data={
+                **FULL_CATALOGUE_ITEM_A_INFO,
+                "catalogue_category_id": str(ObjectId()),
+                "manufacturer_id": manufacturer_id,
             },
-            {
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(manufacturer_2.id),
-                "code": manufacturer_2.code,
-                "name": manufacturer_2.name,
-                "url": manufacturer_2.url,
-                "address": manufacturer_2.address,
-                "telephone": manufacturer_2.telephone,
-            },
-        ],
-    )
-
-    retrieved_manufacturers = manufacturer_repository.list(session=session)
-
-    database_mock.manufacturers.find.assert_called_once_with(session=session)
-    assert retrieved_manufacturers == [manufacturer_1, manufacturer_2]
-
-
-def test_list_when_no_manufacturers(test_helpers, database_mock, manufacturer_repository):
-    """Test trying to get all manufacturers when there are none in the database"""
-    test_helpers.mock_find(database_mock.manufacturers, [])
-    retrieved_manufacturers = manufacturer_repository.list()
-
-    assert retrieved_manufacturers == []
-
-
-def test_get(test_helpers, database_mock, manufacturer_repository):
-    """
-    Test getting a manufacturer by id
-    """
-    manufacturer = ManufacturerOut(
-        id=str(ObjectId()),
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-        **MOCK_CREATED_MODIFIED_TIME,
-    )
-    session = MagicMock()
-
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(manufacturer.id),
-            "code": manufacturer.code,
-            "name": manufacturer.name,
-            "url": manufacturer.url,
-            "address": manufacturer.address,
-            "telephone": manufacturer.telephone,
-        },
-    )
-    retrieved_manufacturer = manufacturer_repository.get(manufacturer.id, session=session)
-    database_mock.manufacturers.find_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer.id)}, session=session
-    )
-    assert retrieved_manufacturer == manufacturer
-
-
-def test_get_with_invalid_id(manufacturer_repository):
-    """
-    Test getting a manufacturer with an Invalid ID
-    """
-    with pytest.raises(InvalidObjectIdError) as exc:
-        manufacturer_repository.get("invalid")
-    assert str(exc.value) == "Invalid ObjectId value 'invalid'"
-
-
-def test_get_with_non_existent_id(test_helpers, database_mock, manufacturer_repository):
-    """
-    Test getting a manufacturer with an ID that does not exist
-    """
-    manufacturer_id = str(ObjectId())
-    test_helpers.mock_find_one(database_mock.manufacturers, None)
-    retrieved_manufacturer = manufacturer_repository.get(manufacturer_id)
-
-    assert retrieved_manufacturer is None
-    database_mock.manufacturers.find_one.assert_called_once_with({"_id": CustomObjectId(manufacturer_id)}, session=None)
-
-
-def test_update_change_capitalisation_of_name(test_helpers, database_mock, manufacturer_repository):
-    """Test updating a manufacturer when the code is the same and the capitalisation of the name has changed."""
-    # pylint: disable=duplicate-code
-    manufacturer = ManufacturerOut(
-        id=str(ObjectId()),
-        name="MaNuFaCtUrEr A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-        **MOCK_CREATED_MODIFIED_TIME,
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock 'find_one' to return the existing manufacturer document
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(manufacturer.id),
-            "code": "manufacturer-a",
-            "name": "Manufacturer A",
-            "url": "http://testUrl.co.uk",
-            "address": {
-                "address_line": "1 Example Street",
-                "town": "Oxford",
-                "county": "Oxfordshire",
-                "postcode": "OX1 2AB",
-                "country": "United Kingdom",
-            },
-            "telephone": "0932348348",
-        },
-    )
-
-    # Mock `find_one` to return None as a duplicate was not found
-    test_helpers.mock_find_one(database_mock.manufacturers, None)
-
-    test_helpers.mock_update_one(database_mock.manufacturers)
-    # Mock 'find_one' to return the inserted manufacturer document
-    manufacturer_in = ManufacturerIn(**manufacturer.model_dump())
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **manufacturer_in.model_dump(),
-            "_id": CustomObjectId(manufacturer.id),
-        },
-    )
-
-    # pylint: disable=duplicate-code
-    updated_manufacturer = manufacturer_repository.update(manufacturer.id, manufacturer_in, session=session)
-    # pylint: enable=duplicate-code
-
-    database_mock.manufacturers.update_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer.id)}, {"$set": manufacturer_in.model_dump()}, session=session
-    )
-
-    assert updated_manufacturer == ManufacturerOut(id=manufacturer.id, **manufacturer_in.model_dump())
-
-
-def test_update(test_helpers, database_mock, manufacturer_repository):
-    """Test updating a manufacturer"""
-    # pylint: disable=duplicate-code
-    manufacturer = ManufacturerOut(
-        id=str(ObjectId()),
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-        **MOCK_CREATED_MODIFIED_TIME,
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock 'find_one' to return the existing manufacturer document
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(manufacturer.id),
-            "code": "manufacturer-b",
-            "name": "Manufacturer B",
-            "url": "http://example.com",
-            "address": {
-                "address_line": "2 Test Street",
-                "town": "Newbury",
-                "county": "Berkshire",
-                "postcode": "QW2 4DF",
-                "country": "United Kingdom",
-            },
-            "telephone": "0348343897",
-        },
-    )
-
-    # Mock `find_one` to return no duplicate manufacturers found
-    test_helpers.mock_find_one(database_mock.manufacturers, None)
-
-    test_helpers.mock_update_one(database_mock.manufacturers)
-    # Mock 'find_one' to return the inserted manufacturer document
-    manufacturer_in = ManufacturerIn(**manufacturer.model_dump())
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **manufacturer_in.model_dump(),
-            "_id": CustomObjectId(manufacturer.id),
-        },
-    )
-
-    # pylint: disable=duplicate-code
-    updated_manufacturer = manufacturer_repository.update(manufacturer.id, manufacturer_in, session=session)
-    # pylint: enable=duplicate-code
-
-    database_mock.manufacturers.update_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer.id)}, {"$set": manufacturer_in.model_dump()}, session=session
-    )
-
-    assert updated_manufacturer == ManufacturerOut(id=manufacturer.id, **manufacturer_in.model_dump())
-
-
-def test_update_with_invalid_id(manufacturer_repository):
-    """Test trying to update with an invalid ID"""
-
-    updated_manufacturer = MagicMock()
-    manufacturer_id = "invalid"
-
-    with pytest.raises(InvalidObjectIdError) as exc:
-        manufacturer_repository.update(manufacturer_id, updated_manufacturer)
-    assert str(exc.value) == "Invalid ObjectId value 'invalid'"
-
-
-def test_update_with_duplicate_name(test_helpers, database_mock, manufacturer_repository):
-    """Testing trying to update a manufacturer's name to one that already exists in the database"""
-
-    updated_manufacturer = ManufacturerIn(
-        **MOCK_CREATED_MODIFIED_TIME,
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-    )
-
-    manufacturer_id = str(ObjectId())
-
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(manufacturer_id),
-            "code": "manufacturer-b",
-            "name": "Manufacturer B",
-            "url": "http://example.com",
-            "address": {
-                "address_line": "2 Example Street",
-                "town": "Newbury",
-                "county": "Berkshire",
-                "postcode": "QW2 4DF",
-                "country": "United Kingdom",
-            },
-            "telephone": "0348343897",
-            **MOCK_CREATED_MODIFIED_TIME,
-        },
-    )
-
-    # Mock `find_one` to return duplicate manufacturer found
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            "_id": ObjectId(),
-            "code": "manufacturer-b",
-            "name": "Manufacturer B",
-            "url": "http://example.com",
-            "address": {
-                "address_line": "2 Example Street",
-                "town": "Newbury",
-                "county": "Berkshire",
-                "postcode": "QW2 4DF",
-                "country": "United Kingdom",
-            },
-            "telephone": "0348343897",
-            **MOCK_CREATED_MODIFIED_TIME,
-        },
-    )
-
-    # Mock `find_one` to return no child catalogue item document
-    test_helpers.mock_find_one(database_mock.catalogue_items, None)
-
-    with pytest.raises(DuplicateRecordError) as exc:
-        manufacturer_repository.update(manufacturer_id, updated_manufacturer)
-
-    assert str(exc.value) == "Duplicate manufacturer found"
-
-
-def test_partial_update_address(test_helpers, database_mock, manufacturer_repository):
-    """Test partially updating a manufacturer address"""
-    # pylint: disable=duplicate-code
-    manufacturer = ManufacturerOut(
-        id=str(ObjectId()),
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testurl.co.uk/",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-        **MOCK_CREATED_MODIFIED_TIME,
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `find_one` to return the existing manufacturer document
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(manufacturer.id),
-            "name": "Manufacturer A",
-            "code": "manufacturer-a",
-            "url": "http://testurl.co.uk/",
-            "address": {"address_line": "100 Test Street", "postcode": "test", "country": "test"},
-            "telephone": "0932348348",
-        },
-    )
-
-    # Mock `find_one` to return no child catalogue item document
-    test_helpers.mock_find_one(database_mock.catalogue_items, None)
-
-    test_helpers.mock_update_one(database_mock.manufacturers)
-
-    # Mock 'find_one' to return the inserted manufacturer document
-    test_helpers.mock_find_one(
-        database_mock.manufacturers,
-        {
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(manufacturer.id),
-            "code": manufacturer.code,
-            "name": manufacturer.name,
-            "url": manufacturer.url,
-            "address": manufacturer.address,
-            "telephone": manufacturer.telephone,
-        },
-    )
-
-    manufacturer_in = ManufacturerIn(
-        name=manufacturer.name,
-        code=manufacturer.code,
-        url=manufacturer.url,
-        address=AddressSchema(address_line="100 Test Street", postcode="test", country="test"),
-        telephone=manufacturer.telephone,
-    )
-
-    updated_manufacturer = manufacturer_repository.update(manufacturer.id, manufacturer_in, session=session)
-
-    database_mock.manufacturers.update_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer.id)},
-        {
-            "$set": manufacturer_in.model_dump(),
-        },
-        session=session,
-    )
-    assert updated_manufacturer == manufacturer
-
-
-def test_delete(test_helpers, database_mock, manufacturer_repository):
-    """Test trying to delete a manufacturer"""
-    manufacturer_id = str(ObjectId())
-    session = MagicMock()
-
-    test_helpers.mock_delete_one(database_mock.manufacturers, 1)
-
-    # Mock `find_one` to return no child catalogue item document
-    test_helpers.mock_find_one(database_mock.catalogue_items, None)
-
-    manufacturer_repository.delete(manufacturer_id, session=session)
-
-    database_mock.manufacturers.delete_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer_id)}, session=session
-    )
-
-
-def test_delete_with_an_invalid_id(manufacturer_repository):
-    """Test trying to delete a manufacturer with an invalid ID"""
-    manufacturer_id = "invalid"
-
-    with pytest.raises(InvalidObjectIdError) as exc:
-        manufacturer_repository.delete(manufacturer_id)
-    assert str(exc.value) == "Invalid ObjectId value 'invalid'"
-
-
-def test_delete_with_a_non_existent_id(test_helpers, database_mock, manufacturer_repository):
-    """Test trying to delete a manufacturer with a non-existent ID"""
-    manufacturer_id = str(ObjectId())
-
-    test_helpers.mock_delete_one(database_mock.manufacturers, 0)
-    # Mock `find_one` to return no child catalogue item document
-    test_helpers.mock_find_one(database_mock.catalogue_items, None)
-
-    with pytest.raises(MissingRecordError) as exc:
-        manufacturer_repository.delete(manufacturer_id)
-    assert str(exc.value) == f"No manufacturer found with ID: {manufacturer_id}"
-    database_mock.manufacturers.delete_one.assert_called_once_with(
-        {"_id": CustomObjectId(manufacturer_id)}, session=None
-    )
-
-
-def test_delete_manufacturer_that_is_part_of_a_catalogue_item(test_helpers, database_mock, manufacturer_repository):
-    """Test trying to delete a manufacturer that is part of a Catalogue Item"""
-    manufacturer_id = str(ObjectId())
-
-    catalogue_category_id = str(ObjectId())
-
-    # pylint: disable=duplicate-code
-    # Mock `find_one` to return the child catalogue item document
-    test_helpers.mock_find_one(
-        database_mock.catalogue_items,
-        {
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "_id": CustomObjectId(str(ObjectId())),
-            "catalogue_category_id": CustomObjectId(catalogue_category_id),
-        },
-    )
-    # pylint: enable=duplicate-code
-    with pytest.raises(PartOfCatalogueItemError) as exc:
-        manufacturer_repository.delete(manufacturer_id)
-    assert str(exc.value) == f"The manufacturer with id {str(manufacturer_id)} is a part of a Catalogue Item"
+        )
+        self.call_delete_expecting_error(manufacturer_id, PartOfCatalogueItemError)
+        self.check_delete_failed_with_exception(f"Manufacturer with ID '{manufacturer_id}' is part of a catalogue item")
+
+    def test_delete_non_existent_id(self):
+        """
+        Test deleting a manufacturer with a non-existent ID.
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_delete(deleted_count=0)
+        self.call_delete_expecting_error(manufacturer_id, MissingRecordError)
+        self.check_delete_failed_with_exception(
+            f"No manufacturer found with ID: {manufacturer_id}", expecting_delete_one_called=True
+        )
+
+    def test_delete_with_invalid_id(self):
+        """
+        Test deleting a manufacturer with an invalid ID.
+        """
+        manufacturer_id = "invalid-id"
+
+        self.call_delete_expecting_error(manufacturer_id, InvalidObjectIdError)
+        self.check_delete_failed_with_exception(f"Invalid ObjectId value '{manufacturer_id}'")

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the `ManufacturerRepo` repository.
-"""
+"""Unit tests for the `ManufacturerRepo` repository."""
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code
@@ -26,9 +24,7 @@ from inventory_management_system_api.repositories.manufacturer import Manufactur
 
 
 class ManufacturerRepoDSL:
-    """
-    Base class for `ManufacturerRepo` unit tests.
-    """
+    """Base class for `ManufacturerRepo` unit tests."""
 
     mock_database: Mock
     manufacturer_repository: ManufacturerRepo
@@ -50,7 +46,7 @@ class ManufacturerRepoDSL:
 
     def mock_is_duplicate_manufacturer(self, duplicate_manufacturer_in_data: Optional[dict] = None) -> None:
         """
-        Mocks database methods appropriately for when the '_is_duplicate_manufacturer' repo method will be called.
+        Mocks database methods appropriately for when the `_is_duplicate_manufacturer` repo method will be called.
 
         :param duplicate_manufacturer_in_data: Either `None` or a dictionary containing manufacturer data for a
             duplicate manufacturer.
@@ -71,16 +67,14 @@ class ManufacturerRepoDSL:
         Returns the expected `find_one` calls that should occur when `_is_duplicate_manufacturer` is called.
 
         :param manufacturer_in: `ManufacturerIn` model containing the data about the manufacturer.
-        :param expected_manufacturer_id: Expected `manufacturer_id` provided to `_is_duplicate_manufacturer`
+        :param expected_manufacturer_id: Expected `manufacturer_id` provided to `_is_duplicate_manufacturer`.
         :return: Expected `find_one` calls.
         """
         return call({"code": manufacturer_in.code, "_id": {"$ne": expected_manufacturer_id}}, session=self.mock_session)
 
 
 class CreateDSL(ManufacturerRepoDSL):
-    """
-    Base class for create tests.
-    """
+    """Base class for `create` tests."""
 
     _manufacturer_in: ManufacturerIn
     _expected_manufacturer_out: ManufacturerOut
@@ -92,7 +86,7 @@ class CreateDSL(ManufacturerRepoDSL):
         Mocks database methods appropriately to test the `create` repo method.
 
         :param manufacturer_in_data: Dictionary containing the manufacturer data as would be required for a
-            `ManufacturerIn` database model (i.e. no id or created and modified times required).
+            `ManufacturerIn` database model (i.e. no ID or created and modified times required).
         :param duplicate_manufacturer_in_data: Either `None` or a dictionary containing manufacturer data for a
             duplicate manufacturer.
         """
@@ -106,17 +100,15 @@ class CreateDSL(ManufacturerRepoDSL):
         )
         #
         self.mock_is_duplicate_manufacturer(duplicate_manufacturer_in_data)
-        # Mock 'insert one' to return object for inserted manufacturer
+        # Mock `insert one` to return object for inserted manufacturer
         RepositoryTestHelpers.mock_insert_one(self.manufacturers_collection, inserted_manufacturer_id)
-        # Mock 'find_one' to return the inserted manufacturer document
+        # Mock `find_one` to return the inserted manufacturer document
         RepositoryTestHelpers.mock_find_one(
             self.manufacturers_collection, {**self._manufacturer_in.model_dump(), "_id": inserted_manufacturer_id}
         )
 
     def call_create(self) -> None:
-        """
-        Calls the `ManufacturerRepo` `create` method with the appropriate data from a prior call to `mock_create`.
-        """
+        """Calls the `ManufacturerRepo` `create` method with the appropriate data from a prior call to `mock_create`."""
         self._created_manufacturer = self.manufacturer_repository.create(
             self._manufacturer_in, session=self.mock_session
         )
@@ -133,9 +125,7 @@ class CreateDSL(ManufacturerRepoDSL):
         self._create_exception = exc
 
     def check_create_success(self) -> None:
-        """
-        Checks that a prior call to `call_create` worked as expected.
-        """
+        """Checks that a prior call to `call_create` worked as expected."""
         manufacturer_in_data = self._manufacturer_in.model_dump()
 
         # Obtain a list of expected find_one calls
@@ -157,38 +147,30 @@ class CreateDSL(ManufacturerRepoDSL):
         Checks that a prior call to `call_create_expecting_error` worked as expected, raising an exception with the
         correct message.
 
-        :param message: Message of the raised exception.
+        :param message: Expected message of the raised exception.
         """
         self.manufacturers_collection.insert_one.assert_not_called()
         assert str(self._create_exception.value) == message
 
 
 class TestCreate(CreateDSL):
-    """
-    Tests for creating a manufacturer.
-    """
+    """Tests for creating a manufacturer."""
 
     def test_create(self):
-        """
-        Test creating a system.
-        """
+        """Test creating a manufacturer."""
         self.mock_create(MANUFACTURER_IN_DATA_A)
         self.call_create()
         self.check_create_success()
 
     def test_create_with_duplicate_name(self):
-        """
-        Test creating a manufacturer with a duplicate manufacturer being found.
-        """
+        """Test creating a manufacturer with a duplicate manufacturer being found."""
         self.mock_create(MANUFACTURER_IN_DATA_A, duplicate_manufacturer_in_data=MANUFACTURER_IN_DATA_A)
         self.call_create_expecting_error(DuplicateRecordError)
         self.check_create_failed_with_exception("Duplicate manufacturer found")
 
 
 class GetDSL(ManufacturerRepoDSL):
-    """
-    Base class for get tests.
-    """
+    """Base class for `get` tests."""
 
     _obtained_manufacturer_id: str
     _expected_manufacturer_out: Optional[ManufacturerOut]
@@ -199,7 +181,7 @@ class GetDSL(ManufacturerRepoDSL):
         """
         Mocks database methods appropriately to test the `get` repo method.
 
-        :param manufacturer_id: ID of the manufacturer that will be obtained.
+        :param manufacturer_id: ID of the manufacturer to be obtained.
         :param manufacturer_in_data: Either `None` or a dictionary containing the manufacturer data as would be required
             for a `ManufacturerIn` database model (i.e. no ID or created and modified times required).
         """
@@ -236,9 +218,7 @@ class GetDSL(ManufacturerRepoDSL):
         self._get_exception = exc
 
     def check_get_success(self) -> None:
-        """
-        Checks that a prior call to `call_get` worked as expected.
-        """
+        """Checks that a prior call to `call_get` worked as expected."""
         self.manufacturers_collection.find_one.assert_called_once_with(
             {"_id": CustomObjectId(self._obtained_manufacturer_id)}, session=self.mock_session
         )
@@ -249,21 +229,17 @@ class GetDSL(ManufacturerRepoDSL):
         Checks that a prior call to `call_get_expecting_error` worked as expected, raising an exception with the correct
         message.
 
-        :param message: Message of the raised exception.
+        :param message: Expected message of the raised exception.
         """
         self.manufacturers_collection.find_one.assert_not_called()
         assert str(self._get_exception.value) == message
 
 
 class TestGet(GetDSL):
-    """
-    Tests for getting a manufacturer.
-    """
+    """Tests for getting a manufacturer."""
 
     def test_get(self):
-        """
-        Test getting a system.
-        """
+        """Test getting a system."""
         manufacturer_id = str(ObjectId())
 
         self.mock_get(manufacturer_id, MANUFACTURER_IN_DATA_A)
@@ -271,9 +247,7 @@ class TestGet(GetDSL):
         self.check_get_success()
 
     def test_get_with_non_existent_id(self):
-        """
-        Testing getting a manufacturer with a non-existent ID.
-        """
+        """Testing getting a manufacturer with a non-existent ID."""
         manufacturer_id = str(ObjectId())
 
         self.mock_get(manufacturer_id, None)
@@ -281,9 +255,7 @@ class TestGet(GetDSL):
         self.check_get_success()
 
     def test_get_with_invalid_id(self):
-        """
-        Test getting a manufacturer with an invalid ID.
-        """
+        """Test getting a manufacturer with an invalid ID."""
         manufacturer_id = "invalid-id"
 
         self.call_get_expecting_error(manufacturer_id, InvalidObjectIdError)
@@ -291,9 +263,7 @@ class TestGet(GetDSL):
 
 
 class ListDSL(ManufacturerRepoDSL):
-    """
-    Base class for list tests.
-    """
+    """Base class for `list` tests."""
 
     _expected_manufacturers_out: list[ManufacturerOut]
     _obtained_manufacturers_out: list[ManufacturerOut]
@@ -316,45 +286,33 @@ class ListDSL(ManufacturerRepoDSL):
         )
 
     def call_list(self) -> None:
-        """
-        Calls the `ManufacturerRepo` `list method` method.
-        """
+        """Calls the `ManufacturerRepo` `list method` method."""
         self._obtained_manufacturers_out = self.manufacturer_repository.list(session=self.mock_session)
 
     def check_list_success(self) -> None:
-        """
-        Checks that a prior call to `call_list` worked as expected.
-        """
+        """Checks that a prior call to `call_list` worked as expected."""
         self.manufacturers_collection.find.assert_called_once_with(session=self.mock_session)
         assert self._obtained_manufacturers_out == self._expected_manufacturers_out
 
 
 class TestList(ListDSL):
-    """
-    Tests for listing manufacturers.
-    """
+    """Tests for listing manufacturers."""
 
     def test_list(self):
-        """
-        Test listing all manufacturers.
-        """
+        """Test listing all manufacturers."""
         self.mock_list([MANUFACTURER_IN_DATA_A, MANUFACTURER_IN_DATA_B])
         self.call_list()
         self.check_list_success()
 
     def test_list_with_no_results(self):
-        """
-        Test listing all manufacturers returning no results.
-        """
+        """Test listing all manufacturers returning no results."""
         self.mock_list([])
         self.call_list()
         self.check_list_success()
 
 
 class UpdateDSL(ManufacturerRepoDSL):
-    """
-    Base class for update tests.
-    """
+    """Base class for `update` tests."""
 
     _manufacturer_in: ManufacturerIn
     _stored_manufacturer_out: Optional[ManufacturerOut]
@@ -366,6 +324,7 @@ class UpdateDSL(ManufacturerRepoDSL):
     def set_update_data(self, new_manufacturer_in_data: dict) -> None:
         """
         Assigns the update data to use during a call to `call_update`.
+
         :param new_manufacturer_in_data: New manufacturer data as would be required for a `ManufacturerIn` database
             model to supply to the `SystemRepo` `update` method.
         """
@@ -430,18 +389,16 @@ class UpdateDSL(ManufacturerRepoDSL):
         """
         Calls the `ManufacturerRepo` `update` method with the appropriate data from a prior call to `mock_update` (or
         `set_update_data`) while expecting an error to be raised.
+
         :param manufacturer_id: ID of the manufacturer to be updated.
         :param error_type: Expected exception to be raised.
         """
-
         with pytest.raises(error_type) as exc:
             self.manufacturer_repository.update(manufacturer_id, self._manufacturer_in)
         self._update_exception = exc
 
     def check_update_success(self) -> None:
-        """
-        Checks that a prior call to `call_update` worked as expected.
-        """
+        """Checks that a prior call to `call_update` worked as expected."""
         # Obtain a list of expected `find_one` calls
         expected_find_one_calls = [
             # Stored manufacturer
@@ -472,21 +429,17 @@ class UpdateDSL(ManufacturerRepoDSL):
         Checks that a prior call to `call_update_expecting_error` worked as expected, raising an exception with the
         correct message.
 
-        :param message: Message of the raised exception.
+        :param message: Expected message of the raised exception.
         """
         self.manufacturers_collection.update_one.assert_not_called()
         assert str(self._update_exception.value) == message
 
 
 class TestUpdate(UpdateDSL):
-    """
-    Tests for updating a manufacturer.
-    """
+    """Tests for updating a manufacturer."""
 
     def test_update(self):
-        """
-        Test updating a manufacturer.
-        """
+        """Test updating a manufacturer."""
         manufacturer_id = str(ObjectId())
 
         self.mock_update(manufacturer_id, MANUFACTURER_IN_DATA_A, MANUFACTURER_IN_DATA_B)
@@ -494,9 +447,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_name_capitalisation(self):
-        """
-        Test updating the name capitalisation of a manufacturer.
-        """
+        """Test updating the name capitalisation of a manufacturer."""
         manufacturer_id = str(ObjectId())
         new_name = "manufacturer a"
 
@@ -505,9 +456,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_name_to_duplicate(self):
-        """
-        Test updating the name of a manufacturer to one that is a duplicate.
-        """
+        """Test updating the name of a manufacturer to one that is a duplicate."""
         manufacturer_id = str(ObjectId())
         duplicate_name = "Duplicate name"
 
@@ -519,9 +468,7 @@ class TestUpdate(UpdateDSL):
         )
 
     def test_update_with_invalid_id(self):
-        """
-        Test updating a manufacturer with an invalid ID.
-        """
+        """Test updating a manufacturer with an invalid ID."""
         manufacturer_id = "invalid-id"
 
         self.set_update_data(MANUFACTURER_IN_DATA_A)
@@ -530,21 +477,18 @@ class TestUpdate(UpdateDSL):
 
 
 class DeleteDSL(ManufacturerRepoDSL):
-    """
-    Base class for delete tests.
-    """
+    """Base class for `delete` tests."""
 
     _delete_manufacturer_id: str
     _delete_exception: pytest.ExceptionInfo
     _mock_catalogue_item_data: Optional[dict]
 
-    def mock_delete(self, deleted_count: int, catalogue_item_data: Optional[dict] = None):
+    def mock_delete(self, deleted_count: int, catalogue_item_data: Optional[dict] = None) -> None:
         """
         Mocks database methods appropriately to test the `delete` repo method.
 
         :param deleted_count: Number of documents deleted successfully.
         :param catalogue_item_data: Dictionary containing a catalogue item's data (or `None`).
-        :return:
         """
         self.mock_is_manufacturer_in_catalogue_item(catalogue_item_data)
         RepositoryTestHelpers.mock_delete_one(self.manufacturers_collection, deleted_count)
@@ -563,7 +507,7 @@ class DeleteDSL(ManufacturerRepoDSL):
         Calls the `ManufacturerRepo` `delete` method with the appropriate data from a prior call to `mock_delete` while
         expecting an error to be raised.
 
-        :param manufacturer_id: ID of the manufacturer to be obtained.
+        :param manufacturer_id: ID of the manufacturer to be deleted.
         :param error_type: Expected exception to be raised.
         """
         self._delete_manufacturer_id = manufacturer_id
@@ -572,9 +516,7 @@ class DeleteDSL(ManufacturerRepoDSL):
         self._delete_exception = exc
 
     def check_delete_success(self) -> None:
-        """
-        Checks that a prior call to `call_delete` worked as expected.
-        """
+        """Checks that a prior call to `call_delete` worked as expected."""
         self.check_is_manufacturer_in_catalogue_item_performed_expected_calls(self._delete_manufacturer_id)
         self.manufacturers_collection.delete_one.assert_called_once_with(
             {"_id": CustomObjectId(self._delete_manufacturer_id)}, session=self.mock_session
@@ -585,10 +527,9 @@ class DeleteDSL(ManufacturerRepoDSL):
         Checks that a prior call to `call_delete_expecting_error` worked as expected, raising an exception with the
         correct message.
 
-        :param message: Message of the raised exception.
+        :param message: Expected message of the raised exception.
         :param expecting_delete_one_called: Whether the `delete_one` method is expected to be called or not.
         """
-
         if not expecting_delete_one_called:
             self.manufacturers_collection.delete_one.assert_not_called()
         else:
@@ -600,10 +541,10 @@ class DeleteDSL(ManufacturerRepoDSL):
 
     def mock_is_manufacturer_in_catalogue_item(self, catalogue_item_data: Optional[dict] = None) -> None:
         """
-        Mocks database methods appropriately for when the '_is_manufacturer_in_catalogue_item' repo method will be
+        Mocks database methods appropriately for when the `_is_manufacturer_in_catalogue_item` repo method will be
         called.
 
-        :param catalogue_item_data: Dictionary containing a catalogue item's data (or `None`)
+        :param catalogue_item_data: Dictionary containing a catalogue item's data (or `None`).
         """
         self._mock_catalogue_item_data = catalogue_item_data
         RepositoryTestHelpers.mock_find_one(self.catalogue_items_collection, catalogue_item_data)
@@ -613,29 +554,22 @@ class DeleteDSL(ManufacturerRepoDSL):
 
         :param expected_manufacturer_id: Expected manufacturer ID used in the database calls.
         """
-
         self.catalogue_items_collection.find_one.assert_called_once_with(
             {"manufacturer_id": CustomObjectId(expected_manufacturer_id)}, session=self.mock_session
         )
 
 
 class TestDelete(DeleteDSL):
-    """
-    Tests for deleting a manufacturer.
-    """
+    """Tests for deleting a manufacturer."""
 
     def test_delete(self):
-        """
-        Test deleting a manufacturer.
-        """
+        """Test deleting a manufacturer."""
         self.mock_delete(deleted_count=1)
         self.call_delete(str(ObjectId()))
         self.check_delete_success()
 
     def test_delete_when_part_of_catalogue_item(self):
-        """
-        Test deleting a manufacturer when it is part of a catalogue item.
-        """
+        """Test deleting a manufacturer when it is part of a catalogue item."""
         manufacturer_id = str(ObjectId())
 
         # pylint:disable=fixme
@@ -652,9 +586,7 @@ class TestDelete(DeleteDSL):
         self.check_delete_failed_with_exception(f"Manufacturer with ID '{manufacturer_id}' is part of a catalogue item")
 
     def test_delete_non_existent_id(self):
-        """
-        Test deleting a manufacturer with a non-existent ID.
-        """
+        """Test deleting a manufacturer with a non-existent ID."""
         manufacturer_id = str(ObjectId())
 
         self.mock_delete(deleted_count=0)
@@ -664,9 +596,7 @@ class TestDelete(DeleteDSL):
         )
 
     def test_delete_with_invalid_id(self):
-        """
-        Test deleting a manufacturer with an invalid ID.
-        """
+        """Test deleting a manufacturer with an invalid ID."""
         manufacturer_id = "invalid-id"
 
         self.call_delete_expecting_error(manufacturer_id, InvalidObjectIdError)

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -27,7 +27,7 @@ from inventory_management_system_api.repositories.manufacturer import Manufactur
 
 class ManufacturerRepoDSL:
     """
-    Base class form `ManufacturerRepo` unit tests.
+    Base class for `ManufacturerRepo` unit tests.
     """
 
     mock_database: Mock

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -1,4 +1,6 @@
-"""Unit tests for the `ManufacturerRepo` repository."""
+"""
+Unit tests for the `ManufacturerRepo` repository.
+"""
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
 from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
 from inventory_management_system_api.models.item import ItemOut
+from inventory_management_system_api.models.manufacturer import ManufacturerOut
 from inventory_management_system_api.models.system import SystemOut
 from inventory_management_system_api.models.unit import UnitOut
 from inventory_management_system_api.models.usage_status import UsageStatusOut
@@ -242,7 +243,8 @@ class ServiceTestHelpers:
 
     @staticmethod
     def mock_create(
-        repository_mock: Mock, repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut]
+        repository_mock: Mock,
+        repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, ManufacturerOut, SystemOut],
     ) -> None:
         """
         Mock the `create` method of the repository mock to return a repository object.
@@ -255,7 +257,7 @@ class ServiceTestHelpers:
     @staticmethod
     def mock_get(
         repository_mock: Mock,
-        repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut, UnitOut, None],
+        repo_obj: Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, ManufacturerOut, SystemOut, UnitOut, None],
     ) -> None:
         """
         Mock the `get` method of the repository mock to return a specific repository object.
@@ -285,7 +287,9 @@ class ServiceTestHelpers:
     @staticmethod
     def mock_list(
         repository_mock: Mock,
-        repo_objs: List[Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, SystemOut, UsageStatusOut]],
+        repo_objs: List[
+            Union[CatalogueCategoryOut, CatalogueItemOut, ItemOut, ManufacturerOut, SystemOut, UsageStatusOut]
+        ],
     ) -> None:
         """
         Mock the `list` method of the repository mock to return a specific list of repository objects.
@@ -303,6 +307,7 @@ class ServiceTestHelpers:
             CatalogueCategoryOut,
             CatalogueItemOut,
             ItemOut,
+            ManufacturerOut,
             SystemOut,
         ],
     ) -> None:

--- a/test/unit/services/test_manufacturer.py
+++ b/test/unit/services/test_manufacturer.py
@@ -2,237 +2,382 @@
 Unit tests for the `ManufacturerService` service.
 """
 
-from datetime import timedelta
-from unittest.mock import MagicMock
-from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
+from typing import Optional
+from unittest.mock import MagicMock, Mock, patch
+
+from test.mock_data import MANUFACTURER_POST_DATA_A, MANUFACTURER_POST_DATA_B
+from test.unit.services.conftest import ServiceTestHelpers
 
 import pytest
 from bson import ObjectId
 
+from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import MissingRecordError
 from inventory_management_system_api.models.manufacturer import ManufacturerIn, ManufacturerOut
-from inventory_management_system_api.schemas.manufacturer import (
-    AddressSchema,
-    ManufacturerPatchSchema,
-    ManufacturerPostSchema,
-)
+from inventory_management_system_api.schemas.manufacturer import ManufacturerPatchSchema, ManufacturerPostSchema
+from inventory_management_system_api.services import utils
+from inventory_management_system_api.services.manufacturer import ManufacturerService
 
 
-def test_create(
-    test_helpers,
-    manufacturer_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    manufacturer_service,
-):
+class ManufacturerServiceDSL:
     """
-    Testing creating a manufacturer
+    Base class for `ManufacturerService` unit tests.
     """
-    # pylint: disable=duplicate-code
 
-    manufacturer = ManufacturerOut(
-        _id=str(ObjectId()),
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
+    wrapped_utils: Mock
+    mock_manufacturer_repository: Mock
+    manufacturer_service: ManufacturerService
 
-    # Mock `create` to return the created manufacturer
-    test_helpers.mock_create(manufacturer_repository_mock, manufacturer)
-
-    created_manufacturer = manufacturer_service.create(
-        ManufacturerPostSchema(
-            name=manufacturer.name,
-            url=manufacturer.url,
-            address=manufacturer.address,
-            telephone=manufacturer.telephone,
-        )
-    )
-    manufacturer_repository_mock.create.assert_called_once_with(
-        ManufacturerIn(
-            name=manufacturer.name,
-            code=manufacturer.code,
-            url=manufacturer.url,
-            address=manufacturer.address,
-            telephone=manufacturer.telephone,
-        )
-    )
-    assert created_manufacturer == manufacturer
-
-
-def test_delete(manufacturer_repository_mock, manufacturer_service):
-    """Test deleting a manufacturer"""
-    manufacturer_id = str(ObjectId())
-
-    manufacturer_service.delete(manufacturer_id)
-
-    manufacturer_repository_mock.delete.assert_called_once_with(manufacturer_id)
-
-
-def test_get(test_helpers, manufacturer_repository_mock, manufacturer_service):
-    """Test getting a manufacturer by ID"""
-    manufacturer_id = str(ObjectId())
-    manufacturer = MagicMock()
-
-    # Mock `get` to return a manufacturer
-    test_helpers.mock_get(manufacturer_repository_mock, manufacturer)
-
-    retrieved_manufacturer = manufacturer_service.get(manufacturer_id)
-
-    manufacturer_repository_mock.get.assert_called_once_with(manufacturer_id)
-    assert retrieved_manufacturer == manufacturer
-
-
-def test_get_with_non_existent_id(test_helpers, manufacturer_repository_mock, manufacturer_service):
-    """Test getting a manufacturer with an non-existent ID"""
-    manufacturer_id = str(ObjectId())
-    test_helpers.mock_get(manufacturer_repository_mock, None)
-
-    # Mock `get` to return a manufacturer
-    retrieved_manufacturer = manufacturer_service.get(manufacturer_id)
-
-    assert retrieved_manufacturer is None
-    manufacturer_repository_mock.get.assert_called_once_with(manufacturer_id)
-
-
-def test_list(manufacturer_repository_mock, manufacturer_service):
-    """Test getting all manufacturers"""
-    result = manufacturer_service.list()
-
-    manufacturer_repository_mock.list.assert_called_once()
-    assert result == manufacturer_repository_mock.list.return_value
-
-
-def test_update_with_non_existent_id(test_helpers, manufacturer_repository_mock, manufacturer_service):
-    """Test updating a manufacturer with a non-existent id"""
-    # pylint: disable=duplicate-code
-    manufacturer = ManufacturerOut(
-        _id=str(ObjectId()),
-        name="Manufacturer A",
-        code="manufacturer-a",
-        url="http://testUrl.co.uk",
-        address=AddressSchema(
-            address_line="1 Example Street",
-            town="Oxford",
-            county="Oxfordshire",
-            postcode="OX1 2AB",
-            country="United Kingdom",
-        ),
-        telephone="0932348348",
-        created_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-        modified_time=MODEL_MIXINS_FIXED_DATETIME_NOW,
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to not return a manufacturer
-    test_helpers.mock_get(manufacturer_repository_mock, None)
-
-    manufacturer_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        manufacturer_service.update(manufacturer_id, manufacturer)
-    manufacturer_repository_mock.update.assert_not_called()
-    assert str(exc.value) == "No manufacturer found with ID " + manufacturer_id
-
-
-def test_partial_update_of_address(
-    test_helpers,
-    manufacturer_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    manufacturer_service,
-):
-    """Test the partial update of a manufacturer's address"""
-    manufacturer_info = {
-        "_id": str(ObjectId()),
-        "name": "Manufacturer A",
-        "code": "manufacturer-a",
-        "url": "http://testUrl.co.uk",
-        "address": {"address_line": "1 Example Street", "postcode": "AB1 2CD", "country": "United Kingdom"},
-    }
-    full_manufacturer_info = {
-        **manufacturer_info,
-        "address": {"address_line": "test", "postcode": "AB1 2CD", "country": "United Kingdom"},
-        "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    }
-    manufacturer = ManufacturerOut(**full_manufacturer_info)
-
-    # Mock `get` to return a manufacturer
-    test_helpers.mock_get(
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
         manufacturer_repository_mock,
-        ManufacturerOut(
-            **{
-                **manufacturer_info,
-                "created_time": manufacturer.created_time,
-                "modified_time": manufacturer.created_time,
-            }
-        ),
-    )
+        manufacturer_service,
+        # Ensures all created and modified times are mocked throughout
+        # pylint: disable=unused-argument
+        model_mixins_datetime_now_mock,
+    ):
+        """Setup fixtures"""
+        self.mock_manufacturer_repository = manufacturer_repository_mock
+        self.manufacturer_service = manufacturer_service
 
-    # Mock `get` to return the updated manufacturer
-    test_helpers.mock_update(manufacturer_repository_mock, manufacturer)
-
-    updated_manufacturer = manufacturer_service.update(
-        manufacturer.id,
-        ManufacturerPatchSchema(address={"address_line": "test"}),
-    )
-
-    manufacturer_repository_mock.update.assert_called_once_with(
-        manufacturer.id, ManufacturerIn(**full_manufacturer_info)
-    )
-    assert updated_manufacturer == manufacturer
+        with patch("inventory_management_system_api.services.manufacturer.utils", wraps=utils) as wrapped_utils:
+            self.wrapped_utils = wrapped_utils
+            yield
 
 
-def test_partial_update_of_manufacturer(
-    test_helpers,
-    manufacturer_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    manufacturer_service,
-):
-    """Test the partial update of a manufacturer's name"""
-    manufacturer_info = {
-        "_id": str(ObjectId()),
-        "name": "Manufacturer A",
-        "code": "manufacturer-a",
-        "url": "http://testUrl.co.uk",
-        "address": {"address_line": "1 Example Street", "postcode": "AB1 2CD", "country": "United Kingdom"},
-    }
-    full_manufacturer_info = {
-        **manufacturer_info,
-        "name": "test",
-        "code": "test",
-        "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW - timedelta(days=5),
-        "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    }
-    manufacturer = ManufacturerOut(**full_manufacturer_info)
+class CreateDSL(ManufacturerServiceDSL):
+    """
+    Base class for create tests.
+    """
 
-    # Mock `get` to return a manufacturer
-    test_helpers.mock_get(
-        manufacturer_repository_mock,
-        ManufacturerOut(
-            **{
-                **manufacturer_info,
-                "created_time": manufacturer.created_time,
-                "modified_time": manufacturer.created_time,
-            }
-        ),
-    )
+    _manufacturer_post: ManufacturerPostSchema
+    _expected_manufacturer_in: ManufacturerIn
+    _expected_manufacturer_out: ManufacturerOut
+    _created_manufacturer: ManufacturerOut
+    _create_exception: pytest.ExceptionInfo
 
-    # Mock `get` to return the updated manufacturer
-    test_helpers.mock_update(manufacturer_repository_mock, manufacturer)
+    def mock_create(self, manufacturer_post_data: dict) -> None:
+        """
+        Mocks repo methods appropriately to test the `create` service method.
 
-    updated_manufacturer = manufacturer_service.update(manufacturer.id, ManufacturerPatchSchema(name="test"))
+        :param manufacturer_post_data: Dictionary containing the basic manufacturer data as would be required for a
+            `ManufacturerPostSchema` (i.e. no ID, code or created and modified times required).
+        """
+        self._manufacturer_post = ManufacturerPostSchema(**manufacturer_post_data)
 
-    manufacturer_repository_mock.update.assert_called_once_with(
-        manufacturer.id, ManufacturerIn(**full_manufacturer_info)
-    )
-    assert updated_manufacturer == manufacturer
+        self._expected_manufacturer_in = ManufacturerIn(
+            **manufacturer_post_data, code=utils.generate_code(manufacturer_post_data["name"], "manufacturer")
+        )
+        self._expected_manufacturer_out = ManufacturerOut(**self._expected_manufacturer_in.model_dump(), id=ObjectId())
+
+        ServiceTestHelpers.mock_create(self.mock_manufacturer_repository, self._expected_manufacturer_out)
+
+    def call_create(self) -> None:
+        """
+        Calls the `ManufacturerService` `create` method with the appropriate data from a prior call to `mock_create`.
+        """
+        self._created_manufacturer = self.manufacturer_service.create(self._manufacturer_post)
+
+    def check_create_success(self) -> None:
+        """
+        Checks that a prior call to `call_create` worked as expected.
+        """
+        self.wrapped_utils.generate_code.assert_called_once_with(self._expected_manufacturer_out.name, "manufacturer")
+        self.mock_manufacturer_repository.create.assert_called_once_with(self._expected_manufacturer_in)
+        assert self._created_manufacturer == self._expected_manufacturer_out
+
+
+class TestCreate(CreateDSL):
+    """
+    Tests for creating a manufacturer.
+    """
+
+    def test_create(self):
+        """
+        Test creating a manufacturer.
+        """
+        self.mock_create(MANUFACTURER_POST_DATA_A)
+        self.call_create()
+        self.check_create_success()
+
+
+class GetDSL(ManufacturerServiceDSL):
+    """
+    Base class for get tests.
+    """
+
+    _obtained_manufacturer_id: str
+    _expected_manufacturer: MagicMock
+    _obtained_manufacturer: MagicMock
+
+    def mock_get(self) -> None:
+        """
+        Mocks repo methods appropriately to test the `get` service method.
+        """
+        # Simply a return currently, so no need to use actual data
+        self._expected_manufacturer = MagicMock()
+        ServiceTestHelpers.mock_get(self.mock_manufacturer_repository, self._expected_manufacturer)
+
+    def call_get(self, manufacturer_id: str) -> None:
+        """
+        Calls the `ManufacturerService` `get` method.
+
+        :param manufacturer_id: ID of the manufacturer that will be obtained.
+        """
+        self._obtained_manufacturer_id = manufacturer_id
+        self._obtained_manufacturer = self.manufacturer_service.get(manufacturer_id)
+
+    def check_get_success(self):
+        """
+        Checks that a prior call to `call_get` worked as expected.
+        """
+        self.mock_manufacturer_repository.get.assert_called_once_with(self._obtained_manufacturer_id)
+        assert self._obtained_manufacturer == self._expected_manufacturer
+
+
+class TestGet(GetDSL):
+    """
+    Tests for getting a manufacturer.
+    """
+
+    def test_get(self):
+        """
+        Test getting a manufacturer.
+        """
+        self.mock_get()
+        self.call_get(str(ObjectId()))
+        self.check_get_success()
+
+
+class ListDSL(ManufacturerServiceDSL):
+    """
+    Base class for list tests.
+    """
+
+    _expected_manufacturers: MagicMock
+    _obtained_manufacturers: MagicMock
+
+    def mock_list(self) -> None:
+        """
+        Mocks repo methods appropriately to test the `list` service method.
+        """
+        # Simply a return currently, so no need to use actual data
+        self._expected_manufacturers = [MagicMock()]
+        ServiceTestHelpers.mock_list(self.mock_manufacturer_repository, self._expected_manufacturers)
+
+    def call_list(self) -> None:
+        """
+        Calls the `ManufacturerService` `list` method.
+        """
+        self._obtained_manufacturers = self.manufacturer_service.list()
+
+    def check_list_success(self) -> None:
+        """
+        Checks that a prior call to `call_list` worked as expected.
+        """
+        self.mock_manufacturer_repository.list.assert_called_once()
+        assert self._obtained_manufacturers == self._expected_manufacturers
+
+
+class TestList(ListDSL):
+    """
+    Tests for listing manufacturers.
+    """
+
+    def test_list(self):
+        """
+        Test listing manufacturers.
+        """
+        self.mock_list()
+        self.call_list()
+        self.check_list_success()
+
+
+class UpdateDSL(ManufacturerServiceDSL):
+    """
+    Base class for update tests.
+    """
+
+    _stored_manufacturer: Optional[ManufacturerOut]
+    _manufacturer_patch: ManufacturerPatchSchema
+    _expected_manufacturer_in: ManufacturerIn
+    _expected_manufacturer_out: MagicMock
+    _updated_manufacturer_id: str
+    _updated_manufacturer: MagicMock
+    _update_exception: pytest.ExceptionInfo
+
+    def mock_update(
+        self, manufacturer_id: str, manufacturer_patch_data: dict, stored_manufacturer_post_data: Optional[dict]
+    ) -> None:
+        """
+        Mocks the repository methods appropriately to test the `update` service method.
+
+        :param manufacturer_id: ID of the manufacturer to be updated.
+        :param manufacturer_patch_data: Dictionary containing the patch data as would be required for a
+            `ManufacturerPatchSchema` (i.e. no ID, code, or created and modified times required).
+        :param stored_manufacturer_post_data: Dictionary containing the manufacturer data for the existing stored
+            manufacturer as would be required for `ManufacturerPostSchema` (i.e. no ID, code or created and modified
+            times required).
+        """
+        # Stored manufacturer
+        self._stored_manufacturer = (
+            ManufacturerOut(
+                **ManufacturerIn(
+                    **stored_manufacturer_post_data,
+                    code=utils.generate_code(stored_manufacturer_post_data["name"], "manufacturer"),
+                ).model_dump(),
+                id=CustomObjectId(manufacturer_id),
+            )
+            if stored_manufacturer_post_data
+            else None
+        )
+        ServiceTestHelpers.mock_get(self.mock_manufacturer_repository, self._stored_manufacturer)
+
+        # Patch schema
+        self._manufacturer_patch = ManufacturerPatchSchema(**manufacturer_patch_data)
+
+        # Updated manufacturer
+        self._expected_manufacturer_out = MagicMock()
+        ServiceTestHelpers.mock_update(self.mock_manufacturer_repository, self._expected_manufacturer_out)
+
+        # Construct the expected input for the repository
+        merged_manufacturer_data = {**(stored_manufacturer_post_data or {}), **manufacturer_patch_data}
+        self._expected_manufacturer_in = ManufacturerIn(
+            **merged_manufacturer_data, code=utils.generate_code(merged_manufacturer_data["name"], "manufacturer")
+        )
+
+    def call_update(self, manufacturer_id: str) -> None:
+        """
+        Class the `ManufacturerService` `update` method with the appropriate data from a prior call to `mock_update`.
+
+        :param manufacturer_id: ID of the manufacturer to be updated.
+        """
+        self._updated_manufacturer_id = manufacturer_id
+        self._updated_manufacturer = self.manufacturer_service.update(manufacturer_id, self._manufacturer_patch)
+
+    def call_update_expecting_error(self, manufacturer_id: str, error_type: type[BaseException]) -> None:
+        """
+        Class the `ManufacturerService` `update` method with the appropriate data from a prior call to `mock_update`
+        while expecting an error to be raised.
+
+        :param manufacturer_id: ID of the manufacturer to be updated.
+        :param error_type: Expected exception to be raised.
+        """
+        with pytest.raises(error_type) as exc:
+            self.manufacturer_service.update(manufacturer_id, self._manufacturer_patch)
+        self._update_exception = exc
+
+    def check_update_success(self) -> None:
+        """
+        Checks that a prior call to `call_update` worked as updated.
+        """
+        # Ensure obtained old manufacturer
+        self.mock_manufacturer_repository.get.assert_called_once_with(self._updated_manufacturer_id)
+
+        # Ensure new code was obtained if patching name
+        if self._manufacturer_patch.name:
+            self.wrapped_utils.generate_code.assert_called_once_with(self._manufacturer_patch.name, "manufacturer")
+        else:
+            self.wrapped_utils.generate_code.assert_not_called()
+
+        # Ensure updated with expected data
+        self.mock_manufacturer_repository.update.assert_called_once_with(
+            self._updated_manufacturer_id, self._expected_manufacturer_in
+        )
+
+        assert self._updated_manufacturer == self._expected_manufacturer_out
+
+    def check_update_failed_with_exception(self, message: str):
+        """
+        Checks that a prior call to `call_update_expecting_error` worked as expected, raising an exception with the
+        correct message.
+
+        :param message: Message of the raised exception.
+        """
+        self.mock_manufacturer_repository.update.assert_not_called()
+        assert str(self._update_exception.value) == message
+
+
+class TestUpdate(UpdateDSL):
+    """
+    Tests for updating a manufacturer.
+    """
+
+    def test_update(self):
+        """
+        Test updating all fields of a manufacturer.
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_update(
+            manufacturer_id,
+            manufacturer_patch_data=MANUFACTURER_POST_DATA_B,
+            stored_manufacturer_post_data=MANUFACTURER_POST_DATA_A,
+        )
+        self.call_update(manufacturer_id)
+        self.check_update_success()
+
+    def test_update_address_only(self) -> None:
+        """
+        Test updating manufacturer's address only (code should not need regenerating as name doesn't change).
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_update(
+            manufacturer_id,
+            manufacturer_patch_data=MANUFACTURER_POST_DATA_B["address"],
+            stored_manufacturer_post_data=MANUFACTURER_POST_DATA_A,
+        )
+        self.call_update(manufacturer_id)
+        self.check_update_success()
+
+    def test_update_with_non_existent_id(self):
+        """
+        Test updating a manufacturer with a non-existent ID.
+        """
+        manufacturer_id = str(ObjectId())
+
+        self.mock_update(
+            manufacturer_id, manufacturer_patch_data=MANUFACTURER_POST_DATA_A, stored_manufacturer_post_data=None
+        )
+        self.call_update_expecting_error(manufacturer_id, MissingRecordError)
+        self.check_update_failed_with_exception(f"No manufacturer found with ID: {manufacturer_id}")
+
+
+class DeleteDSL(ManufacturerServiceDSL):
+    """
+    Base class for delete tests.
+    """
+
+    _delete_manufacturer_id: str
+
+    def call_delete(self, manufacturer_id: str) -> None:
+        """
+        Calls the `ManufacturerService` `delete` method.
+        :param manufacturer_id: ID of the manufacturer to be deleted.
+        """
+        self._delete_manufacturer_id = manufacturer_id
+        self.manufacturer_service.delete(manufacturer_id)
+
+    def check_delete_success(self) -> None:
+        """
+        Checks that a prior call to `call_delete` worked as expected.
+        """
+        self.mock_manufacturer_repository.delete.assert_called_once_with(self._delete_manufacturer_id)
+
+
+class TestDelete(DeleteDSL):
+    """
+    Tests for deleting a manufacturer.
+    """
+
+    def test_delete(self):
+        """
+        Test deleting a manufacturer.
+        """
+        self.call_delete(str(ObjectId()))
+        self.check_delete_success()

--- a/test/unit/services/test_manufacturer.py
+++ b/test/unit/services/test_manufacturer.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for the `ManufacturerService` service.
-"""
+"""Unit tests for the `ManufacturerService` service."""
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code
@@ -23,9 +21,7 @@ from inventory_management_system_api.services.manufacturer import ManufacturerSe
 
 
 class ManufacturerServiceDSL:
-    """
-    Base class for `ManufacturerService` unit tests.
-    """
+    """Base class for `ManufacturerService` unit tests."""
 
     wrapped_utils: Mock
     mock_manufacturer_repository: Mock
@@ -50,9 +46,7 @@ class ManufacturerServiceDSL:
 
 
 class CreateDSL(ManufacturerServiceDSL):
-    """
-    Base class for create tests.
-    """
+    """Base class for `create` tests."""
 
     _manufacturer_post: ManufacturerPostSchema
     _expected_manufacturer_in: ManufacturerIn
@@ -77,47 +71,36 @@ class CreateDSL(ManufacturerServiceDSL):
         ServiceTestHelpers.mock_create(self.mock_manufacturer_repository, self._expected_manufacturer_out)
 
     def call_create(self) -> None:
-        """
-        Calls the `ManufacturerService` `create` method with the appropriate data from a prior call to `mock_create`.
-        """
+        """Calls the `ManufacturerService` `create` method with the appropriate data from a prior call to
+        `mock_create`."""
         self._created_manufacturer = self.manufacturer_service.create(self._manufacturer_post)
 
     def check_create_success(self) -> None:
-        """
-        Checks that a prior call to `call_create` worked as expected.
-        """
+        """Checks that a prior call to `call_create` worked as expected."""
         self.wrapped_utils.generate_code.assert_called_once_with(self._expected_manufacturer_out.name, "manufacturer")
         self.mock_manufacturer_repository.create.assert_called_once_with(self._expected_manufacturer_in)
         assert self._created_manufacturer == self._expected_manufacturer_out
 
 
 class TestCreate(CreateDSL):
-    """
-    Tests for creating a manufacturer.
-    """
+    """Tests for creating a manufacturer."""
 
     def test_create(self):
-        """
-        Test creating a manufacturer.
-        """
+        """Test creating a manufacturer."""
         self.mock_create(MANUFACTURER_POST_DATA_A)
         self.call_create()
         self.check_create_success()
 
 
 class GetDSL(ManufacturerServiceDSL):
-    """
-    Base class for get tests.
-    """
+    """Base class for `get` tests."""
 
     _obtained_manufacturer_id: str
     _expected_manufacturer: MagicMock
     _obtained_manufacturer: MagicMock
 
     def mock_get(self) -> None:
-        """
-        Mocks repo methods appropriately to test the `get` service method.
-        """
+        """Mocks repo methods appropriately to test the `get` service method."""
         # Simply a return currently, so no need to use actual data
         self._expected_manufacturer = MagicMock()
         ServiceTestHelpers.mock_get(self.mock_manufacturer_repository, self._expected_manufacturer)
@@ -126,81 +109,61 @@ class GetDSL(ManufacturerServiceDSL):
         """
         Calls the `ManufacturerService` `get` method.
 
-        :param manufacturer_id: ID of the manufacturer that will be obtained.
+        :param manufacturer_id: ID of the manufacturer to be obtained.
         """
         self._obtained_manufacturer_id = manufacturer_id
         self._obtained_manufacturer = self.manufacturer_service.get(manufacturer_id)
 
     def check_get_success(self):
-        """
-        Checks that a prior call to `call_get` worked as expected.
-        """
+        """Checks that a prior call to `call_get` worked as expected."""
         self.mock_manufacturer_repository.get.assert_called_once_with(self._obtained_manufacturer_id)
         assert self._obtained_manufacturer == self._expected_manufacturer
 
 
 class TestGet(GetDSL):
-    """
-    Tests for getting a manufacturer.
-    """
+    """Tests for getting a manufacturer."""
 
     def test_get(self):
-        """
-        Test getting a manufacturer.
-        """
+        """Test getting a manufacturer."""
         self.mock_get()
         self.call_get(str(ObjectId()))
         self.check_get_success()
 
 
 class ListDSL(ManufacturerServiceDSL):
-    """
-    Base class for list tests.
-    """
+    """Base class for `list` tests."""
 
     _expected_manufacturers: MagicMock
     _obtained_manufacturers: MagicMock
 
     def mock_list(self) -> None:
-        """
-        Mocks repo methods appropriately to test the `list` service method.
-        """
+        """Mocks repo methods appropriately to test the `list` service method."""
         # Simply a return currently, so no need to use actual data
-        self._expected_manufacturers = [MagicMock()]
+        self._expected_manufacturers = MagicMock()
         ServiceTestHelpers.mock_list(self.mock_manufacturer_repository, self._expected_manufacturers)
 
     def call_list(self) -> None:
-        """
-        Calls the `ManufacturerService` `list` method.
-        """
+        """Calls the `ManufacturerService` `list` method."""
         self._obtained_manufacturers = self.manufacturer_service.list()
 
     def check_list_success(self) -> None:
-        """
-        Checks that a prior call to `call_list` worked as expected.
-        """
+        """Checks that a prior call to `call_list` worked as expected."""
         self.mock_manufacturer_repository.list.assert_called_once()
         assert self._obtained_manufacturers == self._expected_manufacturers
 
 
 class TestList(ListDSL):
-    """
-    Tests for listing manufacturers.
-    """
+    """Tests for listing manufacturers."""
 
     def test_list(self):
-        """
-        Test listing manufacturers.
-        """
+        """Test listing manufacturers."""
         self.mock_list()
         self.call_list()
         self.check_list_success()
 
 
 class UpdateDSL(ManufacturerServiceDSL):
-    """
-    Base class for update tests.
-    """
+    """Base class for `update` tests."""
 
     _stored_manufacturer: Optional[ManufacturerOut]
     _manufacturer_patch: ManufacturerPatchSchema
@@ -272,9 +235,7 @@ class UpdateDSL(ManufacturerServiceDSL):
         self._update_exception = exc
 
     def check_update_success(self) -> None:
-        """
-        Checks that a prior call to `call_update` worked as updated.
-        """
+        """Checks that a prior call to `call_update` worked as updated."""
         # Ensure obtained old manufacturer
         self.mock_manufacturer_repository.get.assert_called_once_with(self._updated_manufacturer_id)
 
@@ -296,21 +257,17 @@ class UpdateDSL(ManufacturerServiceDSL):
         Checks that a prior call to `call_update_expecting_error` worked as expected, raising an exception with the
         correct message.
 
-        :param message: Message of the raised exception.
+        :param message: Expected message of the raised exception.
         """
         self.mock_manufacturer_repository.update.assert_not_called()
         assert str(self._update_exception.value) == message
 
 
 class TestUpdate(UpdateDSL):
-    """
-    Tests for updating a manufacturer.
-    """
+    """Tests for updating a manufacturer."""
 
     def test_update(self):
-        """
-        Test updating all fields of a manufacturer.
-        """
+        """Test updating all fields of a manufacturer."""
         manufacturer_id = str(ObjectId())
 
         self.mock_update(
@@ -322,9 +279,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_address_only(self) -> None:
-        """
-        Test updating manufacturer's address only (code should not need regenerating as name doesn't change).
-        """
+        """Test updating manufacturer's address only (code should not need regenerating as name doesn't change)."""
         manufacturer_id = str(ObjectId())
 
         self.mock_update(
@@ -336,9 +291,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_with_non_existent_id(self):
-        """
-        Test updating a manufacturer with a non-existent ID.
-        """
+        """Test updating a manufacturer with a non-existent ID."""
         manufacturer_id = str(ObjectId())
 
         self.mock_update(
@@ -349,35 +302,28 @@ class TestUpdate(UpdateDSL):
 
 
 class DeleteDSL(ManufacturerServiceDSL):
-    """
-    Base class for delete tests.
-    """
+    """Base class for `delete` tests."""
 
     _delete_manufacturer_id: str
 
     def call_delete(self, manufacturer_id: str) -> None:
         """
         Calls the `ManufacturerService` `delete` method.
+
         :param manufacturer_id: ID of the manufacturer to be deleted.
         """
         self._delete_manufacturer_id = manufacturer_id
         self.manufacturer_service.delete(manufacturer_id)
 
     def check_delete_success(self) -> None:
-        """
-        Checks that a prior call to `call_delete` worked as expected.
-        """
+        """Checks that a prior call to `call_delete` worked as expected."""
         self.mock_manufacturer_repository.delete.assert_called_once_with(self._delete_manufacturer_id)
 
 
 class TestDelete(DeleteDSL):
-    """
-    Tests for deleting a manufacturer.
-    """
+    """Tests for deleting a manufacturer."""
 
     def test_delete(self):
-        """
-        Test deleting a manufacturer.
-        """
+        """Test deleting a manufacturer."""
         self.call_delete(str(ObjectId()))
         self.check_delete_success()

--- a/test/unit/services/test_manufacturer.py
+++ b/test/unit/services/test_manufacturer.py
@@ -1,4 +1,6 @@
-"""Unit tests for the `ManufacturerService` service."""
+"""
+Unit tests for the `ManufacturerService` service.
+"""
 
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code


### PR DESCRIPTION
## Description
Refactors the manufacturer tests in the same format as in #302 as part of #90.

Removed the tests:
- `test_partial_update_address` (repo unit and e2e) as the standard update is enough
- `test_get_with_non_existent_id` as not needed

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #312 