### PR TITLE
Refactor CatalogueItemService unit tests #341

### DIFF
--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -169,15 +169,20 @@ class CatalogueItemService:
                     stored_catalogue_item.catalogue_category_id
                 )
 
+                # Ensure the properties are the same in every way ignoring the ids
+                invalid_action_error_message = (
+                    "Cannot move catalogue item to a category with different properties without "
+                    "specifying the new properties"
+                )
+                if len(current_catalogue_category.properties) != len(catalogue_category.properties):
+                    raise InvalidActionError(invalid_action_error_message)
+
                 old_to_new_id_map = {}
                 for current_catalogue_category_prop, catalogue_category_prop in zip(
                     current_catalogue_category.properties, catalogue_category.properties
                 ):
                     if not current_catalogue_category_prop.is_equal_without_id(catalogue_category_prop):
-                        raise InvalidActionError(
-                            "Cannot move catalogue item to a category with different properties without "
-                            "specifying the new properties"
-                        )
+                        raise InvalidActionError(invalid_action_error_message)
                     old_to_new_id_map[current_catalogue_category_prop.id] = catalogue_category_prop.id
 
                 # The IDs of the properties need to be updated to those of the new catalogue category

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -124,6 +124,7 @@ class CatalogueItemService:
         return self._catalogue_item_repository.list(catalogue_category_id)
 
     # pylint:disable=too-many-branches
+    # pylint:disable=too-many-locals
     def update(self, catalogue_item_id: str, catalogue_item: CatalogueItemPatchSchema) -> CatalogueItemOut:
         """
         Update a catalogue item by its ID.

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -185,7 +185,7 @@ class TestCreate(CreateDSL):
             {**CATALOGUE_CATEGORY_GET_DATA_NON_LEAF_REQUIRED_VALUES_ONLY, "parent_id": parent_id}
         )
 
-    def test_create_with_eaf_parent(self):
+    def test_create_with_leaf_parent(self):
         """Test creating a catalogue category with a leaf parent."""
 
         parent_id = self.post_catalogue_category(

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -245,7 +245,6 @@ PROPERTY_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE1 = {
 # This is the base catalogue category to be used in tests with properties
 BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES = CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM
 
-# TODO: Don't think having ids inside here will actually work for e2e tests
 # No properties
 CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY = {
     "name": "Catalogue Item Required Values Only",

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -169,8 +169,6 @@ CATALOGUE_CATEGORY_GET_DATA_LEAF_NO_PARENT_NO_PROPERTIES = {
     "properties": [],
 }
 
-# --------------------------------- Properties ---------------------------------
-
 # Leaf, Required values only
 
 CATALOGUE_CATEGORY_POST_DATA_LEAF_REQUIRED_VALUES_ONLY = {
@@ -223,6 +221,18 @@ CATALOGUE_CATEGORY_GET_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM = {
         CATALOGUE_CATEGORY_PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
         CATALOGUE_CATEGORY_PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST,
     ],
+}
+
+# --------------------------------- CATALOGUE ITEMS ---------------------------------
+
+# No properties
+CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY = {
+    "catalogue_category_id": str(ObjectId()),
+    "manufacturer_id": str(ObjectId()),
+    "name": "Catalogue Item Required Values Only",
+    "cost_gbp": 42,
+    "days_to_replace": 7,
+    "is_obsolete": False,
 }
 
 # --------------------------------- MANUFACTURERS ---------------------------------

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -223,17 +223,71 @@ CATALOGUE_CATEGORY_GET_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM = {
     ],
 }
 
+# --------------------------------- PROPERTIES ---------------------------------
+
+PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE = {
+    "name": CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY["name"],
+    "value": True,
+}
+
+PROPERTY_DATA_NUMBER_NON_MANDATORY_42 = {
+    "name": CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT["name"],
+    "value": 42,
+}
+
+PROPERTY_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE1 = {
+    "name": CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST["name"],
+    "value": "value1",
+}
+
 # --------------------------------- CATALOGUE ITEMS ---------------------------------
 
+# This is the base catalogue category to be used in tests with properties
+BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES = CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM
+
+# TODO: Don't think having ids inside here will actually work for e2e tests
 # No properties
-CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY = {
-    "catalogue_category_id": str(ObjectId()),
-    "manufacturer_id": str(ObjectId()),
+CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY = {
     "name": "Catalogue Item Required Values Only",
     "cost_gbp": 42,
     "days_to_replace": 7,
     "is_obsolete": False,
 }
+
+# Not obsolete, No properties
+CATALOGUE_ITEM_DATA_NOT_OBSOLETE_NO_PROPERTIES = {
+    **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+    "name": "Catalogue Item Not Obsolete No Properties",
+    "description": "Some description",
+    "cost_to_rework": 9001,
+    "days_to_rework": 3,
+    "drawing_number": "12345-1",
+    "drawing_link": "http://example.com",
+    "item_model_number": "123456-1",
+    "is_obsolete": False,
+    "notes": "Some notes",
+}
+
+# Obsolete, No properties
+CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES = {
+    **CATALOGUE_ITEM_DATA_NOT_OBSOLETE_NO_PROPERTIES,
+    "name": "Catalogue Item Obsolete No Properties",
+    "is_obsolete": True,
+    "obsolete_reason": "Manufacturer no longer exists",
+    "obsolete_replacement_catalogue_item_id": str(ObjectId()),
+}
+
+# Properties
+CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES = {
+    **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+    "name": "Catalogue Item With All Properties",
+    "properties": [
+        PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE,
+        PROPERTY_DATA_NUMBER_NON_MANDATORY_42,
+        PROPERTY_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE1,
+    ],
+}
+
 
 # --------------------------------- MANUFACTURERS ---------------------------------
 

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -12,6 +12,7 @@ from test.mock_data import (
     CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
     CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_B,
     CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
+    CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.test_utils import (
@@ -19,7 +20,6 @@ from test.unit.repositories.test_utils import (
     MOCK_MOVE_QUERY_RESULT_INVALID,
     MOCK_MOVE_QUERY_RESULT_VALID,
 )
-from test.unit.services.test_catalogue_item import CATALOGUE_ITEM_A_INFO
 from typing import Optional
 from unittest.mock import MagicMock, Mock, call, patch
 
@@ -979,11 +979,9 @@ class TestHasChildElements(HasChildElementsDSL):
         """Test `has_child_elements` when there are no child catalogue categories but there is a child catalogue
         item."""
 
-        # pylint:disable=fixme
-        # TODO: Replace CATALOGUE_ITEM_A_INFO once catalogue item tests have been refactored
         self.mock_has_child_elements(
             child_catalogue_category_data=None,
-            child_catalogue_item_data=CATALOGUE_ITEM_A_INFO,
+            child_catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
         )
         self.call_has_child_elements(catalogue_category_id=str(ObjectId()))
         self.check_has_child_elements_success(expected_result=True)
@@ -1090,9 +1088,7 @@ class TestDelete(DeleteDSL):
 
         catalogue_category_id = str(ObjectId())
 
-        # pylint:disable=fixme
-        # TODO: Replace CATALOGUE_ITEM_A_INFO once item tests have been refactored
-        self.mock_delete(deleted_count=1, child_catalogue_item_data=CATALOGUE_ITEM_A_INFO)
+        self.mock_delete(deleted_count=1, child_catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY)
         self.call_delete_expecting_error(catalogue_category_id, ChildElementsExistError)
         self.check_delete_failed_with_exception(
             f"Catalogue category with ID {catalogue_category_id} has child elements and cannot be deleted"

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -7,9 +7,10 @@ from typing import List, Type, Union
 from unittest.mock import Mock, patch
 
 import pytest
+from bson import ObjectId
 
-from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
-from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
+from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut, CatalogueCategoryPropertyIn
+from inventory_management_system_api.models.catalogue_item import CatalogueItemOut, PropertyIn
 from inventory_management_system_api.models.item import ItemOut
 from inventory_management_system_api.models.manufacturer import ManufacturerOut
 from inventory_management_system_api.models.system import SystemOut
@@ -23,6 +24,8 @@ from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.repositories.unit import UnitRepo
 from inventory_management_system_api.repositories.usage_status import UsageStatusRepo
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
+from inventory_management_system_api.schemas.catalogue_category import CatalogueCategoryPostPropertySchema
+from inventory_management_system_api.schemas.catalogue_item import PropertyPostSchema
 from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
 from inventory_management_system_api.services.catalogue_category_property import CatalogueCategoryPropertyService
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -7,10 +7,9 @@ from typing import List, Type, Union
 from unittest.mock import Mock, patch
 
 import pytest
-from bson import ObjectId
 
-from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut, CatalogueCategoryPropertyIn
-from inventory_management_system_api.models.catalogue_item import CatalogueItemOut, PropertyIn
+from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
+from inventory_management_system_api.models.catalogue_item import CatalogueItemOut
 from inventory_management_system_api.models.item import ItemOut
 from inventory_management_system_api.models.manufacturer import ManufacturerOut
 from inventory_management_system_api.models.system import SystemOut
@@ -24,8 +23,6 @@ from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.repositories.unit import UnitRepo
 from inventory_management_system_api.repositories.usage_status import UsageStatusRepo
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
-from inventory_management_system_api.schemas.catalogue_category import CatalogueCategoryPostPropertySchema
-from inventory_management_system_api.schemas.catalogue_item import PropertyPostSchema
 from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
 from inventory_management_system_api.services.catalogue_category_property import CatalogueCategoryPropertyService
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -505,7 +505,7 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
                 **CatalogueCategoryIn(
                     **stored_catalogue_category_post_data,
                     code=utils.generate_code(stored_catalogue_category_post_data["name"], "catalogue category"),
-                ).model_dump(),
+                ).model_dump(by_alias=True),
                 id=CustomObjectId(catalogue_category_id),
             )
             if stored_catalogue_category_post_data
@@ -522,9 +522,7 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
 
         # When moving i.e. changing the parent id, the data for the new parent needs to be mocked
         self._moving_catalogue_category = (
-            "parent_id" in catalogue_category_update_data
-            and stored_catalogue_category_post_data is not None
-            and stored_catalogue_category_post_data["parent_id"] != catalogue_category_update_data["parent_id"]
+            "parent_id" in catalogue_category_update_data and stored_catalogue_category_post_data is not None
         )
 
         if self._moving_catalogue_category and catalogue_category_update_data["parent_id"]:

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -251,7 +251,6 @@ class CreateDSL(CatalogueCategoryServiceDSL):
         )
 
         if self._catalogue_category_post.properties:
-            # TODO: Compare with catalogue items, is this really needed?
             # To assert with property IDs we must compare as dicts and use ANY here as otherwise the ObjectIds will
             # always be different
             actual_catalogue_category_in = self.mock_catalogue_category_repository.create.call_args_list[0][0][0]
@@ -490,7 +489,7 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
                                                stored catalogue category as would be required for a
                                                `CatalogueCategoryPostSchema` (i.e. no ID, code or created and modified
                                                times required).
-        :param has_child_elements: Boolean of whether the category being updated has child elements or not
+        :param has_child_elements: Boolean of whether the catalogue category being updated has child elements or not
         :param new_parent_catalogue_category_in_data: Either `None` or a dictionary containing the new parent catalogue
                                                category data as would be required for a `CatalogueCategoryIn` database
                                                model.

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -166,7 +166,7 @@ class CreateDSL(CatalogueCategoryServiceDSL):
         Mocks repo methods appropriately to test the `create` service method.
 
         :param catalogue_category_data: Dictionary containing the basic catalogue category data as would be required
-                                        for a `CatalogueCategoryPostSchema` but with any unit_id's replaced by the
+                                        for a `CatalogueCategoryPostSchema` but with any `unit_id`'s replaced by the
                                         'unit' value in its properties as the IDs will be added automatically.
         :param parent_catalogue_category_in_data: Either `None` or a dictionary containing the parent catalogue category
                                                   data as would be required for a `CatalogueCategoryIn` database model.

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -251,6 +251,7 @@ class CreateDSL(CatalogueCategoryServiceDSL):
         )
 
         if self._catalogue_category_post.properties:
+            # TODO: Compare with catalogue items, is this really needed?
             # To assert with property IDs we must compare as dicts and use ANY here as otherwise the ObjectIds will
             # always be different
             actual_catalogue_category_in = self.mock_catalogue_category_repository.create.call_args_list[0][0][0]

--- a/test/unit/services/test_catalogue_category.py
+++ b/test/unit/services/test_catalogue_category.py
@@ -598,11 +598,11 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
     def check_update_success(self) -> None:
         """Checks that a prior call to `call_update` worked as expected."""
 
-        # Obtain a list of expected get calls
-        expected_get_calls = []
+        # Obtain a list of expected catalogue category get calls
+        expected_catalogue_category_get_calls = []
 
         # Ensure obtained old catalogue category
-        expected_get_calls.append(call(self._updated_catalogue_category_id))
+        expected_catalogue_category_get_calls.append(call(self._updated_catalogue_category_id))
 
         # Ensure checking children if needed
         if self._expect_child_check:
@@ -620,9 +620,9 @@ class UpdateDSL(CatalogueCategoryServiceDSL):
 
         # Ensure obtained new parent if moving
         if self._moving_catalogue_category and self._catalogue_category_patch.parent_id:
-            expected_get_calls.append(call(self._catalogue_category_patch.parent_id))
+            expected_catalogue_category_get_calls.append(call(self._catalogue_category_patch.parent_id))
 
-        self.mock_catalogue_category_repository.get.assert_has_calls(expected_get_calls)
+        self.mock_catalogue_category_repository.get.assert_has_calls(expected_catalogue_category_get_calls)
 
         # Ensure updated with expected data
         if self._catalogue_category_patch.properties:
@@ -667,7 +667,7 @@ class TestUpdate(UpdateDSL):
     """Tests for updating a catalogue category."""
 
     def test_update_non_leaf_all_fields_except_parent_id_no_children(self):
-        """Test updating all fields of a non-leaf catalogue category except its parent id when it has no children."""
+        """Test updating all fields of a non-leaf catalogue category except its `parent_id` when it has no children."""
 
         catalogue_category_id = str(ObjectId())
 
@@ -680,7 +680,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_all_fields_except_parent_id_with_children(self):
-        """Test updating all allowable fields of a catalogue category except its parent id when it has children
+        """Test updating all allowable fields of a catalogue category except its `parent_id` when it has children
         (leaf/non-leaf doesn't matter as properties can't be updated with children anyway)."""
 
         catalogue_category_id = str(ObjectId())
@@ -694,7 +694,7 @@ class TestUpdate(UpdateDSL):
         self.call_update(catalogue_category_id)
         self.check_update_success()
 
-    def test_update_is_leaf_only_without_children(self):
+    def test_update_is_leaf_without_children(self):
         """Test updating a catalogue categories is_leaf field only when it doesn't have any children
         (code should not need regenerating as name doesn't change)."""
 
@@ -708,7 +708,7 @@ class TestUpdate(UpdateDSL):
         self.call_update(catalogue_category_id)
         self.check_update_success()
 
-    def test_update_is_leaf_only_with_children(self):
+    def test_update_is_leaf_with_children(self):
         """Test updating a catalogue categories is_leaf field only when it has children
         (code should not need regenerating as name doesn't change)."""
 
@@ -726,7 +726,7 @@ class TestUpdate(UpdateDSL):
         )
 
     def test_update_leaf_all_fields_except_parent_id_with_no_children(self):
-        """Test updating all fields of a leaf catalogue category except its parent id when it has no children."""
+        """Test updating all fields of a leaf catalogue category except its `parent_id` when it has no children."""
 
         catalogue_category_id = str(ObjectId())
 
@@ -739,7 +739,7 @@ class TestUpdate(UpdateDSL):
         self.call_update(catalogue_category_id)
         self.check_update_success()
 
-    def test_update_leaf_properties_only_with_children(self):
+    def test_update_leaf_properties_with_children(self):
         """Test updating the properties of a leaf catalogue category when it has children."""
 
         catalogue_category_id = str(ObjectId())
@@ -758,7 +758,7 @@ class TestUpdate(UpdateDSL):
             f"Catalogue category with ID {catalogue_category_id} has child elements and cannot be updated"
         )
 
-    def test_update_leaf_properties_only_with_non_existent_unit_id(self):
+    def test_update_leaf_properties_with_non_existent_unit_id(self):
         """Test updating the properties of a leaf catalogue category when given a property with an non-existent unit
         ID."""
 

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -669,7 +669,6 @@ class UpdateDSL(CatalogueItemServiceDSL):
             )
 
         # When properties are given need to add any property `id`s and ensure the expected data inserts them as well
-        property_post_schemas = []
         expected_properties_in = []
         if self._updating_properties:
 
@@ -756,8 +755,9 @@ class UpdateDSL(CatalogueItemServiceDSL):
             )
 
         # Ensure obtained new catalogue category if moving
+        expected_catalogue_category_get_calls = []
         if self._moving_catalogue_item and self._catalogue_item_patch.catalogue_category_id:
-            expected_catalogue_category_get_calls = [call(self._catalogue_item_patch.catalogue_category_id)]
+            expected_catalogue_category_get_calls.append(call(self._catalogue_item_patch.catalogue_category_id))
 
             # Expect additional call from existing catalogue category to compare properties if new properties aren't
             # given
@@ -807,8 +807,8 @@ class TestUpdate(UpdateDSL):
     """Tests for updating a catalogue item."""
 
     def test_update_all_fields_except_ids_or_properties_with_no_children(self):
-        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties when it has
-        no children."""
+        """Test updating all fields of a catalogue item except any of its `_id` fields or properties when it has no
+        children."""
 
         catalogue_item_id = str(ObjectId())
 
@@ -821,8 +821,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_all_fields_except_ids_or_properties_with_children(self):
-        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties it has
-        children."""
+        """Test updating all fields of a catalogue item except any of its `_id` fields or properties it has children."""
 
         catalogue_item_id = str(ObjectId())
 

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -486,7 +486,12 @@ class TestList(ListDSL):
 class UpdateDSL(CatalogueItemServiceDSL):
     """Base class for `update` tests."""
 
+    # TODO: Remove unused parameters that were copied (e.g. unit_value_id_dict?)
     _stored_catalogue_item: Optional[CatalogueItemOut]
+    _stored_catalogue_category_in: Optional[CatalogueCategoryIn]
+    _stored_catalogue_category_out: Optional[CatalogueCategoryOut]
+    _new_catalogue_category_in: Optional[CatalogueCategoryIn]
+    _new_catalogue_category_out: Optional[CatalogueCategoryOut]
     _catalogue_item_patch: CatalogueItemPatchSchema
     _expected_catalogue_item_in: CatalogueItemIn
     _expected_catalogue_item_out: MagicMock
@@ -498,6 +503,7 @@ class UpdateDSL(CatalogueItemServiceDSL):
     _moving_catalogue_item: bool
     _updating_manufacturer: bool
     _updating_obsolete_replacement_catalogue_item: bool
+    _updating_properties: bool
     unit_value_id_dict: dict[str, str]
 
     # TODO: Update comment and parameters
@@ -507,6 +513,7 @@ class UpdateDSL(CatalogueItemServiceDSL):
         catalogue_item_id: str,
         catalogue_item_update_data: dict,
         stored_catalogue_item_data: Optional[dict],
+        stored_catalogue_category_in_data: Optional[dict] = None,
         new_catalogue_category_in_data: Optional[dict] = None,
         new_manufacturer_in_data: Optional[dict] = None,
         new_obsolete_replacement_catalogue_item_data: Optional[dict] = None,
@@ -533,14 +540,29 @@ class UpdateDSL(CatalogueItemServiceDSL):
                               required by the given catalogue category properties in the patch data.
         """
 
+        # Add property ids to the stored catalogue item if needed
+        self._stored_catalogue_category_in = (
+            CatalogueCategoryIn(**stored_catalogue_category_in_data) if stored_catalogue_category_in_data else None
+        )
+        expected_stored_properties_in = []
+        if (
+            self._stored_catalogue_category_in
+            and "properties" in stored_catalogue_item_data
+            and stored_catalogue_item_data["properties"]
+        ):
+            expected_stored_properties_in, _ = self.construct_properties_in_and_post_with_ids(
+                self._stored_catalogue_category_in.properties, stored_catalogue_item_data["properties"]
+            )
+
+        # Generate mandatory IDs to be inserted where needed
+        stored_ids_to_insert = {"catalogue_category_id": str(ObjectId()), "manufacturer_id": str(ObjectId())}
+
         # Stored catalogue item
         self._stored_catalogue_item = (
             CatalogueItemOut(
                 **CatalogueItemIn(
-                    **stored_catalogue_item_data,
-                    code=utils.generate_code(stored_catalogue_item_data["name"], "catalogue item"),
-                    catalogue_category_id=str(ObjectId()),
-                    manufacturer_id=str(ObjectId()),
+                    **{**stored_catalogue_item_data, "properties": expected_stored_properties_in},
+                    **stored_ids_to_insert,
                 ).model_dump(),
                 id=CustomObjectId(catalogue_item_id),
             )
@@ -548,6 +570,15 @@ class UpdateDSL(CatalogueItemServiceDSL):
             else None
         )
         ServiceTestHelpers.mock_get(self.mock_catalogue_item_repository, self._stored_catalogue_item)
+
+        self._stored_catalogue_category_out = (
+            CatalogueCategoryOut(
+                **self._stored_catalogue_category_in.model_dump(by_alias=True),
+                id=self._stored_catalogue_item.catalogue_category_id,
+            )
+            if stored_catalogue_category_in_data
+            else None
+        )
 
         # Need to mock has_child_elements only if the check is required
         self._expect_child_check = any(
@@ -559,25 +590,44 @@ class UpdateDSL(CatalogueItemServiceDSL):
         # When moving i.e. changing the catalogue category id, the data for the new catalogue category needs to be
         # mocked
         self._moving_catalogue_item = (
-            "parent_id" in catalogue_item_update_data
-            and new_catalogue_category_in_data is not None
-            and new_catalogue_category_in_data["parent_id"] != catalogue_item_update_data["parent_id"]
+            "catalogue_category_id" in catalogue_item_update_data and stored_catalogue_item_data is not None
         )
 
-        if self._moving_catalogue_item and catalogue_item_update_data["parent_id"]:
-            ServiceTestHelpers.mock_get(
-                self.mock_catalogue_item_repository,
-                (
-                    CatalogueCategoryOut(
-                        **{
-                            **CatalogueCategoryIn(**new_catalogue_category_in_data).model_dump(by_alias=True),
-                            "_id": catalogue_item_update_data["parent_id"],
-                        }
-                    )
-                    if new_catalogue_category_in_data
-                    else None
-                ),
+        self._updating_properties = "properties" in catalogue_item_update_data
+
+        if self._moving_catalogue_item and catalogue_item_update_data["catalogue_category_id"]:
+            self._new_catalogue_category_in = (
+                CatalogueCategoryIn(**new_catalogue_category_in_data) if new_catalogue_category_in_data else None
             )
+            self._new_catalogue_category_out = (
+                CatalogueCategoryOut(
+                    **{
+                        **self._new_catalogue_category_in.model_dump(by_alias=True),
+                        "_id": catalogue_item_update_data["catalogue_category_id"],
+                    }
+                )
+                if new_catalogue_category_in_data
+                else None
+            )
+
+            ServiceTestHelpers.mock_get(self.mock_catalogue_category_repository, self._new_catalogue_category_out)
+
+            # Existing category is needed only if the new properties are not given
+            if not self._updating_properties:
+                ServiceTestHelpers.mock_get(
+                    self.mock_catalogue_category_repository,
+                    (
+                        CatalogueCategoryOut(
+                            **{
+                                **self._stored_catalogue_category_in.model_dump(by_alias=True),
+                                "_id": self._stored_catalogue_item.catalogue_category_id,
+                            }
+                        )
+                        # Should not be None here, if properties is not given, then expect test to assign this too
+                        if self._stored_catalogue_category_in
+                        else None
+                    ),
+                )
 
             # TODO: Deal with properties in the above?
 
@@ -625,11 +675,46 @@ class UpdateDSL(CatalogueItemServiceDSL):
                 ),
             )
 
-        # TODO: Deal with process properties
+        # When properties are given need to add any property `id`s and ensure the expected data inserts them as well
+        property_post_schemas = []
+        expected_properties_in = []
+        if self._updating_properties:
+            expected_properties_in, property_post_schemas = self.construct_properties_in_and_post_with_ids(
+                (
+                    self._new_catalogue_category_in.properties
+                    if self._moving_catalogue_item
+                    else self._stored_catalogue_category_in.properties
+                ),
+                catalogue_item_update_data["properties"],
+            )
+            expected_properties_in = utils.process_properties(
+                (
+                    self._new_catalogue_category_out.properties
+                    if self._moving_catalogue_item
+                    else self._stored_catalogue_category_out.properties
+                ),
+                property_post_schemas,
+            )
+
+            catalogue_item_update_data["properties"] = property_post_schemas
+
+        # Updated catalogue item
+        self._expected_catalogue_item_out = MagicMock()
+        ServiceTestHelpers.mock_update(self.mock_catalogue_item_repository, self._expected_catalogue_item_out)
 
         # TODO: Move this to the top? Same for catalogue categories
         # Patch schema
         self._catalogue_item_patch = CatalogueItemPatchSchema(**catalogue_item_update_data)
+
+        # Construct the expected input for the repository
+        merged_catalogue_item_data = {
+            **(stored_catalogue_item_data or {}),
+            **stored_ids_to_insert,
+            **catalogue_item_update_data,
+        }
+        self._expected_catalogue_item_in = CatalogueItemIn(
+            **{**merged_catalogue_item_data, "properties": expected_properties_in}
+        )
 
     def call_update(self, catalogue_item_id: str) -> None:
         """
@@ -672,9 +757,14 @@ class UpdateDSL(CatalogueItemServiceDSL):
 
         # Ensure obtained new catalogue category if moving
         if self._moving_catalogue_item and self._catalogue_item_patch.catalogue_category_id:
-            self.mock_catalogue_category_repository.get.assert_called_once_with(
-                self._catalogue_item_patch.catalogue_category_id
-            )
+            expected_catalogue_category_get_calls = [call(self._catalogue_item_patch.catalogue_category_id)]
+
+            # Expect additional call from existing catalogue category to compare properties if new properties aren't
+            # given
+            if self._catalogue_item_patch.properties is None:
+                expected_catalogue_category_get_calls.append(call(self._stored_catalogue_item.catalogue_category_id))
+
+            self.mock_catalogue_category_repository.get.assert_has_calls(expected_catalogue_category_get_calls)
 
         # Ensure obtained new manufacturer if needed
         if self._updating_manufacturer and self._catalogue_item_patch.manufacturer_id:
@@ -682,7 +772,22 @@ class UpdateDSL(CatalogueItemServiceDSL):
 
         self.mock_catalogue_item_repository.get.assert_has_calls(expected_catalogue_item_get_calls)
 
+        # TODO: This is different to catalogue category tests - use self._catalogue_category_post.properties there
+        if self._updating_properties:
+            # TODO: Implement
+            self.wrapped_utils.process_properties.assert_called_once_with(
+                (
+                    self._new_catalogue_category_out.properties
+                    if self._moving_catalogue_item
+                    else self._stored_catalogue_category_out.properties
+                ),
+                self._catalogue_item_patch.properties,
+            )
+        else:
+            self.wrapped_utils.process_properties.assert_not_called()
+
         # TODO: Implement
+        assert self._updated_catalogue_item == self._expected_catalogue_item_out
 
     def check_update_failed_with_exception(self, message: str) -> None:
         """
@@ -701,8 +806,8 @@ class TestUpdate(UpdateDSL):
     """Tests for updating a catalogue item."""
 
     def test_update_all_fields_except_ids_or_properties_with_no_children(self):
-        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties when there
-        are no child items."""
+        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties when it has
+        no children."""
 
         catalogue_item_id = str(ObjectId())
 
@@ -715,8 +820,8 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_all_fields_except_ids_or_properties_with_children(self):
-        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties when there
-        are child items."""
+        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties it has
+        children."""
 
         catalogue_item_id = str(ObjectId())
 
@@ -731,8 +836,91 @@ class TestUpdate(UpdateDSL):
 
     # TODO: Implement more tests
 
+    def test_update_catalogue_category_id_no_properties(self):
+        """Test updating the catalogue item's `catalogue_category_id` when no properties are involved."""
+
+        catalogue_item_id = str(ObjectId())
+
+        self.mock_update(
+            catalogue_item_id,
+            catalogue_item_update_data={"catalogue_category_id": str(ObjectId())},
+            stored_catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+            new_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+        )
+        self.call_update(catalogue_item_id)
+        self.check_update_success()
+
+    # TODO: This should be with a list of actual properties for simplicity
+    def test_update_catalogue_category_id_and_empty_properties(self):
+        """Test updating the catalogue item's `catalogue_category_id` as well as setting `properties` to an empty list.
+        (Should not need to get the current catalogue category as no need to compare the properties in this case)
+        """
+
+        catalogue_item_id = str(ObjectId())
+
+        self.mock_update(
+            catalogue_item_id,
+            catalogue_item_update_data={"catalogue_category_id": str(ObjectId()), "properties": []},
+            stored_catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+            new_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+        )
+        self.call_update(catalogue_item_id)
+        self.check_update_success()
+
+    def test_update_catalogue_category_id_without_properties_with_same_defined_properties(self):
+        """Test updating the catalogue item's `catalogue_category_id` when both the old and new catalogue category has
+        identical properties.
+        """
+
+        catalogue_item_id = str(ObjectId())
+
+        self.mock_update(
+            catalogue_item_id,
+            catalogue_item_update_data={"catalogue_category_id": str(ObjectId())},
+            stored_catalogue_item_data=CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
+            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
+            new_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
+        )
+        self.call_update(catalogue_item_id)
+        self.check_update_success()
+
+    def test_update_catalogue_category_id_with_properties_with_same_defined_properties(self):
+        """Test updating the catalogue item's `catalogue_category_id` and `properties` when both the old and new
+        catalogue category has identical properties.
+        """
+
+        catalogue_item_id = str(ObjectId())
+
+        self.mock_update(
+            catalogue_item_id,
+            catalogue_item_update_data={
+                "catalogue_category_id": str(ObjectId()),
+                "properties": CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES["properties"],
+            },
+            stored_catalogue_item_data=CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
+            stored_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
+            new_catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
+        )
+        self.call_update(catalogue_item_id)
+        self.check_update_success()
+
+    def test_update_with_non_existent_catalogue_category_id(self):
+        """Test updating the catalogue item's `catalogue_category_id` to a non-existent catalogue category."""
+
+        catalogue_item_id = str(ObjectId())
+        catalogue_category_id = str(ObjectId())
+
+        self.mock_update(
+            catalogue_item_id,
+            catalogue_item_update_data={"catalogue_category_id": catalogue_category_id},
+            stored_catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+        )
+        self.call_update_expecting_error(catalogue_item_id, MissingRecordError)
+        self.check_update_failed_with_exception(f"No catalogue category found with ID: {catalogue_category_id}")
+
     def test_update_manufacturer_id_with_no_children(self):
-        """Test updating the catalogue item's `manufacturer_id`"""
+        """Test updating the catalogue item's `manufacturer_id` when it has no children."""
 
         catalogue_item_id = str(ObjectId())
 
@@ -746,7 +934,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_success()
 
     def test_update_manufacturer_id_with_children(self):
-        """Test updating the catalogue item's `manufacturer_id`"""
+        """Test updating the catalogue item's `manufacturer_id` when it has children."""
 
         catalogue_item_id = str(ObjectId())
 
@@ -778,7 +966,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_failed_with_exception(f"No manufacturer found with ID: {manufacturer_id}")
 
     def test_update_obsolete_replacement_catalogue_item_id(self):
-        """Test updating the catalogue item's `obsolete_replacement_catalogue_item_id`"""
+        """Test updating the catalogue item's `obsolete_replacement_catalogue_item_id`."""
 
         catalogue_item_id = str(ObjectId())
 
@@ -925,110 +1113,6 @@ class TestDelete(DeleteDSL):
 #     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
 # }
 # # pylint: enable=duplicate-code
-
-# # pylint: disable=duplicate-code
-# FULL_MANUFACTURER_INFO = {
-#     "name": "Manufacturer A",
-#     "code": "manufacturer-a",
-#     "url": "http://example.com/",
-#     "address": {
-#         "address_line": "1 Example Street",
-#         "town": "Oxford",
-#         "county": "Oxfordshire",
-#         "country": "United Kingdom",
-#         "postcode": "OX1 2AB",
-#     },
-#     "telephone": "0932348348",
-#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-# }
-# # pylint: enable=duplicate-code
-
-
-# def test_update_change_catalogue_category_id_same_defined_properties_without_supplied_properties(
-#     test_helpers,
-#     catalogue_category_repository_mock,
-#     catalogue_item_repository_mock,
-#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-#     catalogue_item_service,
-# ):
-#     """
-#     Test moving a catalogue item to another catalogue category that has the same defined  when
-#     no properties are supplied.
-#     """
-#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-#     catalogue_item = CatalogueItemOut(
-#         id=str(ObjectId()),
-#         catalogue_category_id=str(ObjectId()),
-#         manufacturer_id=str(ObjectId()),
-#         **{
-#             **FULL_CATALOGUE_ITEM_A_INFO,
-#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-#             "properties": properties,
-#         },
-#     )
-
-#     current_catalogue_category_id = str(ObjectId())
-#     current_properties = add_ids_to_properties(None, properties)
-#     # Mock `get` to return a catalogue item
-#     test_helpers.mock_get(
-#         catalogue_item_repository_mock,
-#         CatalogueItemOut(
-#             **{
-#                 **catalogue_item.model_dump(),
-#                 "catalogue_category_id": current_catalogue_category_id,
-#                 "modified_time": catalogue_item.created_time,
-#                 "properties": current_properties,
-#             }
-#         ),
-#     )
-#     # Mock so no child elements found
-#     catalogue_item_repository_mock.has_child_elements.return_value = False
-#     # Mock `get` to return the new catalogue category
-#     test_helpers.mock_get(
-#         catalogue_category_repository_mock,
-#         CatalogueCategoryOut(
-#             id=catalogue_item.catalogue_category_id,
-#             **{
-#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
-#                 "properties": add_ids_to_properties(
-#                     properties,
-#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-#                 ),
-#             },
-#         ),
-#     )
-#     # Mock `get` to return the current catalogue category
-#     test_helpers.mock_get(
-#         catalogue_category_repository_mock,
-#         CatalogueCategoryOut(
-#             id=current_catalogue_category_id,
-#             **{
-#                 **FULL_CATALOGUE_CATEGORY_C_INFO,
-#                 "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
-#             },
-#         ),
-#     )
-#     # Mock `update` to return the updated catalogue item
-#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-#     updated_catalogue_item = catalogue_item_service.update(
-#         catalogue_item.id, CatalogueItemPatchSchema(catalogue_category_id=catalogue_item.catalogue_category_id)
-#     )
-
-#     catalogue_item_repository_mock.update.assert_called_once_with(
-#         catalogue_item.id,
-#         CatalogueItemIn(
-#             catalogue_category_id=catalogue_item.catalogue_category_id,
-#             manufacturer_id=catalogue_item.manufacturer_id,
-#             **{
-#                 **FULL_CATALOGUE_ITEM_A_INFO,
-#                 "created_time": catalogue_item.created_time,
-#                 "properties": properties,
-#             },
-#         ),
-#     )
-#     assert updated_catalogue_item == catalogue_item
 
 
 # def test_update_change_catalogue_category_id_same_defined_properties_with_supplied_properties(
@@ -1357,42 +1441,6 @@ class TestDelete(DeleteDSL):
 #         ),
 #     )
 #     assert updated_catalogue_item == catalogue_item
-
-
-# def test_update_with_non_existent_catalogue_category_id(
-#     test_helpers,
-#     catalogue_category_repository_mock,
-#     catalogue_item_repository_mock,
-#     catalogue_item_service,
-# ):
-#     """
-#     Test updating a catalogue item with a non-existent catalogue category ID.
-#     """
-#     catalogue_item = CatalogueItemOut(
-#         id=str(ObjectId()),
-#         catalogue_category_id=str(ObjectId()),
-#         manufacturer_id=str(ObjectId()),
-#         **{
-#             **FULL_CATALOGUE_ITEM_A_INFO,
-#             "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-#         },
-#     )
-
-#     # Mock `get` to return a catalogue item
-#     test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
-#     # Mock so no child elements found
-#     catalogue_item_repository_mock.has_child_elements.return_value = False
-#     # Mock `get` to not return a catalogue category
-#     test_helpers.mock_get(catalogue_category_repository_mock, None)
-
-#     catalogue_category_id = str(ObjectId())
-#     with pytest.raises(MissingRecordError) as exc:
-#         catalogue_item_service.update(
-#             catalogue_item.id,
-#             CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
-#         )
-#     catalogue_item_repository_mock.update.assert_not_called()
-#     assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
 
 
 # def test_update_change_catalogue_category_id_non_leaf_catalogue_category(

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -4,8 +4,17 @@ Unit tests for the `CatalogueCategoryService` service.
 """
 from datetime import timedelta
 from test.conftest import add_ids_to_properties
-from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW
-from unittest.mock import MagicMock, call
+from test.mock_data import (
+    CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
+    CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+    CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+    CATALOGUE_CATEGORY_POST_DATA_LEAF_REQUIRED_VALUES_ONLY,
+    CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY,
+    MANUFACTURER_IN_DATA_A,
+)
+from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW, ServiceTestHelpers
+from typing import Optional
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 from bson import ObjectId
@@ -18,2093 +27,2232 @@ from inventory_management_system_api.core.exceptions import (
     MissingRecordError,
     NonLeafCatalogueCategoryError,
 )
-from inventory_management_system_api.models.catalogue_category import CatalogueCategoryOut
-from inventory_management_system_api.models.catalogue_item import CatalogueItemIn, CatalogueItemOut
-from inventory_management_system_api.models.manufacturer import ManufacturerOut
+from inventory_management_system_api.models.catalogue_category import CatalogueCategoryIn, CatalogueCategoryOut
+from inventory_management_system_api.models.catalogue_item import CatalogueItemIn, CatalogueItemOut, PropertyIn
+from inventory_management_system_api.models.manufacturer import ManufacturerIn, ManufacturerOut
+from inventory_management_system_api.models.unit import UnitIn, UnitOut
 from inventory_management_system_api.schemas.catalogue_item import (
     CatalogueItemPatchSchema,
     CatalogueItemPostSchema,
+    PropertyPostSchema,
 )
-
-FULL_CATALOGUE_CATEGORY_A_INFO = {
-    "name": "Category A",
-    "code": "category-a",
-    "is_leaf": True,
-    "parent_id": None,
-    "properties": [
-        {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
-        {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True},
-        {"name": "Property C", "type": "string", "unit": "cm", "mandatory": True},
-    ],
-    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-}
-
-FULL_CATALOGUE_CATEGORY_B_INFO = {
-    "name": "Category B",
-    "code": "category-b",
-    "is_leaf": False,
-    "parent_id": None,
-    "properties": [],
-    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-}
-
-FULL_CATALOGUE_CATEGORY_C_INFO = {
-    "name": "Category C",
-    "code": "category-c",
-    "is_leaf": True,
-    "parent_id": None,
-    "properties": [],
-    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-}
-
-# pylint: disable=duplicate-code
-CATALOGUE_ITEM_A_INFO = {
-    "name": "Catalogue Item A",
-    "description": "This is Catalogue Item A",
-    "cost_gbp": 129.99,
-    "days_to_replace": 2.0,
-    "drawing_link": "https://drawing-link.com/",
-    "item_model_number": "abc123",
-    "is_obsolete": False,
-    "properties": [
-        {"name": "Property A", "value": 20},
-        {"name": "Property B", "value": False},
-        {"name": "Property C", "value": "20x15x10"},
-    ],
-}
-
-FULL_CATALOGUE_ITEM_A_INFO = {
-    **CATALOGUE_ITEM_A_INFO,
-    "cost_to_rework_gbp": None,
-    "days_to_rework": None,
-    "drawing_number": None,
-    "obsolete_reason": None,
-    "obsolete_replacement_catalogue_item_id": None,
-    "notes": None,
-    "properties": [
-        {"name": "Property A", "value": 20, "unit": "mm"},
-        {"name": "Property B", "value": False, "unit": None},
-        {"name": "Property C", "value": "20x15x10", "unit": "cm"},
-    ],
-    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-}
-# pylint: enable=duplicate-code
-
-# pylint: disable=duplicate-code
-FULL_MANUFACTURER_INFO = {
-    "name": "Manufacturer A",
-    "code": "manufacturer-a",
-    "url": "http://example.com/",
-    "address": {
-        "address_line": "1 Example Street",
-        "town": "Oxford",
-        "county": "Oxfordshire",
-        "country": "United Kingdom",
-        "postcode": "OX1 2AB",
-    },
-    "telephone": "0932348348",
-    "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-    "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
-}
-# pylint: enable=duplicate-code
+from inventory_management_system_api.services import utils
+from inventory_management_system_api.services.catalogue_item import CatalogueItemService
 
 
-def test_create(
-    test_helpers,
-    catalogue_item_repository_mock,
-    catalogue_category_repository_mock,
-    manufacturer_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):  # pylint: disable=too-many-arguments
-    """
-    Test creating a catalogue item.
+class CatalogueItemServiceDSL:
+    """Base class for `CatalogueItemService` unit tests."""
 
-    Verify that the `create` method properly handles the catalogue item to be created, checks that the catalogue
-    category exists and that it is a leaf category, checks for missing mandatory , filters the
-    matching , adds the units to the supplied properties, and validates the property values.
-    """
-    # pylint: disable=duplicate-code
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": properties,
-        },
-    )
-    # pylint: enable=duplicate-code
+    wrapped_utils: Mock
+    mock_catalogue_item_repository: Mock
+    mock_catalogue_category_repository: Mock
+    mock_manufacturer_repository: Mock
+    mock_unit_repository: Mock
+    catalogue_item_service: CatalogueItemService
 
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
+    property_name_id_dict: dict[str, str]
+
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        catalogue_item_repository_mock,
         catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
-            },
-        ),
-    )
-    # Mock `get` to return a manufacturer
-    test_helpers.mock_get(
         manufacturer_repository_mock,
-        ManufacturerOut(id=catalogue_item.manufacturer_id, **FULL_MANUFACTURER_INFO),
-    )
-    # Mock `create` to return the created catalogue item
-    test_helpers.mock_create(catalogue_item_repository_mock, catalogue_item)
+        unit_repository_mock,
+        catalogue_item_service,
+        # Ensures all created and modified times are mocked throughout
+        # pylint: disable=unused-argument
+        model_mixins_datetime_now_mock,
+    ):
+        """Setup fixtures"""
 
-    created_catalogue_item = catalogue_item_service.create(
-        CatalogueItemPostSchema(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **CATALOGUE_ITEM_A_INFO,
-                "properties": [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
-            },
-        )
-    )
+        self.mock_catalogue_item_repository = catalogue_item_repository_mock
+        self.mock_catalogue_category_repository = catalogue_category_repository_mock
+        self.mock_manufacturer_repository = manufacturer_repository_mock
+        self.mock_unit_repository = unit_repository_mock
+        self.catalogue_item_service = catalogue_item_service
 
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_item.catalogue_category_id)
-    catalogue_item_repository_mock.create.assert_called_once_with(
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "properties": properties,
-            },
-        )
-    )
-    assert created_catalogue_item == catalogue_item
+        with patch("inventory_management_system_api.services.catalogue_item.utils", wraps=utils) as wrapped_utils:
+            self.wrapped_utils = wrapped_utils
+            yield
+
+    def check_add_property_unit_values_performed_expected_calls(
+        self, expected_properties: list[PropertyPostSchema]
+    ) -> None:
+        """Checks that a call to `add_property_unit_values` performed the expected function calls.
+
+        :param expected_properties: Expected properties the function would have been called with.
+        """
+
+        expected_unit_repo_calls = []
+        for prop in expected_properties:
+            if prop.unit_id:
+                expected_unit_repo_calls.append(call(prop.unit_id))
+
+        self.mock_unit_repository.get.assert_has_calls(expected_unit_repo_calls)
 
 
-def test_create_with_non_existent_catalogue_category_id(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item with a non-existent catalogue category ID.
+class CreateDSL(CatalogueItemServiceDSL):
+    """Base class for `create` tests."""
 
-    Verify that the `create` method properly handles a catalogue item with a non-existent catalogue category ID, does
-    not find a catalogue category with such ID, and does not create the catalogue item.
-    """
-    catalogue_category_id = str(ObjectId())
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+    _catalogue_item_post: CatalogueItemPostSchema
+    _expected_catalogue_item_in: CatalogueItemIn
+    _expected_catalogue_item_out: CatalogueItemOut
+    _created_catalogue_item: CatalogueItemOut
+    _create_exception: pytest.ExceptionInfo
 
-    # Mock `get` to not return a catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, None)
+    def mock_create(
+        self,
+        catalogue_item_data: dict,
+        catalogue_category_in_data: Optional[dict] = None,
+        manufacturer_in_data: Optional[dict] = None,
+        obsolete_replacement_catalogue_item_data: Optional[dict] = None,
+    ) -> None:
+        """
+        Mocks repo methods appropriately to test the `create` service method.
 
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category_id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [{"id": prop["id"], "value": prop["value"]} for prop in properties],
-                },
+        :param catalogue_item_data: Dictionary containing the basic catalogue item data as would be required for a
+                                    `CatalogueItemPostSchema` but with any `unit_id`'s replaced by the 'unit' value in
+                                    its properties as the IDs will be added automatically.
+        :param catalogue_category_in_data: Either `None` or a dictionary containing the catalogue category data as would
+                                           be required for a `CatalogueCategoryIn` database model.
+        :param manufacturer_in_data: Either `None` or a dictionary containing the manufacturer data as would be required
+                                     for a `ManufacturerIn` database model.
+        :param obsolete_replacement_catalogue_item_data: Dictionary containing the basic catalogue item data for the
+                                     obsolete replacement as would be required for a `CatalogueItemPostSchema` but with
+                                     any `unit_id`'s replaced by the 'unit' value in its properties as the IDs will be
+                                     added automatically.
+        """
+
+        # TODO: Cleanup?
+
+        catalogue_category_in_dump = {}
+        if catalogue_category_in_data:
+            catalogue_category_in = CatalogueCategoryIn(**catalogue_category_in_data)
+            self.property_name_id_dict = {prop.name: prop.id for prop in catalogue_category_in.properties}
+
+            catalogue_category_in_dump = catalogue_category_in.model_dump(by_alias=True)
+
+        ServiceTestHelpers.mock_get(
+            self.mock_catalogue_category_repository,
+            (
+                CatalogueCategoryOut(
+                    **{
+                        **catalogue_category_in_dump,
+                        "_id": catalogue_item_data["catalogue_category_id"],
+                    },
+                )
+                if catalogue_category_in_data
+                else None
             ),
         )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category_id)
 
+        ServiceTestHelpers.mock_get(
+            self.mock_manufacturer_repository,
+            (
+                ManufacturerOut(
+                    **{
+                        **ManufacturerIn(**manufacturer_in_data).model_dump(),
+                        "_id": catalogue_item_data["manufacturer_id"],
+                    },
+                )
+                if manufacturer_in_data
+                else None
+            ),
+        )
 
-def test_create_with_non_existent_manufacturer_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    manufacturer_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test creating a catalogue item with a manufacturer id that is non-existent
-    """
-    catalogue_category_id = str(ObjectId())
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+        ServiceTestHelpers.mock_get(
+            self.mock_catalogue_item_repository,
+            (
+                CatalogueItemOut(
+                    **{
+                        **CatalogueItemIn(**obsolete_replacement_catalogue_item_data).model_dump(),
+                        "_id": catalogue_item_data["obsolete_replacement_catalogue_item_id"],
+                    },
+                )
+                if obsolete_replacement_catalogue_item_data
+                else None
+            ),
+        )
 
-    # Mock `get` to return a catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to not return a manufacturer
-    test_helpers.mock_get(manufacturer_repository_mock, None)
-
-    manufacturer_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category_id,
-                manufacturer_id=manufacturer_id,
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [{"id": prop["id"], "value": prop["value"]} for prop in properties],
-                },
+        # TODO: Go over catalogue categories and check if should use this method instead of current
+        expected_properties_in = []
+        if "properties" in catalogue_item_data:
+            expected_properties_in = add_ids_to_properties(
+                catalogue_category_in_dump["properties"], catalogue_item_data["properties"]
             )
+
+        self._catalogue_item_post = CatalogueItemPostSchema(
+            **{**catalogue_item_data, "properties": expected_properties_in}
         )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert str(exc.value) == f"No manufacturer found with ID: {manufacturer_id}"
 
-
-def test_create_in_non_leaf_catalogue_category(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item in a non-leaf catalogue category.
-
-    Verify that the `create` method properly handles a catalogue item with a non-leaf catalogue category, checks that
-    the catalogue category exists, finds that the catalogue category is not a leaf category, and does not create the
-    catalogue item.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-
-    catalogue_category = CatalogueCategoryOut(id=str(ObjectId()), **FULL_CATALOGUE_CATEGORY_B_INFO)
-
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(NonLeafCatalogueCategoryError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category.id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [{"id": prop["id"], "value": prop["value"]} for prop in properties],
-                },
-            ),
-        )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert str(exc.value) == "Cannot add catalogue item to a non-leaf catalogue category"
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
-
-
-def test_create_with_obsolete_replacement_catalogue_item_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test creating a catalogue item with an obsolete replacement catalogue item ID.
-    """
-    obsolete_replacement_catalogue_item_id = str(ObjectId())
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "is_obsolete": True,
-            "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
+        self._expected_catalogue_item_in = CatalogueItemIn(
             **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `get` to return a replacement catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            id=obsolete_replacement_catalogue_item_id,
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "name": "Catalogue Item B",
-                "description": "This is Catalogue Item B",
-                "properties": properties,
-            },
-        ),
-    )
-    # Mock `create` to return the created catalogue item
-    test_helpers.mock_create(catalogue_item_repository_mock, catalogue_item)
-
-    created_catalogue_item = catalogue_item_service.create(
-        CatalogueItemPostSchema(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **CATALOGUE_ITEM_A_INFO,
-                "is_obsolete": True,
-                "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
-                "properties": [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
-            },
+                **catalogue_item_data,
+                "properties": expected_properties_in,
+            }
         )
-    )
-
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_item.catalogue_category_id)
-    catalogue_item_repository_mock.get.assert_called_once_with(obsolete_replacement_catalogue_item_id)
-    catalogue_item_repository_mock.create.assert_called_once_with(
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "is_obsolete": True,
-                "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
-                "properties": properties,
-            },
+        self._expected_catalogue_item_out = CatalogueItemOut(
+            **self._expected_catalogue_item_in.model_dump(), id=ObjectId()
         )
-    )
-    assert created_catalogue_item == catalogue_item
 
+        ServiceTestHelpers.mock_create(self.mock_catalogue_item_repository, self._expected_catalogue_item_out)
 
-def test_create_with_non_existent_obsolete_replacement_catalogue_item_id(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item with a non-existent obsolete replacement catalogue item ID.
+    def call_create(self) -> None:
+        """Calls the `CatalogueItemService` `create` method with the appropriate data from a prior call to
+        `mock_create`."""
 
-    Verify that the `create` method properly handles a catalogue item with a non-existent obsolete replacement catalogue
-    item ID, does not find a catalogue item with such ID, and does not create the catalogue item.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+        self._created_catalogue_item = self.catalogue_item_service.create(self._catalogue_item_post)
 
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_CATEGORY_A_INFO,
-            "properties": add_ids_to_properties(
-                properties,
-                FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-            ),
-        },
-    )
+    def call_create_expecting_error(self, error_type: type[BaseException]) -> None:
+        """
+        Calls the `CatalogueItemService` `create` method with the appropriate data from a prior call to
+        `mock_create` while expecting an error to be raised.
 
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
+        :param error_type: Expected exception to be raised.
+        """
 
-    # Mock `get` to not return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, None)
+        with pytest.raises(error_type) as exc:
+            self.catalogue_item_service.create(self._catalogue_item_post)
+        self._create_exception = exc
 
-    obsolete_replacement_catalogue_item_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category.id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **FULL_CATALOGUE_ITEM_A_INFO,
-                    "is_obsolete": True,
-                    "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
-                    "properties": [{"id": prop["id"], "value": prop["value"]} for prop in properties],
-                },
-            ),
+    def check_create_success(self) -> None:
+        """Checks that a prior call to `call_create` worked as expected."""
+
+        # This is the get for the catalogue category
+        self.mock_catalogue_category_repository.get.assert_called_once_with(
+            self._catalogue_item_post.catalogue_category_id
         )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert str(exc.value) == f"No catalogue item found with ID: {obsolete_replacement_catalogue_item_id}"
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
-    catalogue_item_repository_mock.get.assert_called_once_with(obsolete_replacement_catalogue_item_id)
 
+        # This is the get for the manufacturer
+        self.mock_manufacturer_repository.get.assert_called_once_with(self._catalogue_item_post.manufacturer_id)
 
-def test_create_without_properties(
-    test_helpers,
-    catalogue_item_repository_mock,
-    catalogue_category_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test creating a catalogue item without properties.
-
-    Verify that the `create` method properly handles the catalogue item to be created without properties.
-    """
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{**FULL_CATALOGUE_ITEM_A_INFO, "properties": []},
-    )
-
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{**FULL_CATALOGUE_CATEGORY_A_INFO, "properties": []},
-        ),
-    )
-    # Mock `create` to return the created catalogue item
-    test_helpers.mock_create(catalogue_item_repository_mock, catalogue_item)
-
-    created_catalogue_item = catalogue_item_service.create(
-        CatalogueItemPostSchema(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{**CATALOGUE_ITEM_A_INFO, "properties": []},
-        )
-    )
-
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_item.catalogue_category_id)
-    catalogue_item_repository_mock.create.assert_called_once_with(
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{**FULL_CATALOGUE_ITEM_A_INFO, "properties": []},
-        )
-    )
-    assert created_catalogue_item == catalogue_item
-
-
-def test_create_with_missing_mandatory_properties(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item with missing mandatory properties.
-
-    Verify that the `create` method properly handles a catalogue item with missing mandatory properties, checks that
-    the catalogue category exists and that it is a leaf category, finds that there are missing mandatory catalogue item
-    properties, and does not create the catalogue item.
-    """
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_CATEGORY_A_INFO,
-            "properties": add_ids_to_properties(
-                None,
-                FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-            ),
-        },
-    )
-
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(MissingMandatoryProperty) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category.id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [
-                        {
-                            "id": catalogue_category.properties[2].id,
-                            "value": "20x15x10",
-                        },
-                    ],
-                },
-            ),
-        )
-    assert str(exc.value) == f"Missing mandatory property with ID: '{catalogue_category.properties[1].id}'"
-    catalogue_item_repository_mock.create.assert_not_called()
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
-
-
-def test_create_with_with_invalid_value_type_for_string_property(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item with invalid value type for a string property.
-
-    Verify that the `create` method properly handles a catalogue item with invalid value type for a string property,
-    checks that the catalogue category exists and that it is a leaf category, checks that there are no missing mandatory
-    properties, finds invalid value type for a string property, and does not create the catalogue item.
-    """
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_CATEGORY_A_INFO,
-            "properties": add_ids_to_properties(
-                None,
-                FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-            ),
-        },
-    )
-
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(InvalidPropertyTypeError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category.id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [
-                        {"id": catalogue_category.properties[0].id, "value": 20},
-                        {"id": catalogue_category.properties[1].id, "value": False},
-                        {"id": catalogue_category.properties[2].id, "value": True},
-                    ],
-                },
-            ),
-        )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert (
-        str(exc.value) == "Invalid value type for property with ID "
-        f"'{catalogue_category.properties[2].id}'. Expected type: string."
-    )
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
-
-
-def test_create_with_invalid_value_type_for_number_property(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item with invalid value type for a number property.
-
-    Verify that the `create` method properly handles a catalogue item with invalid value type for a number catalogue
-    property, checks that the catalogue category exists and that it is a leaf category, checks that there are no missing
-    mandatory properties, finds invalid value type for a number property, and does not create the catalogue item.
-    """
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_CATEGORY_A_INFO,
-            "properties": add_ids_to_properties(
-                None,
-                FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-            ),
-        },
-    )
-
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(InvalidPropertyTypeError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category.id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [
-                        {"id": catalogue_category.properties[0].id, "value": "20"},
-                        {"id": catalogue_category.properties[1].id, "value": False},
-                        {"id": catalogue_category.properties[2].id, "value": "20x15x10"},
-                    ],
-                },
+        # This is the get for the obsolete replacement catalogue item
+        if self._catalogue_item_post.obsolete_replacement_catalogue_item_id:
+            self.mock_catalogue_item_repository.get.assert_called_once_with(
+                self._catalogue_item_post.obsolete_replacement_catalogue_item_id
             )
+
+        # TODO: Process properties
+
+        if self._catalogue_item_post.properties:
+            pass
+            # TODO: Implement properties check
+            # # To assert with property IDs we must compare as dicts and use ANY here as otherwise the ObjectIds will
+            # # always be different
+            # actual_catalogue_category_in = self.mock_catalogue_category_repository.create.call_args_list[0][0][0]
+            # assert isinstance(actual_catalogue_category_in, CatalogueCategoryIn)
+            # assert actual_catalogue_category_in.model_dump() == {
+            #     **self._expected_catalogue_category_in.model_dump(),
+            #     "properties": [
+            #         {**prop.model_dump(), "id": ANY} for prop in self._expected_catalogue_category_in.properties
+            #     ],
+            # }
+        else:
+            self.mock_catalogue_item_repository.create.assert_called_once_with(self._expected_catalogue_item_in)
+
+        assert self._created_catalogue_item == self._expected_catalogue_item_out
+
+    def check_create_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_create_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.mock_catalogue_item_repository.create.assert_not_called()
+        assert str(self._create_exception.value) == message
+
+
+class TestCreate(CreateDSL):
+    """Tests for creating a catalogue item."""
+
+    def test_create_without_properties(self):
+        """Test creating a catalogue item without any properties in the catalogue category or catalogue item."""
+
+        self.mock_create(
+            CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY,
+            catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+            manufacturer_in_data=MANUFACTURER_IN_DATA_A,
         )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert (
-        str(exc.value) == "Invalid value type for property with ID "
-        f"'{catalogue_category.properties[0].id}'. Expected type: number."
-    )
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
+        self.call_create()
+        self.check_create_success()
 
+    def test_create_with_non_existent_catalogue_category_id(self):
+        """Test creating a catalogue item with a non-existent catalogue category ID."""
 
-def test_create_with_with_invalid_value_type_for_boolean_property(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test creating a catalogue item with invalid value type for a boolean property.
-
-    Verify that the `create` method properly handles a catalogue item with invalid value type for a boolean property,
-    checks that the catalogue category exists and that it is a leaf category, checks that there are no missing
-    mandatory properties, finds invalid value type for a boolean property, and does not create the catalogue item.
-    """
-    catalogue_category = CatalogueCategoryOut(
-        id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_CATEGORY_A_INFO,
-            "properties": add_ids_to_properties(
-                None,
-                FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-            ),
-        },
-    )
-
-    # Mock `get` to return the catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
-
-    with pytest.raises(InvalidPropertyTypeError) as exc:
-        catalogue_item_service.create(
-            CatalogueItemPostSchema(
-                catalogue_category_id=catalogue_category.id,
-                manufacturer_id=str(ObjectId()),
-                **{
-                    **CATALOGUE_ITEM_A_INFO,
-                    "properties": [
-                        {"id": catalogue_category.properties[0].id, "value": 20},
-                        {"id": catalogue_category.properties[1].id, "value": "False"},
-                        {"id": catalogue_category.properties[2].id, "value": "20x15x10"},
-                    ],
-                },
-            )
+        self.mock_create(
+            CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY,
+            catalogue_category_in_data=None,
+            manufacturer_in_data=MANUFACTURER_IN_DATA_A,
         )
-    catalogue_item_repository_mock.create.assert_not_called()
-    assert (
-        str(exc.value) == "Invalid value type for property with ID "
-        f"'{catalogue_category.properties[1].id}'. Expected type: boolean."
-    )
-
-    catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
-
-
-def test_delete(catalogue_item_repository_mock, catalogue_item_service):
-    """
-    Test deleting a catalogue item.
-
-    Verify that the `delete` method properly handles the deletion of a catalogue item by ID.
-    """
-    catalogue_item_id = str(ObjectId())
-
-    catalogue_item_service.delete(catalogue_item_id)
-
-    catalogue_item_repository_mock.delete.assert_called_once_with(catalogue_item_id)
-
-
-def test_get(test_helpers, catalogue_item_repository_mock, catalogue_item_service):
-    """
-    Test getting a catalogue item.
-
-    Verify that the `get` method properly handles the retrieval of a catalogue item by ID.
-    """
-    catalogue_item_id = str(ObjectId())
-    catalogue_item = MagicMock()
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
-
-    retrieved_catalogue_item = catalogue_item_service.get(catalogue_item_id)
-
-    catalogue_item_repository_mock.get.assert_called_once_with(catalogue_item_id)
-    assert retrieved_catalogue_item == catalogue_item
-
-
-def test_get_with_non_existent_id(test_helpers, catalogue_item_repository_mock, catalogue_item_service):
-    """
-    Test getting a catalogue item with a non-existent ID.
-
-    Verify that the `get` method properly handles the retrieval of a catalogue item with a non-existent ID.
-    """
-    catalogue_item_id = str(ObjectId())
-
-    # Mock `get` to not return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, None)
-
-    retrieved_catalogue_item = catalogue_item_service.get(catalogue_item_id)
-
-    assert retrieved_catalogue_item is None
-    catalogue_item_repository_mock.get.assert_called_once_with(catalogue_item_id)
-
-
-def test_list(catalogue_item_repository_mock, catalogue_item_service):
-    """
-    Test listing catalogue items
-
-    Verify that the `list` method properly calls the repository function with any passed filters
-    """
-
-    catalogue_category_id = str(ObjectId())
-
-    result = catalogue_item_service.list(catalogue_category_id=catalogue_category_id)
-
-    catalogue_item_repository_mock.list.assert_called_once_with(catalogue_category_id)
-    assert result == catalogue_item_repository_mock.list.return_value
-
-
-def test_update_when_no_child_elements(
-    test_helpers,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test updating a catalogue item with child elements.
-
-    Verify that the `update` method properly handles the catalogue item to be updated when it doesn't have any
-    children.
-    """
-    # pylint: disable=duplicate-code
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "name": "Catalogue Item B",
-                "description": "This is Catalogue Item B",
-                "modified_time": catalogue_item.created_time,
-            },
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(name=catalogue_item.name, description=catalogue_item.description),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_when_has_child_elements(
-    test_helpers,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test updating a catalogue item with child elements.
-
-    Verify that the `update` method properly handles the catalogue item to be updated when it has children.
-    """
-    # pylint: disable=duplicate-code
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-    # pylint: enable=duplicate-code
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "name": "Catalogue Item B",
-                "description": "This is Catalogue Item B",
-                "modified_time": catalogue_item.created_time,
-            },
-        ),
-    )
-    # Mock so child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = True
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(name=catalogue_item.name, description=catalogue_item.description),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_with_non_existent_id(test_helpers, catalogue_item_repository_mock, catalogue_item_service):
-    """
-    Test updating a catalogue item with a non-existent ID.
-
-    Verify that the `update` method properly handles the catalogue category to be updated with a non-existent ID.
-    """
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, None)
-
-    catalogue_item_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.update(catalogue_item_id, CatalogueItemPatchSchema(properties=[]))
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
-
-
-def test_update_change_catalogue_category_id_same_defined_properties_without_supplied_properties(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test moving a catalogue item to another catalogue category that has the same defined  when
-    no properties are supplied.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    current_catalogue_category_id = str(ObjectId())
-    current_properties = add_ids_to_properties(None, properties)
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "catalogue_category_id": current_catalogue_category_id,
-                "modified_time": catalogue_item.created_time,
-                "properties": current_properties,
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return the new catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `get` to return the current catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=current_catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_C_INFO,
-                "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id, CatalogueItemPatchSchema(catalogue_category_id=catalogue_item.catalogue_category_id)
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_change_catalogue_category_id_same_defined_properties_with_supplied_properties(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test moving a catalogue item to another catalogue category that has the same defined properties when
-    properties are supplied.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    current_catalogue_category_id = str(ObjectId())
-    current_properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "catalogue_category_id": current_catalogue_category_id,
-                "modified_time": catalogue_item.created_time,
-                "properties": current_properties,
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return the new catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `get` to return the current catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=current_catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_C_INFO,
-                "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
-        ),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_change_catalogue_category_id_different_defined_properties_without_supplied_properties(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test moving a catalogue item to another catalogue category that has different defined properties when
-    no properties are supplied.
-    """
-    catalogue_item_id = str(ObjectId())
-    catalogue_category_id = str(ObjectId())
-
-    current_catalogue_category_id = str(ObjectId())
-    current_properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            id=catalogue_item_id,
-            catalogue_category_id=current_catalogue_category_id,
-            manufacturer_id=str(ObjectId()),
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "properties": current_properties,
-            },
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return the new catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    None,
-                    [
-                        {"name": "Property A", "type": "number", "unit": "m", "mandatory": False},
-                        *FULL_CATALOGUE_CATEGORY_A_INFO["properties"][1:],
-                    ],
-                ),
-            },
-        ),
-    )
-    # pylint: enable=duplicate-code
-    # Mock `get` to return the current catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=current_catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_C_INFO,
-                "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
-            },
-        ),
-    )
-
-    with pytest.raises(InvalidActionError) as exc:
-        catalogue_item_service.update(
-            catalogue_item_id,
-            CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+        self.call_create_expecting_error(MissingRecordError)
+        self.check_create_failed_with_exception(
+            f"No catalogue category found with ID: {self._catalogue_item_post.catalogue_category_id}"
         )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value) == "Cannot move catalogue item to a category with different properties without "
-        "specifying the new properties"
-    )
 
+    def test_create_with_non_leaf_catalogue_category(self):
+        """Test creating a catalogue item with a non-leaf catalogue category."""
 
-def test_update_change_catalogue_category_id_different_defined_properties_order_without_supplied_properties(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test moving a catalogue item to another catalogue category that has different defined
-    order when no properties are supplied.
-    """
-    catalogue_item_id = str(ObjectId())
-    catalogue_category_id = str(ObjectId())
-
-    current_catalogue_category_id = str(ObjectId())
-    current_properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            id=catalogue_item_id,
-            catalogue_category_id=current_catalogue_category_id,
-            manufacturer_id=str(ObjectId()),
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "properties": current_properties,
-            },
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return the new catalogue category
-    # pylint: disable=duplicate-code
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    None,
-                    [
-                        *FULL_CATALOGUE_CATEGORY_A_INFO["properties"][::-1],
-                    ],
-                ),
-            },
-        ),
-    )
-    # pylint: enable=duplicate-code
-    # Mock `get` to return the current catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=current_catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_C_INFO,
-                "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
-            },
-        ),
-    )
-
-    with pytest.raises(InvalidActionError) as exc:
-        catalogue_item_service.update(
-            catalogue_item_id,
-            CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+        self.mock_create(
+            CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY,
+            catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
+            manufacturer_in_data=MANUFACTURER_IN_DATA_A,
         )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value) == "Cannot move catalogue item to a category with different properties without "
-        "specifying the new properties"
-    )
+        self.call_create_expecting_error(NonLeafCatalogueCategoryError)
+        self.check_create_failed_with_exception("Cannot add catalogue item to a non-leaf catalogue category")
 
+    def test_create_with_non_existent_manufacturer_id(self):
+        """Test creating a catalogue item with a non-existent manufacturer ID."""
 
-def test_update_change_catalogue_category_id_different_defined_properties_with_supplied_properties(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test moving a catalogue item to another catalogue category that has different defined properties when
-    properties are supplied.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    current_catalogue_category_id = str(ObjectId())
-    current_properties = add_ids_to_properties(None, [{"name": "Property A", "value": True, "unit": None}])
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "catalogue_category_id": current_catalogue_category_id,
-                "modified_time": catalogue_item.created_time,
-                "properties": current_properties,
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return the new catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `get` to return the current catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=current_catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_C_INFO,
-                "properties": add_ids_to_properties(
-                    current_properties,
-                    [{"name": "Property A", "type": "boolean", "unit": None, "mandatory": True}],
-                ),
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
-        ),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_with_non_existent_catalogue_category_id(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test updating a catalogue item with a non-existent catalogue category ID.
-    """
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to not return a catalogue category
-    test_helpers.mock_get(catalogue_category_repository_mock, None)
-
-    catalogue_category_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+        self.mock_create(
+            CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY,
+            catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+            manufacturer_in_data=None,
         )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
-
-
-def test_update_with_existent_manufacturer_id_when_has_no_child_elements(
-    test_helpers,
-    catalogue_item_repository_mock,
-    manufacturer_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test updating manufacturer id to an existing id when the catalogue item has no child elements
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "manufacturer_id": str(ObjectId()),
-                "modified_time": catalogue_item.created_time,
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a manufacturer
-    test_helpers.mock_get(
-        manufacturer_repository_mock,
-        ManufacturerOut(id=catalogue_item.manufacturer_id, **FULL_MANUFACTURER_INFO),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(manufacturer_id=catalogue_item.manufacturer_id),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_with_existent_manufacturer_id_when_has_child_elements(
-    test_helpers,
-    catalogue_item_repository_mock,
-    manufacturer_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test updating manufacturer id to an existing id when the catalogue item has child elements
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "manufacturer_id": str(ObjectId()),
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = True
-    # Mock `get` to return a manufacturer
-    test_helpers.mock_get(
-        manufacturer_repository_mock,
-        ManufacturerOut(id=catalogue_item.manufacturer_id, **FULL_MANUFACTURER_INFO),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    with pytest.raises(ChildElementsExistError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(manufacturer_id=catalogue_item.manufacturer_id),
+        self.call_create_expecting_error(MissingRecordError)
+        self.check_create_failed_with_exception(
+            f"No manufacturer found with ID: {self._catalogue_item_post.manufacturer_id}"
         )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"Catalogue item with ID {catalogue_item.id} has child elements and cannot be updated"
 
+    def test_create_with_non_existent_obsolete_replacement_catalogue_item_id(self):
+        """Test creating a catalogue item with a non-existent obsolete replacement catalogue item ID."""
 
-def test_update_with_non_existent_manufacturer_id(
-    test_helpers,
-    manufacturer_repository_mock,
-    catalogue_item_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test updating a catalogue item with a non-existent manufacturer id
-    """
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to not return a manufacturer
-    test_helpers.mock_get(manufacturer_repository_mock, None)
-
-    manufacturer_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(manufacturer_id=manufacturer_id),
-        )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"No manufacturer found with ID: {manufacturer_id}"
-
-
-def test_update_change_catalogue_category_id_non_leaf_catalogue_category(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test moving a catalogue item to a non-leaf catalogue category.
-    """
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    catalogue_category_id = str(ObjectId())
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(id=catalogue_category_id, **FULL_CATALOGUE_CATEGORY_B_INFO),
-    )
-
-    with pytest.raises(NonLeafCatalogueCategoryError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
-        )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == "Cannot add catalogue item to a non-leaf catalogue category"
-
-
-def test_update_with_obsolete_replacement_catalogue_item_id(
-    test_helpers,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test updating a catalogue item with an obsolete replacement catalogue item ID.
-    """
-    obsolete_replacement_catalogue_item_id = str(ObjectId())
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "is_obsolete": True,
-            "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            id=catalogue_item.id,
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "modified_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a replacement catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            id=obsolete_replacement_catalogue_item_id,
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "name": "Catalogue Item B",
-                "description": "This is Catalogue Item B",
-                "properties": properties,
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(
-            is_obsolete=True, obsolete_replacement_catalogue_item_id=obsolete_replacement_catalogue_item_id
-        ),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "is_obsolete": True,
+        obsolete_replacement_catalogue_item_id = str(ObjectId())
+        self.mock_create(
+            {
+                **CATALOGUE_ITEM_POST_DATA_REQUIRED_VALUES_ONLY,
                 "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
             },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_with_non_existent_obsolete_replacement_catalogue_item_id(
-    test_helpers, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test updating a catalogue item with a non-existent obsolete replacement catalogue item ID.
-    """
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to not return a replacement catalogue item
-    test_helpers.mock_get(catalogue_item_repository_mock, None)
-
-    obsolete_replacement_catalogue_item_id = str(ObjectId())
-    with pytest.raises(MissingRecordError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(
-                is_obsolete=True, obsolete_replacement_catalogue_item_id=obsolete_replacement_catalogue_item_id
-            ),
+            catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
+            manufacturer_in_data=MANUFACTURER_IN_DATA_A,
+            obsolete_replacement_catalogue_item_data=None,
         )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"No catalogue item found with ID: {obsolete_replacement_catalogue_item_id}"
-    catalogue_item_repository_mock.get.assert_has_calls(
-        [call(catalogue_item.id), call(obsolete_replacement_catalogue_item_id)]
-    )
-
-
-def test_update_add_non_mandatory_property(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test adding a non-mandatory property and a value.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "modified_time": catalogue_item.created_time,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_ITEM_A_INFO["properties"][-2:],
-                ),
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(
-            properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
-        ),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_remove_non_mandatory_property(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test removing a non-mandatory property and its value.
-    """
-    properties = add_ids_to_properties(
-        None, [{"name": "Property A", "value": None, "unit": "mm"}, *FULL_CATALOGUE_ITEM_A_INFO["properties"][-2:]]
-    )
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "modified_time": catalogue_item.created_time,
-                "properties": add_ids_to_properties(properties, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
-
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(
-            properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties[-2:]]
-        ),
-    )
-
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
-
-
-def test_update_remove_mandatory_property(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    catalogue_item_service,
-):
-    """
-    Test removing a mandatory property and its value.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        catalogue_item,
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-
-    with pytest.raises(MissingMandatoryProperty) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(
-                properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties[:2]]
-            ),
+        self.call_create_expecting_error(MissingRecordError)
+        self.check_create_failed_with_exception(
+            f"No catalogue item found with ID: {obsolete_replacement_catalogue_item_id}"
         )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"Missing mandatory property with ID: '{catalogue_item.properties[2].id}'"
 
 
-def test_update_change_property_value(
-    test_helpers,
-    catalogue_category_repository_mock,
-    catalogue_item_repository_mock,
-    model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
-    catalogue_item_service,
-):
-    """
-    Test updating a value of a property.
-    """
-    properties = add_ids_to_properties(
-        None, [{"name": "Property A", "value": 1, "unit": "mm"}, *FULL_CATALOGUE_ITEM_A_INFO["properties"][-2:]]
-    )
-    # pylint: disable=duplicate-code
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
-            "properties": properties,
-        },
-    )
-    # pylint: enable=duplicate-code
+# FULL_CATALOGUE_CATEGORY_A_INFO = {
+#     "name": "Category A",
+#     "code": "category-a",
+#     "is_leaf": True,
+#     "parent_id": None,
+#     "properties": [
+#         {"name": "Property A", "type": "number", "unit": "mm", "mandatory": False},
+#         {"name": "Property B", "type": "boolean", "unit": None, "mandatory": True},
+#         {"name": "Property C", "type": "string", "unit": "cm", "mandatory": True},
+#     ],
+#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+# }
 
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        CatalogueItemOut(
-            **{
-                **catalogue_item.model_dump(),
-                "modified_time": catalogue_item.created_time,
-                "properties": add_ids_to_properties(properties, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-            }
-        ),
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+# FULL_CATALOGUE_CATEGORY_B_INFO = {
+#     "name": "Category B",
+#     "code": "category-b",
+#     "is_leaf": False,
+#     "parent_id": None,
+#     "properties": [],
+#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+# }
 
-    updated_catalogue_item = catalogue_item_service.update(
-        catalogue_item.id,
-        CatalogueItemPatchSchema(
-            properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
-        ),
-    )
+# FULL_CATALOGUE_CATEGORY_C_INFO = {
+#     "name": "Category C",
+#     "code": "category-c",
+#     "is_leaf": True,
+#     "parent_id": None,
+#     "properties": [],
+#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+# }
 
-    catalogue_item_repository_mock.update.assert_called_once_with(
-        catalogue_item.id,
-        CatalogueItemIn(
-            catalogue_category_id=catalogue_item.catalogue_category_id,
-            manufacturer_id=catalogue_item.manufacturer_id,
-            **{
-                **FULL_CATALOGUE_ITEM_A_INFO,
-                "created_time": catalogue_item.created_time,
-                "properties": properties,
-            },
-        ),
-    )
-    assert updated_catalogue_item == catalogue_item
+# # pylint: disable=duplicate-code
+# CATALOGUE_ITEM_A_INFO = {
+#     "name": "Catalogue Item A",
+#     "description": "This is Catalogue Item A",
+#     "cost_gbp": 129.99,
+#     "days_to_replace": 2.0,
+#     "drawing_link": "https://drawing-link.com/",
+#     "item_model_number": "abc123",
+#     "is_obsolete": False,
+#     "properties": [
+#         {"name": "Property A", "value": 20},
+#         {"name": "Property B", "value": False},
+#         {"name": "Property C", "value": "20x15x10"},
+#     ],
+# }
 
+# FULL_CATALOGUE_ITEM_A_INFO = {
+#     **CATALOGUE_ITEM_A_INFO,
+#     "cost_to_rework_gbp": None,
+#     "days_to_rework": None,
+#     "drawing_number": None,
+#     "obsolete_reason": None,
+#     "obsolete_replacement_catalogue_item_id": None,
+#     "notes": None,
+#     "properties": [
+#         {"name": "Property A", "value": 20, "unit": "mm"},
+#         {"name": "Property B", "value": False, "unit": None},
+#         {"name": "Property C", "value": "20x15x10", "unit": "cm"},
+#     ],
+#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+# }
+# # pylint: enable=duplicate-code
 
-def test_update_change_value_for_string_property_invalid_type(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test changing the value of a string property to an invalid type.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        catalogue_item,
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-
-    properties = [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
-    properties[2]["value"] = True
-    with pytest.raises(InvalidPropertyTypeError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(properties=properties),
-        )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value) == f"Invalid value type for property with ID '{catalogue_item.properties[2].id}'. "
-        "Expected type: string."
-    )
+# # pylint: disable=duplicate-code
+# FULL_MANUFACTURER_INFO = {
+#     "name": "Manufacturer A",
+#     "code": "manufacturer-a",
+#     "url": "http://example.com/",
+#     "address": {
+#         "address_line": "1 Example Street",
+#         "town": "Oxford",
+#         "county": "Oxfordshire",
+#         "country": "United Kingdom",
+#         "postcode": "OX1 2AB",
+#     },
+#     "telephone": "0932348348",
+#     "created_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+#     "modified_time": MODEL_MIXINS_FIXED_DATETIME_NOW,
+# }
+# # pylint: enable=duplicate-code
 
 
-def test_update_change_value_for_number_property_invalid_type(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test changing the value of a number property to an invalid type.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": properties,
-        },
-    )
+# def test_create(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     catalogue_category_repository_mock,
+#     manufacturer_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):  # pylint: disable=too-many-arguments
+#     """
+#     Test creating a catalogue item.
 
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        catalogue_item,
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
+#     Verify that the `create` method properly handles the catalogue item to be created, checks that the catalogue
+#     category exists and that it is a leaf category, checks for missing mandatory , filters the
+#     matching , adds the units to the supplied properties, and validates the property values.
+#     """
+#     # pylint: disable=duplicate-code
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": properties,
+#         },
+#     )
+#     # pylint: enable=duplicate-code
 
-    properties = [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
-    properties[0]["value"] = "20"
-    with pytest.raises(InvalidPropertyTypeError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(properties=properties),
-        )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value) == f"Invalid value type for property with ID '{catalogue_item.properties[0].id}'. "
-        "Expected type: number."
-    )
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
+#             },
+#         ),
+#     )
+#     # Mock `get` to return a manufacturer
+#     test_helpers.mock_get(
+#         manufacturer_repository_mock,
+#         ManufacturerOut(id=catalogue_item.manufacturer_id, **FULL_MANUFACTURER_INFO),
+#     )
+#     # Mock `create` to return the created catalogue item
+#     test_helpers.mock_create(catalogue_item_repository_mock, catalogue_item)
 
+#     created_catalogue_item = catalogue_item_service.create(
+#         CatalogueItemPostSchema(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **CATALOGUE_ITEM_A_INFO,
+#                 "properties": [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
+#             },
+#         )
+#     )
 
-def test_update_change_value_for_boolean_property_invalid_type(
-    test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test changing the value of a boolean property to an invalid type.
-    """
-    properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": properties,
-        },
-    )
-
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        catalogue_item,
-    )
-    # Mock so no child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = False
-    # Mock `get` to return a catalogue category
-    test_helpers.mock_get(
-        catalogue_category_repository_mock,
-        CatalogueCategoryOut(
-            id=catalogue_item.catalogue_category_id,
-            **{
-                **FULL_CATALOGUE_CATEGORY_A_INFO,
-                "properties": add_ids_to_properties(
-                    properties,
-                    FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
-                ),
-            },
-        ),
-    )
-
-    properties = [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
-    properties[1]["value"] = "False"
-    with pytest.raises(InvalidPropertyTypeError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(properties=properties),
-        )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert (
-        str(exc.value) == f"Invalid value type for property with ID '{catalogue_item.properties[1].id}'. "
-        "Expected type: boolean."
-    )
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_item.catalogue_category_id)
+#     catalogue_item_repository_mock.create.assert_called_once_with(
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "properties": properties,
+#             },
+#         )
+#     )
+#     assert created_catalogue_item == catalogue_ite
 
 
-def test_update_properties_when_has_child_elements(
-    test_helpers, catalogue_item_repository_mock, catalogue_item_service
-):
-    """
-    Test updating a catalogue item's properties when it has child elements.
-    """
-    # pylint: disable=duplicate-code
-    catalogue_item = CatalogueItemOut(
-        id=str(ObjectId()),
-        catalogue_category_id=str(ObjectId()),
-        manufacturer_id=str(ObjectId()),
-        **{
-            **FULL_CATALOGUE_ITEM_A_INFO,
-            "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
-        },
-    )
-    # pylint: enable=duplicate-code
+# def test_create_with_obsolete_replacement_catalogue_item_id(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test creating a catalogue item with an obsolete replacement catalogue item ID.
+#     """
+#     obsolete_replacement_catalogue_item_id = str(ObjectId())
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "is_obsolete": True,
+#             "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
+#             "properties": properties,
+#         },
+#     )
 
-    # Mock `get` to return a catalogue item
-    test_helpers.mock_get(
-        catalogue_item_repository_mock,
-        catalogue_item.model_dump(),
-    )
-    # Mock so child elements found
-    catalogue_item_repository_mock.has_child_elements.return_value = True
-    # Mock `update` to return the updated catalogue item
-    test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `get` to return a replacement catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             id=obsolete_replacement_catalogue_item_id,
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "name": "Catalogue Item B",
+#                 "description": "This is Catalogue Item B",
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     # Mock `create` to return the created catalogue item
+#     test_helpers.mock_create(catalogue_item_repository_mock, catalogue_item)
 
-    with pytest.raises(ChildElementsExistError) as exc:
-        catalogue_item_service.update(
-            catalogue_item.id,
-            CatalogueItemPatchSchema(properties=[]),
-        )
-    catalogue_item_repository_mock.update.assert_not_called()
-    assert str(exc.value) == f"Catalogue item with ID {catalogue_item.id} has child elements and cannot be updated"
+#     created_catalogue_item = catalogue_item_service.create(
+#         CatalogueItemPostSchema(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **CATALOGUE_ITEM_A_INFO,
+#                 "is_obsolete": True,
+#                 "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
+#                 "properties": [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
+#             },
+#         )
+#     )
+
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_item.catalogue_category_id)
+#     catalogue_item_repository_mock.get.assert_called_once_with(obsolete_replacement_catalogue_item_id)
+#     catalogue_item_repository_mock.create.assert_called_once_with(
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "is_obsolete": True,
+#                 "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
+#                 "properties": properties,
+#             },
+#         )
+#     )
+#     assert created_catalogue_item == catalogue_item
+
+
+# def test_create_without_properties(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     catalogue_category_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test creating a catalogue item without properties.
+
+#     Verify that the `create` method properly handles the catalogue item to be created without properties.
+#     """
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{**FULL_CATALOGUE_ITEM_A_INFO, "properties": []},
+#     )
+
+#     # Mock `get` to return the catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{**FULL_CATALOGUE_CATEGORY_A_INFO, "properties": []},
+#         ),
+#     )
+#     # Mock `create` to return the created catalogue item
+#     test_helpers.mock_create(catalogue_item_repository_mock, catalogue_item)
+
+#     created_catalogue_item = catalogue_item_service.create(
+#         CatalogueItemPostSchema(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{**CATALOGUE_ITEM_A_INFO, "properties": []},
+#         )
+#     )
+
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_item.catalogue_category_id)
+#     catalogue_item_repository_mock.create.assert_called_once_with(
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{**FULL_CATALOGUE_ITEM_A_INFO, "properties": []},
+#         )
+#     )
+#     assert created_catalogue_item == catalogue_item
+
+
+# def test_create_with_missing_mandatory_properties(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test creating a catalogue item with missing mandatory properties.
+
+#     Verify that the `create` method properly handles a catalogue item with missing mandatory properties, checks that
+#     the catalogue category exists and that it is a leaf category, finds that there are missing mandatory catalogue item
+#     properties, and does not create the catalogue item.
+#     """
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_CATEGORY_A_INFO,
+#             "properties": add_ids_to_properties(
+#                 None,
+#                 FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#             ),
+#         },
+#     )
+
+#     # Mock `get` to return the catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(MissingMandatoryProperty) as exc:
+#         catalogue_item_service.create(
+#             CatalogueItemPostSchema(
+#                 catalogue_category_id=catalogue_category.id,
+#                 manufacturer_id=str(ObjectId()),
+#                 **{
+#                     **CATALOGUE_ITEM_A_INFO,
+#                     "properties": [
+#                         {
+#                             "id": catalogue_category.properties[2].id,
+#                             "value": "20x15x10",
+#                         },
+#                     ],
+#                 },
+#             ),
+#         )
+#     assert str(exc.value) == f"Missing mandatory property with ID: '{catalogue_category.properties[1].id}'"
+#     catalogue_item_repository_mock.create.assert_not_called()
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
+
+
+# def test_create_with_with_invalid_value_type_for_string_property(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test creating a catalogue item with invalid value type for a string property.
+
+#     Verify that the `create` method properly handles a catalogue item with invalid value type for a string property,
+#     checks that the catalogue category exists and that it is a leaf category, checks that there are no missing mandatory
+#     properties, finds invalid value type for a string property, and does not create the catalogue item.
+#     """
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_CATEGORY_A_INFO,
+#             "properties": add_ids_to_properties(
+#                 None,
+#                 FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#             ),
+#         },
+#     )
+
+#     # Mock `get` to return the catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(InvalidPropertyTypeError) as exc:
+#         catalogue_item_service.create(
+#             CatalogueItemPostSchema(
+#                 catalogue_category_id=catalogue_category.id,
+#                 manufacturer_id=str(ObjectId()),
+#                 **{
+#                     **CATALOGUE_ITEM_A_INFO,
+#                     "properties": [
+#                         {"id": catalogue_category.properties[0].id, "value": 20},
+#                         {"id": catalogue_category.properties[1].id, "value": False},
+#                         {"id": catalogue_category.properties[2].id, "value": True},
+#                     ],
+#                 },
+#             ),
+#         )
+#     catalogue_item_repository_mock.create.assert_not_called()
+#     assert (
+#         str(exc.value) == "Invalid value type for property with ID "
+#         f"'{catalogue_category.properties[2].id}'. Expected type: string."
+#     )
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
+
+
+# def test_create_with_invalid_value_type_for_number_property(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test creating a catalogue item with invalid value type for a number property.
+
+#     Verify that the `create` method properly handles a catalogue item with invalid value type for a number catalogue
+#     property, checks that the catalogue category exists and that it is a leaf category, checks that there are no missing
+#     mandatory properties, finds invalid value type for a number property, and does not create the catalogue item.
+#     """
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_CATEGORY_A_INFO,
+#             "properties": add_ids_to_properties(
+#                 None,
+#                 FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#             ),
+#         },
+#     )
+
+#     # Mock `get` to return the catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(InvalidPropertyTypeError) as exc:
+#         catalogue_item_service.create(
+#             CatalogueItemPostSchema(
+#                 catalogue_category_id=catalogue_category.id,
+#                 manufacturer_id=str(ObjectId()),
+#                 **{
+#                     **CATALOGUE_ITEM_A_INFO,
+#                     "properties": [
+#                         {"id": catalogue_category.properties[0].id, "value": "20"},
+#                         {"id": catalogue_category.properties[1].id, "value": False},
+#                         {"id": catalogue_category.properties[2].id, "value": "20x15x10"},
+#                     ],
+#                 },
+#             )
+#         )
+#     catalogue_item_repository_mock.create.assert_not_called()
+#     assert (
+#         str(exc.value) == "Invalid value type for property with ID "
+#         f"'{catalogue_category.properties[0].id}'. Expected type: number."
+#     )
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
+
+
+# def test_create_with_with_invalid_value_type_for_boolean_property(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test creating a catalogue item with invalid value type for a boolean property.
+
+#     Verify that the `create` method properly handles a catalogue item with invalid value type for a boolean property,
+#     checks that the catalogue category exists and that it is a leaf category, checks that there are no missing
+#     mandatory properties, finds invalid value type for a boolean property, and does not create the catalogue item.
+#     """
+#     catalogue_category = CatalogueCategoryOut(
+#         id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_CATEGORY_A_INFO,
+#             "properties": add_ids_to_properties(
+#                 None,
+#                 FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#             ),
+#         },
+#     )
+
+#     # Mock `get` to return the catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, catalogue_category)
+
+#     with pytest.raises(InvalidPropertyTypeError) as exc:
+#         catalogue_item_service.create(
+#             CatalogueItemPostSchema(
+#                 catalogue_category_id=catalogue_category.id,
+#                 manufacturer_id=str(ObjectId()),
+#                 **{
+#                     **CATALOGUE_ITEM_A_INFO,
+#                     "properties": [
+#                         {"id": catalogue_category.properties[0].id, "value": 20},
+#                         {"id": catalogue_category.properties[1].id, "value": "False"},
+#                         {"id": catalogue_category.properties[2].id, "value": "20x15x10"},
+#                     ],
+#                 },
+#             )
+#         )
+#     catalogue_item_repository_mock.create.assert_not_called()
+#     assert (
+#         str(exc.value) == "Invalid value type for property with ID "
+#         f"'{catalogue_category.properties[1].id}'. Expected type: boolean."
+#     )
+
+#     catalogue_category_repository_mock.get.assert_called_once_with(catalogue_category.id)
+
+
+# def test_delete(catalogue_item_repository_mock, catalogue_item_service):
+#     """
+#     Test deleting a catalogue item.
+
+#     Verify that the `delete` method properly handles the deletion of a catalogue item by ID.
+#     """
+#     catalogue_item_id = str(ObjectId())
+
+#     catalogue_item_service.delete(catalogue_item_id)
+
+#     catalogue_item_repository_mock.delete.assert_called_once_with(catalogue_item_id)
+
+
+# def test_get(test_helpers, catalogue_item_repository_mock, catalogue_item_service):
+#     """
+#     Test getting a catalogue item.
+
+#     Verify that the `get` method properly handles the retrieval of a catalogue item by ID.
+#     """
+#     catalogue_item_id = str(ObjectId())
+#     catalogue_item = MagicMock()
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
+
+#     retrieved_catalogue_item = catalogue_item_service.get(catalogue_item_id)
+
+#     catalogue_item_repository_mock.get.assert_called_once_with(catalogue_item_id)
+#     assert retrieved_catalogue_item == catalogue_item
+
+
+# def test_get_with_non_existent_id(test_helpers, catalogue_item_repository_mock, catalogue_item_service):
+#     """
+#     Test getting a catalogue item with a non-existent ID.
+
+#     Verify that the `get` method properly handles the retrieval of a catalogue item with a non-existent ID.
+#     """
+#     catalogue_item_id = str(ObjectId())
+
+#     # Mock `get` to not return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, None)
+
+#     retrieved_catalogue_item = catalogue_item_service.get(catalogue_item_id)
+
+#     assert retrieved_catalogue_item is None
+#     catalogue_item_repository_mock.get.assert_called_once_with(catalogue_item_id)
+
+
+# def test_list(catalogue_item_repository_mock, catalogue_item_service):
+#     """
+#     Test listing catalogue items
+
+#     Verify that the `list` method properly calls the repository function with any passed filters
+#     """
+
+#     catalogue_category_id = str(ObjectId())
+
+#     result = catalogue_item_service.list(catalogue_category_id=catalogue_category_id)
+
+#     catalogue_item_repository_mock.list.assert_called_once_with(catalogue_category_id)
+#     assert result == catalogue_item_repository_mock.list.return_value
+
+
+# def test_update_when_no_child_elements(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating a catalogue item with child elements.
+
+#     Verify that the `update` method properly handles the catalogue item to be updated when it doesn't have any
+#     children.
+#     """
+#     # pylint: disable=duplicate-code
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "name": "Catalogue Item B",
+#                 "description": "This is Catalogue Item B",
+#                 "modified_time": catalogue_item.created_time,
+#             },
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(name=catalogue_item.name, description=catalogue_item.description),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_when_has_child_elements(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating a catalogue item with child elements.
+
+#     Verify that the `update` method properly handles the catalogue item to be updated when it has children.
+#     """
+#     # pylint: disable=duplicate-code
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "name": "Catalogue Item B",
+#                 "description": "This is Catalogue Item B",
+#                 "modified_time": catalogue_item.created_time,
+#             },
+#         ),
+#     )
+#     # Mock so child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = True
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(name=catalogue_item.name, description=catalogue_item.description),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_with_non_existent_id(test_helpers, catalogue_item_repository_mock, catalogue_item_service):
+#     """
+#     Test updating a catalogue item with a non-existent ID.
+
+#     Verify that the `update` method properly handles the catalogue category to be updated with a non-existent ID.
+#     """
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, None)
+
+#     catalogue_item_id = str(ObjectId())
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_item_service.update(catalogue_item_id, CatalogueItemPatchSchema(properties=[]))
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"No catalogue item found with ID: {catalogue_item_id}"
+
+
+# def test_update_change_catalogue_category_id_same_defined_properties_without_supplied_properties(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test moving a catalogue item to another catalogue category that has the same defined  when
+#     no properties are supplied.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     current_catalogue_category_id = str(ObjectId())
+#     current_properties = add_ids_to_properties(None, properties)
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "catalogue_category_id": current_catalogue_category_id,
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": current_properties,
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return the new catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `get` to return the current catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=current_catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_C_INFO,
+#                 "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id, CatalogueItemPatchSchema(catalogue_category_id=catalogue_item.catalogue_category_id)
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_change_catalogue_category_id_same_defined_properties_with_supplied_properties(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test moving a catalogue item to another catalogue category that has the same defined properties when
+#     properties are supplied.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     current_catalogue_category_id = str(ObjectId())
+#     current_properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "catalogue_category_id": current_catalogue_category_id,
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": current_properties,
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return the new catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `get` to return the current catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=current_catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_C_INFO,
+#                 "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
+#         ),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_change_catalogue_category_id_different_defined_properties_without_supplied_properties(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test moving a catalogue item to another catalogue category that has different defined properties when
+#     no properties are supplied.
+#     """
+#     catalogue_item_id = str(ObjectId())
+#     catalogue_category_id = str(ObjectId())
+
+#     current_catalogue_category_id = str(ObjectId())
+#     current_properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             id=catalogue_item_id,
+#             catalogue_category_id=current_catalogue_category_id,
+#             manufacturer_id=str(ObjectId()),
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "properties": current_properties,
+#             },
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return the new catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     None,
+#                     [
+#                         {"name": "Property A", "type": "number", "unit": "m", "mandatory": False},
+#                         *FULL_CATALOGUE_CATEGORY_A_INFO["properties"][1:],
+#                     ],
+#                 ),
+#             },
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+#     # Mock `get` to return the current catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=current_catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_C_INFO,
+#                 "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
+#             },
+#         ),
+#     )
+
+#     with pytest.raises(InvalidActionError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item_id,
+#             CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value) == "Cannot move catalogue item to a category with different properties without "
+#         "specifying the new properties"
+#     )
+
+
+# def test_update_change_catalogue_category_id_different_defined_properties_order_without_supplied_properties(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test moving a catalogue item to another catalogue category that has different defined
+#     order when no properties are supplied.
+#     """
+#     catalogue_item_id = str(ObjectId())
+#     catalogue_category_id = str(ObjectId())
+
+#     current_catalogue_category_id = str(ObjectId())
+#     current_properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             id=catalogue_item_id,
+#             catalogue_category_id=current_catalogue_category_id,
+#             manufacturer_id=str(ObjectId()),
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "properties": current_properties,
+#             },
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return the new catalogue category
+#     # pylint: disable=duplicate-code
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     None,
+#                     [
+#                         *FULL_CATALOGUE_CATEGORY_A_INFO["properties"][::-1],
+#                     ],
+#                 ),
+#             },
+#         ),
+#     )
+#     # pylint: enable=duplicate-code
+#     # Mock `get` to return the current catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=current_catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_C_INFO,
+#                 "properties": add_ids_to_properties(current_properties, FULL_CATALOGUE_CATEGORY_A_INFO["properties"]),
+#             },
+#         ),
+#     )
+
+#     with pytest.raises(InvalidActionError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item_id,
+#             CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value) == "Cannot move catalogue item to a category with different properties without "
+#         "specifying the new properties"
+#     )
+
+
+# def test_update_change_catalogue_category_id_different_defined_properties_with_supplied_properties(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test moving a catalogue item to another catalogue category that has different defined properties when
+#     properties are supplied.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     current_catalogue_category_id = str(ObjectId())
+#     current_properties = add_ids_to_properties(None, [{"name": "Property A", "value": True, "unit": None}])
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "catalogue_category_id": current_catalogue_category_id,
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": current_properties,
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return the new catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `get` to return the current catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=current_catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_C_INFO,
+#                 "properties": add_ids_to_properties(
+#                     current_properties,
+#                     [{"name": "Property A", "type": "boolean", "unit": None, "mandatory": True}],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties],
+#         ),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_with_non_existent_catalogue_category_id(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating a catalogue item with a non-existent catalogue category ID.
+#     """
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to not return a catalogue category
+#     test_helpers.mock_get(catalogue_category_repository_mock, None)
+
+#     catalogue_category_id = str(ObjectId())
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"No catalogue category found with ID: {catalogue_category_id}"
+
+
+# def test_update_with_existent_manufacturer_id_when_has_no_child_elements(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     manufacturer_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating manufacturer id to an existing id when the catalogue item has no child elements
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "manufacturer_id": str(ObjectId()),
+#                 "modified_time": catalogue_item.created_time,
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a manufacturer
+#     test_helpers.mock_get(
+#         manufacturer_repository_mock,
+#         ManufacturerOut(id=catalogue_item.manufacturer_id, **FULL_MANUFACTURER_INFO),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(manufacturer_id=catalogue_item.manufacturer_id),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_with_existent_manufacturer_id_when_has_child_elements(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     manufacturer_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating manufacturer id to an existing id when the catalogue item has child elements
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "manufacturer_id": str(ObjectId()),
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = True
+#     # Mock `get` to return a manufacturer
+#     test_helpers.mock_get(
+#         manufacturer_repository_mock,
+#         ManufacturerOut(id=catalogue_item.manufacturer_id, **FULL_MANUFACTURER_INFO),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     with pytest.raises(ChildElementsExistError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(manufacturer_id=catalogue_item.manufacturer_id),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"Catalogue item with ID {catalogue_item.id} has child elements and cannot be updated"
+
+
+# def test_update_with_non_existent_manufacturer_id(
+#     test_helpers,
+#     manufacturer_repository_mock,
+#     catalogue_item_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating a catalogue item with a non-existent manufacturer id
+#     """
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to not return a manufacturer
+#     test_helpers.mock_get(manufacturer_repository_mock, None)
+
+#     manufacturer_id = str(ObjectId())
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(manufacturer_id=manufacturer_id),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"No manufacturer found with ID: {manufacturer_id}"
+
+
+# def test_update_change_catalogue_category_id_non_leaf_catalogue_category(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test moving a catalogue item to a non-leaf catalogue category.
+#     """
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     catalogue_category_id = str(ObjectId())
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(id=catalogue_category_id, **FULL_CATALOGUE_CATEGORY_B_INFO),
+#     )
+
+#     with pytest.raises(NonLeafCatalogueCategoryError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(catalogue_category_id=catalogue_category_id),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == "Cannot add catalogue item to a non-leaf catalogue category"
+
+
+# def test_update_with_obsolete_replacement_catalogue_item_id(
+#     test_helpers,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating a catalogue item with an obsolete replacement catalogue item ID.
+#     """
+#     obsolete_replacement_catalogue_item_id = str(ObjectId())
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "is_obsolete": True,
+#             "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             id=catalogue_item.id,
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a replacement catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             id=obsolete_replacement_catalogue_item_id,
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "name": "Catalogue Item B",
+#                 "description": "This is Catalogue Item B",
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(
+#             is_obsolete=True, obsolete_replacement_catalogue_item_id=obsolete_replacement_catalogue_item_id
+#         ),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "is_obsolete": True,
+#                 "obsolete_replacement_catalogue_item_id": obsolete_replacement_catalogue_item_id,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_with_non_existent_obsolete_replacement_catalogue_item_id(
+#     test_helpers, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test updating a catalogue item with a non-existent obsolete replacement catalogue item ID.
+#     """
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, catalogue_item)
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to not return a replacement catalogue item
+#     test_helpers.mock_get(catalogue_item_repository_mock, None)
+
+#     obsolete_replacement_catalogue_item_id = str(ObjectId())
+#     with pytest.raises(MissingRecordError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(
+#                 is_obsolete=True, obsolete_replacement_catalogue_item_id=obsolete_replacement_catalogue_item_id
+#             ),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"No catalogue item found with ID: {obsolete_replacement_catalogue_item_id}"
+#     catalogue_item_repository_mock.get.assert_has_calls(
+#         [call(catalogue_item.id), call(obsolete_replacement_catalogue_item_id)]
+#     )
+
+
+# def test_update_add_non_mandatory_property(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test adding a non-mandatory property and a value.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_ITEM_A_INFO["properties"][-2:],
+#                 ),
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(
+#             properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
+#         ),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_remove_non_mandatory_property(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test removing a non-mandatory property and its value.
+#     """
+#     properties = add_ids_to_properties(
+#         None, [{"name": "Property A", "value": None, "unit": "mm"}, *FULL_CATALOGUE_ITEM_A_INFO["properties"][-2:]]
+#     )
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": add_ids_to_properties(properties, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(
+#             properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties[-2:]]
+#         ),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_remove_mandatory_property(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     catalogue_item_service,
+# ):
+#     """
+#     Test removing a mandatory property and its value.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         catalogue_item,
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+
+#     with pytest.raises(MissingMandatoryProperty) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(
+#                 properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties[:2]]
+#             ),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"Missing mandatory property with ID: '{catalogue_item.properties[2].id}'"
+
+
+# def test_update_change_property_value(
+#     test_helpers,
+#     catalogue_category_repository_mock,
+#     catalogue_item_repository_mock,
+#     model_mixins_datetime_now_mock,  # pylint: disable=unused-argument
+#     catalogue_item_service,
+# ):
+#     """
+#     Test updating a value of a property.
+#     """
+#     properties = add_ids_to_properties(
+#         None, [{"name": "Property A", "value": 1, "unit": "mm"}, *FULL_CATALOGUE_ITEM_A_INFO["properties"][-2:]]
+#     )
+#     # pylint: disable=duplicate-code
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "created_time": FULL_CATALOGUE_ITEM_A_INFO["created_time"] - timedelta(days=5),
+#             "properties": properties,
+#         },
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         CatalogueItemOut(
+#             **{
+#                 **catalogue_item.model_dump(),
+#                 "modified_time": catalogue_item.created_time,
+#                 "properties": add_ids_to_properties(properties, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#             }
+#         ),
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     updated_catalogue_item = catalogue_item_service.update(
+#         catalogue_item.id,
+#         CatalogueItemPatchSchema(
+#             properties=[{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
+#         ),
+#     )
+
+#     catalogue_item_repository_mock.update.assert_called_once_with(
+#         catalogue_item.id,
+#         CatalogueItemIn(
+#             catalogue_category_id=catalogue_item.catalogue_category_id,
+#             manufacturer_id=catalogue_item.manufacturer_id,
+#             **{
+#                 **FULL_CATALOGUE_ITEM_A_INFO,
+#                 "created_time": catalogue_item.created_time,
+#                 "properties": properties,
+#             },
+#         ),
+#     )
+#     assert updated_catalogue_item == catalogue_item
+
+
+# def test_update_change_value_for_string_property_invalid_type(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test changing the value of a string property to an invalid type.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         catalogue_item,
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+
+#     properties = [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
+#     properties[2]["value"] = True
+#     with pytest.raises(InvalidPropertyTypeError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(properties=properties),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value) == f"Invalid value type for property with ID '{catalogue_item.properties[2].id}'. "
+#         "Expected type: string."
+#     )
+
+
+# def test_update_change_value_for_number_property_invalid_type(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test changing the value of a number property to an invalid type.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         catalogue_item,
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+
+#     properties = [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
+#     properties[0]["value"] = "20"
+#     with pytest.raises(InvalidPropertyTypeError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(properties=properties),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value) == f"Invalid value type for property with ID '{catalogue_item.properties[0].id}'. "
+#         "Expected type: number."
+#     )
+
+
+# def test_update_change_value_for_boolean_property_invalid_type(
+#     test_helpers, catalogue_category_repository_mock, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test changing the value of a boolean property to an invalid type.
+#     """
+#     properties = add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"])
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": properties,
+#         },
+#     )
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         catalogue_item,
+#     )
+#     # Mock so no child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = False
+#     # Mock `get` to return a catalogue category
+#     test_helpers.mock_get(
+#         catalogue_category_repository_mock,
+#         CatalogueCategoryOut(
+#             id=catalogue_item.catalogue_category_id,
+#             **{
+#                 **FULL_CATALOGUE_CATEGORY_A_INFO,
+#                 "properties": add_ids_to_properties(
+#                     properties,
+#                     FULL_CATALOGUE_CATEGORY_A_INFO["properties"],
+#                 ),
+#             },
+#         ),
+#     )
+
+#     properties = [{"id": prop.id, "value": prop.value} for prop in catalogue_item.properties]
+#     properties[1]["value"] = "False"
+#     with pytest.raises(InvalidPropertyTypeError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(properties=properties),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert (
+#         str(exc.value) == f"Invalid value type for property with ID '{catalogue_item.properties[1].id}'. "
+#         "Expected type: boolean."
+#     )
+
+
+# def test_update_properties_when_has_child_elements(
+#     test_helpers, catalogue_item_repository_mock, catalogue_item_service
+# ):
+#     """
+#     Test updating a catalogue item's properties when it has child elements.
+#     """
+#     # pylint: disable=duplicate-code
+#     catalogue_item = CatalogueItemOut(
+#         id=str(ObjectId()),
+#         catalogue_category_id=str(ObjectId()),
+#         manufacturer_id=str(ObjectId()),
+#         **{
+#             **FULL_CATALOGUE_ITEM_A_INFO,
+#             "properties": add_ids_to_properties(None, FULL_CATALOGUE_ITEM_A_INFO["properties"]),
+#         },
+#     )
+#     # pylint: enable=duplicate-code
+
+#     # Mock `get` to return a catalogue item
+#     test_helpers.mock_get(
+#         catalogue_item_repository_mock,
+#         catalogue_item.model_dump(),
+#     )
+#     # Mock so child elements found
+#     catalogue_item_repository_mock.has_child_elements.return_value = True
+#     # Mock `update` to return the updated catalogue item
+#     test_helpers.mock_update(catalogue_item_repository_mock, catalogue_item)
+
+#     with pytest.raises(ChildElementsExistError) as exc:
+#         catalogue_item_service.update(
+#             catalogue_item.id,
+#             CatalogueItemPatchSchema(properties=[]),
+#         )
+#     catalogue_item_repository_mock.update.assert_not_called()
+#     assert str(exc.value) == f"Catalogue item with ID {catalogue_item.id} has child elements and cannot be updated"

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -6,17 +6,12 @@ Unit tests for the `CatalogueCategoryService` service.
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code
 
-from datetime import timedelta
-from test.conftest import add_ids_to_properties
 from test.mock_data import (
     BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES,
-    CATALOGUE_CATEGORY_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_WITH_PROPERTIES_MM,
     CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
-    CATALOGUE_CATEGORY_POST_DATA_LEAF_REQUIRED_VALUES_ONLY,
     CATALOGUE_CATEGORY_PROPERTY_IN_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
-    CATALOGUE_CATEGORY_PROPERTY_IN_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST,
     CATALOGUE_ITEM_DATA_NOT_OBSOLETE_NO_PROPERTIES,
     CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
     CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
@@ -24,7 +19,7 @@ from test.mock_data import (
     MANUFACTURER_IN_DATA_A,
     PROPERTY_DATA_NUMBER_NON_MANDATORY_42,
 )
-from test.unit.services.conftest import MODEL_MIXINS_FIXED_DATETIME_NOW, ServiceTestHelpers
+from test.unit.services.conftest import ServiceTestHelpers
 from typing import Optional
 from unittest.mock import MagicMock, Mock, call, patch
 
@@ -35,8 +30,6 @@ from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     InvalidActionError,
-    InvalidPropertyTypeError,
-    MissingMandatoryProperty,
     MissingRecordError,
     NonLeafCatalogueCategoryError,
 )
@@ -47,8 +40,6 @@ from inventory_management_system_api.models.catalogue_category import (
 )
 from inventory_management_system_api.models.catalogue_item import CatalogueItemIn, CatalogueItemOut, PropertyIn
 from inventory_management_system_api.models.manufacturer import ManufacturerIn, ManufacturerOut
-from inventory_management_system_api.models.unit import UnitIn, UnitOut
-from inventory_management_system_api.schemas.catalogue_category import CatalogueCategoryPostPropertySchema
 from inventory_management_system_api.schemas.catalogue_item import (
     CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS,
     CatalogueItemPatchSchema,
@@ -71,6 +62,7 @@ class CatalogueItemServiceDSL:
 
     property_name_id_dict: dict[str, str]
 
+    # pylint:disable=too-many-arguments
     @pytest.fixture(autouse=True)
     def setup(
         self,
@@ -191,7 +183,6 @@ class CreateDSL(CatalogueItemServiceDSL):
         )
         ServiceTestHelpers.mock_get(self.mock_catalogue_category_repository, self._catalogue_category_out)
 
-        # TODO: Could this be simplified? - similar logic elsewhere and in the catalogue category service tests
         # Manufacturer
         ServiceTestHelpers.mock_get(
             self.mock_manufacturer_repository,
@@ -221,8 +212,6 @@ class CreateDSL(CatalogueItemServiceDSL):
                 else None
             ),
         )
-
-        # TODO: Go over catalogue categories and check if should use this method instead of current
 
         # When properties are given need to add any property `id`s and ensure the expected data inserts them as well
         property_post_schemas = []
@@ -398,8 +387,8 @@ class TestCreate(CreateDSL):
         )
         self.call_create_expecting_error(MissingRecordError)
         self.check_create_failed_with_exception(
-            f"No catalogue item found with ID: "
-            f"{CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES["obsolete_replacement_catalogue_item_id"]}"
+            "No catalogue item found with ID: "
+            f"{CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES['obsolete_replacement_catalogue_item_id']}"
         )
 
 
@@ -488,14 +477,10 @@ class TestList(ListDSL):
         self.check_list_success()
 
 
-# TODO: Update tests
-
-
 # pylint:disable=too-many-instance-attributes
 class UpdateDSL(CatalogueItemServiceDSL):
     """Base class for `update` tests."""
 
-    # TODO: Remove unused parameters that were copied (e.g. unit_value_id_dict?)
     _stored_catalogue_item: Optional[CatalogueItemOut]
     _stored_catalogue_category_in: Optional[CatalogueCategoryIn]
     _stored_catalogue_category_out: Optional[CatalogueCategoryOut]
@@ -513,9 +498,7 @@ class UpdateDSL(CatalogueItemServiceDSL):
     _updating_manufacturer: bool
     _updating_obsolete_replacement_catalogue_item: bool
     _updating_properties: bool
-    unit_value_id_dict: dict[str, str]
 
-    # TODO: Update comment and parameters
     # pylint:disable=too-many-arguments
     def mock_update(
         self,
@@ -527,26 +510,29 @@ class UpdateDSL(CatalogueItemServiceDSL):
         new_manufacturer_in_data: Optional[dict] = None,
         new_obsolete_replacement_catalogue_item_data: Optional[dict] = None,
         has_child_elements: bool = False,
-        units_in_data: Optional[list[Optional[dict]]] = None,
     ) -> None:
         """
         Mocks repository methods appropriately to test the `update` service method.
 
-        :param catalogue_item_id: ID of the catalogue category that will be obtained.
+        :param catalogue_item_id: ID of the catalogue item that will be obtained.
         :param catalogue_item_update_data: Dictionary containing the basic patch data as would be required for a
-                                               `CatalogueCategoryPatchSchema` but with any unit_id's replaced by the
-                                               'unit' value in its properties as the IDs will be added automatically.
-        :param stored_catalogue_category_post_data: Dictionary containing the catalogue category data for the existing
-                                               stored catalogue category as would be required for a
-                                               `CatalogueCategoryPostSchema` (i.e. no ID, code or created and modified
-                                               times required).
-        :param has_child_elements: Boolean of whether the category being updated has child elements or not
-        :param new_catalogue_category_in_data: Either `None` or a dictionary containing the new parent catalogue
-                                               category data as would be required for a `CatalogueCategoryIn` database
-                                               model.
-        :param units_in_data: Either `None` or a list of dictionaries (or `None`) containing the unit data as would be
-                              required for a `UnitIn` database model. These values will be used for any unit look ups
-                              required by the given catalogue category properties in the patch data.
+                                          `CatalogueItemPatchSchema` but without any mandatory IDs or property IDs.
+        :param stored_catalogue_item_data: Either `None` or a dictionary containing the catalogue basic catalogue item
+                                           data for the existing stored catalogue item as would be required for a
+                                           `CatalogueItemPostSchema` but without any mandatory IDs or property IDs.
+        :param stored_catalogue_category_in_data: Either `None` or a dictionary containing the catalogue category data
+                                                  for the existing stored catalogue category as would be required for a
+                                                  `CatalogueCategoryIn` database model.
+        :param new_catalogue_category_in_data: Either `None` or a dictionary containing the catalogue category data for
+                                               the new stored catalogue category as would be required for a
+                                               `CatalogueCategoryIn` database model.
+        :param new_manufacturer_in_data: Either `None` or a dictionary containing the manufacturer data for the new
+                                         stored manufacturer as would be required for a `ManufacturerIn` database model.
+        :param new_obsolete_replacement_catalogue_item_data: Either `None` or a dictionary containing the basic
+                                         catalogue item data for the new stored obsolete replacement catalogue item as
+                                         would be required for a `CatalogueItemPostSchema` but without any mandatory IDs
+                                         or property IDs.
+        :param has_child_elements: Boolean of whether the catalogue item being updated has child elements or not
         """
 
         # Add property ids to the stored catalogue item if needed
@@ -638,8 +624,6 @@ class UpdateDSL(CatalogueItemServiceDSL):
                     ),
                 )
 
-            # TODO: Deal with properties in the above?
-
         self._updating_manufacturer = (
             "manufacturer_id" in catalogue_item_update_data
             and catalogue_item_update_data["manufacturer_id"] != self._stored_catalogue_item.manufacturer_id
@@ -719,7 +703,6 @@ class UpdateDSL(CatalogueItemServiceDSL):
         self._expected_catalogue_item_out = MagicMock()
         ServiceTestHelpers.mock_update(self.mock_catalogue_item_repository, self._expected_catalogue_item_out)
 
-        # TODO: Move this to the top? Same for catalogue categories
         # Patch schema
         self._catalogue_item_patch = CatalogueItemPatchSchema(**catalogue_item_update_data)
 
@@ -789,9 +772,10 @@ class UpdateDSL(CatalogueItemServiceDSL):
 
         self.mock_catalogue_item_repository.get.assert_has_calls(expected_catalogue_item_get_calls)
 
-        # TODO: This is different to catalogue category tests - use self._catalogue_category_post.properties there
         if self._updating_properties:
-            # TODO: Implement
+            if self._moving_catalogue_item:
+                expected_catalogue_category_get_calls.append(call(self._stored_catalogue_item.catalogue_category_id))
+
             self.wrapped_utils.process_properties.assert_called_once_with(
                 (
                     self._new_catalogue_category_out.properties
@@ -803,7 +787,6 @@ class UpdateDSL(CatalogueItemServiceDSL):
         else:
             self.wrapped_utils.process_properties.assert_not_called()
 
-        # TODO: Implement
         assert self._updated_catalogue_item == self._expected_catalogue_item_out
 
     def check_update_failed_with_exception(self, message: str) -> None:
@@ -819,6 +802,7 @@ class UpdateDSL(CatalogueItemServiceDSL):
         assert str(self._update_exception.value) == message
 
 
+# pylint: disable=too-many-public-methods
 class TestUpdate(UpdateDSL):
     """Tests for updating a catalogue item."""
 
@@ -1171,8 +1155,6 @@ class TestUpdate(UpdateDSL):
         self.check_update_failed_with_exception(
             f"No catalogue item found with ID: {obsolete_replacement_catalogue_item_id}"
         )
-
-    # TODO: Implement more tests
 
     def test_update_with_non_existent_id(self):
         """Test updating a catalogue item with a non-existent ID."""


### PR DESCRIPTION
## Description
See #341.

### Notes
- Removed some unit tests that were already handled by `utils.process_properties`  e.g. `test_update_add_non_mandatory_property`, `test_update_remove_non_mandatory_property` etc.
- Removed `test_get_with_non_existent_id` - Logic handled in repo unit tests and e2e tests (matches already refactored service tests)
- Found and fixed #349 


I think we should be able to clean up the mock_create/update methods later by adding some additional functions in the tests/helper functions in conftest, although its not clear how it will impact items yet or the e2e tests yet.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #341, Closes #349
