### PR TITLE
Refactor ItemRepo unit tests #345

### DIFF
--- a/inventory_management_system_api/repositories/item.py
+++ b/inventory_management_system_api/repositories/item.py
@@ -51,20 +51,6 @@ class ItemRepo:
         item = self.get(str(result.inserted_id), session=session)
         return item
 
-    def delete(self, item_id: str, session: ClientSession = None) -> None:
-        """
-        Delete an item by its ID from a MongoDB database.
-
-        :param item_id: The ID of the item to delete.
-        :param session: PyMongo ClientSession to use for database operations
-        :raises MissingRecordError: If the item doesn't exist
-        """
-        item_id = CustomObjectId(item_id)
-        logger.info("Deleting item with ID: %s from the database", item_id)
-        result = self._items_collection.delete_one({"_id": item_id}, session=session)
-        if result.deleted_count == 0:
-            raise MissingRecordError(f"No item found with ID: {str(item_id)}")
-
     def get(self, item_id: str, session: ClientSession = None) -> Optional[ItemOut]:
         """
         Retrieve an item by its ID from a MongoDB database.
@@ -126,6 +112,20 @@ class ItemRepo:
         self._items_collection.update_one({"_id": item_id}, {"$set": item.model_dump(by_alias=True)}, session=session)
         item = self.get(str(item_id), session=session)
         return item
+
+    def delete(self, item_id: str, session: ClientSession = None) -> None:
+        """
+        Delete an item by its ID from a MongoDB database.
+
+        :param item_id: The ID of the item to delete.
+        :param session: PyMongo ClientSession to use for database operations
+        :raises MissingRecordError: If the item doesn't exist
+        """
+        item_id = CustomObjectId(item_id)
+        logger.info("Deleting item with ID: %s from the database", item_id)
+        result = self._items_collection.delete_one({"_id": item_id}, session=session)
+        if result.deleted_count == 0:
+            raise MissingRecordError(f"No item found with ID: {str(item_id)}")
 
     def insert_property_to_all_in(
         self, catalogue_item_ids: List[ObjectId], property_in: PropertyIn, session: ClientSession = None

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -840,7 +840,7 @@ class TestUpdate(UpdateDSL):
     """Tests for updating a catalogue item."""
 
     def test_partial_update_all_fields_except_ids_or_properties_with_no_children(self):
-        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties when it has
+        """Test updating all fields of a catalogue item except any of its `_id` fields or properties when it has
         no children."""
 
         catalogue_item_id = self.post_catalogue_item_and_prerequisites_no_properties(
@@ -851,7 +851,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_item_response_success(CATALOGUE_ITEM_GET_DATA_NOT_OBSOLETE_NO_PROPERTIES)
 
     def test_partial_update_all_fields_except_ids_or_properties_with_children(self):
-        """Test updating all fields of a catalogue item except its any of its `_id` fields or properties when it has
+        """Test updating all fields of a catalogue item except any of its `_id` fields or properties when it has
         children."""
 
         catalogue_item_id = self.post_catalogue_item_and_prerequisites_no_properties(

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -443,6 +443,16 @@ ITEM_IN_DATA_REQUIRED_VALUES_ONLY = {
     "usage_status": "In Use",
 }
 
+
+# TODO: Replace in later PR when have a suitable name for one
+ITEM_IN_DATA_A = {
+    "catalogue_item_id": str(ObjectId()),
+    "system_id": str(ObjectId()),
+    "is_defective": False,
+    "usage_status_id": str(ObjectId()),
+    "usage_status": "In Use",
+}
+
 # --------------------------------- MANUFACTURERS ---------------------------------
 
 # Required values only

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -435,16 +435,20 @@ CATALOGUE_ITEM_GET_DATA_WITH_MANDATORY_PROPERTIES_ONLY = {
 
 # ------------------------------------- ITEMS -------------------------------------
 
-ITEM_IN_DATA_REQUIRED_VALUES_ONLY = {
-    "catalogue_item_id": str(ObjectId()),
-    "system_id": str(ObjectId()),
+ITEM_DATA_REQUIRED_VALUES_ONLY = {
     "is_defective": False,
-    "usage_status_id": str(ObjectId()),
     "usage_status": "In Use",
 }
 
+ITEM_IN_DATA_REQUIRED_VALUES_ONLY = {
+    **ITEM_DATA_REQUIRED_VALUES_ONLY,
+    "catalogue_item_id": str(ObjectId()),
+    "system_id": str(ObjectId()),
+    "usage_status_id": str(ObjectId()),
+}
 
-# TODO: Replace in later PR when have a suitable name for one
+# pylint:disable=fixme
+# TODO: Replace in later item's PR when have a suitable name for one
 ITEM_IN_DATA_A = {
     "catalogue_item_id": str(ObjectId()),
     "system_id": str(ObjectId()),

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -433,6 +433,15 @@ CATALOGUE_ITEM_GET_DATA_WITH_MANDATORY_PROPERTIES_ONLY = {
     ],
 }
 
+# ------------------------------------- ITEMS -------------------------------------
+
+ITEM_IN_DATA_REQUIRED_VALUES_ONLY = {
+    "catalogue_item_id": str(ObjectId()),
+    "system_id": str(ObjectId()),
+    "is_defective": False,
+    "usage_status_id": str(ObjectId()),
+    "usage_status": "In Use",
+}
 
 # --------------------------------- MANUFACTURERS ---------------------------------
 

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -13,7 +13,6 @@ from pymongo.database import Database
 from pymongo.results import DeleteResult, InsertOneResult, UpdateResult
 
 from inventory_management_system_api.repositories.item import ItemRepo
-from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
 from inventory_management_system_api.repositories.unit import UnitRepo
 from inventory_management_system_api.repositories.usage_status import UsageStatusRepo
 
@@ -45,14 +44,6 @@ def fixture_item_repository(database_mock: Mock) -> ItemRepo:
     :return: `ItemRepo` instance with the mocked dependency.
     """
     return ItemRepo(database_mock)
-
-
-@pytest.fixture(name="manufacturer_repository")
-def fixture_manufacturer_repository(database_mock: Mock) -> ManufacturerRepo:
-    """
-    Fixture to create ManufacturerRepo instance
-    """
-    return ManufacturerRepo(database_mock)
 
 
 @pytest.fixture(name="unit_repository")

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -776,7 +776,7 @@ class UpdateDSL(CatalogueCategoryRepoDSL):
                 "_id": CustomObjectId(self._updated_catalogue_category_id),
             },
             {
-                "$set": self._catalogue_category_in.model_dump(),
+                "$set": self._catalogue_category_in.model_dump(by_alias=True),
             },
             session=self.mock_session,
         )

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -350,7 +350,6 @@ class UpdateDSL(CatalogueItemRepoDSL):
         """
         self._catalogue_item_in = CatalogueItemIn(**new_catalogue_item_in_data)
 
-    # pylint:disable=too-many-arguments
     def mock_update(
         self,
         catalogue_item_id: str,
@@ -377,7 +376,7 @@ class UpdateDSL(CatalogueItemRepoDSL):
     def call_update(self, catalogue_item_id: str) -> None:
         """
         Calls the `CatalogueItemRepo` `update` method with the appropriate data from a prior call to `mock_update`
-        (or`set_update_data`).
+        (or `set_update_data`).
 
         :param catalogue_item_id: ID of the catalogue item to be updated.
         """
@@ -408,7 +407,7 @@ class UpdateDSL(CatalogueItemRepoDSL):
                 "_id": CustomObjectId(self._updated_catalogue_item_id),
             },
             {
-                "$set": self._catalogue_item_in.model_dump(),
+                "$set": self._catalogue_item_in.model_dump(by_alias=True),
             },
             session=self.mock_session,
         )

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -8,10 +8,10 @@ Unit tests for the `CatalogueItemRepo` repository.
 from test.mock_data import (
     CATALOGUE_ITEM_IN_DATA_NOT_OBSOLETE_NO_PROPERTIES,
     CATALOGUE_ITEM_IN_DATA_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_REQUIRED_VALUES_ONLY,
     PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
-from test.unit.repositories.test_item import FULL_ITEM_INFO
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
@@ -122,13 +122,13 @@ class CreateDSL(CatalogueItemRepoDSL):
 
         catalogue_item_in_data = self._catalogue_item_in.model_dump(by_alias=True)
 
+        self.catalogue_items_collection.insert_one.assert_called_once_with(
+            catalogue_item_in_data, session=self.mock_session
+        )
         self.catalogue_items_collection.find_one.assert_called_once_with(
             {"_id": CustomObjectId(self._expected_catalogue_item_out.id)}, session=self.mock_session
         )
 
-        self.catalogue_items_collection.insert_one.assert_called_once_with(
-            catalogue_item_in_data, session=self.mock_session
-        )
         assert self._created_catalogue_item == self._expected_catalogue_item_out
 
 
@@ -538,9 +538,7 @@ class TestDelete(DeleteDSL):
 
         catalogue_item_id = str(ObjectId())
 
-        # pylint:disable=fixme
-        # TODO: Replace FULL_ITEM_INFO once items has been refactored
-        self.mock_delete(deleted_count=1, child_item_data=FULL_ITEM_INFO)
+        self.mock_delete(deleted_count=1, child_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY)
         self.call_delete_expecting_error(catalogue_item_id, ChildElementsExistError)
         self.check_delete_failed_with_exception(
             f"Catalogue item with ID {catalogue_item_id} has child elements and cannot be deleted"
@@ -607,11 +605,7 @@ class TestHasChildElements(HasChildElementsDSL):
     def test_has_child_elements_with_child_item(self):
         """Test `has_child_elements` when there is a child item."""
 
-        # pylint:disable=fixme
-        # TODO: Replace FULL_ITEM_INFO once items has been refactored
-        self.mock_has_child_elements(
-            child_item_data=FULL_ITEM_INFO,
-        )
+        self.mock_has_child_elements(child_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY)
         self.call_has_child_elements(catalogue_item_id=str(ObjectId()))
         self.check_has_child_elements_success(expected_result=True)
 

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -82,7 +82,6 @@ class CreateDSL(CatalogueItemRepoDSL):
     _catalogue_item_in: CatalogueItemIn
     _expected_catalogue_item_out: CatalogueItemOut
     _created_catalogue_item: CatalogueItemOut
-    _create_exception: pytest.ExceptionInfo
 
     def mock_create(
         self,
@@ -118,18 +117,6 @@ class CreateDSL(CatalogueItemRepoDSL):
             self._catalogue_item_in, session=self.mock_session
         )
 
-    def call_create_expecting_error(self, error_type: type[BaseException]) -> None:
-        """
-        Calls the `CatalogueItemRepo` `create` method with the appropriate data from a prior call to `mock_create`
-        while expecting an error to be raised.
-
-        :param error_type: Expected exception to be raised.
-        """
-
-        with pytest.raises(error_type) as exc:
-            self.catalogue_item_repository.create(self._catalogue_item_in)
-        self._create_exception = exc
-
     def check_create_success(self):
         """Checks that a prior call to `call_create` worked as expected."""
 
@@ -143,18 +130,6 @@ class CreateDSL(CatalogueItemRepoDSL):
             catalogue_item_in_data, session=self.mock_session
         )
         assert self._created_catalogue_item == self._expected_catalogue_item_out
-
-    def check_create_failed_with_exception(self, message: str) -> None:
-        """
-        Checks that a prior call to `call_create_expecting_error` worked as expected, raising an exception
-        with the correct message.
-
-        :param message: Expected message of the raised exception.
-        """
-
-        self.catalogue_items_collection.insert_one.assert_not_called()
-
-        assert str(self._create_exception.value) == message
 
 
 class TestCreate(CreateDSL):

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -2,17 +2,21 @@
 Unit tests for the `ItemRepo` repository.
 """
 
-from test.mock_data import ITEM_IN_DATA_REQUIRED_VALUES_ONLY, SYSTEM_IN_DATA_NO_PARENT_A
+from test.mock_data import (ITEM_IN_DATA_A, ITEM_IN_DATA_REQUIRED_VALUES_ONLY,
+                            SYSTEM_IN_DATA_NO_PARENT_A)
 from test.unit.repositories.conftest import RepositoryTestHelpers
-from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME, MOCK_PROPERTY_A_INFO
+from test.unit.repositories.mock_models import (MOCK_CREATED_MODIFIED_TIME,
+                                                MOCK_PROPERTY_A_INFO)
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from bson import ObjectId
 
-from inventory_management_system_api.core.custom_object_id import CustomObjectId
-from inventory_management_system_api.core.exceptions import InvalidObjectIdError, MissingRecordError
+from inventory_management_system_api.core.custom_object_id import \
+    CustomObjectId
+from inventory_management_system_api.core.exceptions import (
+    InvalidObjectIdError, MissingRecordError)
 from inventory_management_system_api.models.catalogue_item import PropertyIn
 from inventory_management_system_api.models.item import ItemIn, ItemOut
 from inventory_management_system_api.models.system import SystemIn
@@ -256,469 +260,296 @@ class TestGet(GetDSL):
         self.check_get_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
 
-# FULL_ITEM_INFO = {
-#     "purchase_order_number": None,
-#     "is_defective": False,
-#     "warranty_end_date": "2015-11-15T23:59:59Z",
-#     "asset_number": None,
-#     "serial_number": "xyz123",
-#     "delivered_date": "2012-12-05T12:00:00Z",
-#     "notes": "Test notes",
-#     "properties": [{"id": str(ObjectId()), "name": "Property A", "value": 21, "unit": "mm"}],
-# }
-# # pylint: enable=duplicate-code
-
-
-# def test_delete(test_helpers, database_mock, item_repository):
-#     """
-#     Test deleting an item.
-
-#     Verify that the `delete` method properly handles the deletion of an item by ID.
-#     """
-#     item_id = str(ObjectId())
-#     session = MagicMock()
-
-#     # Mock `delete_one` to return that one document has been deleted
-#     test_helpers.mock_delete_one(database_mock.items, 1)
-
-#     item_repository.delete(item_id, session=session)
-
-#     database_mock.items.delete_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=session)
-
-
-# def test_delete_with_invalid_id(item_repository):
-#     """
-#     Test deleting an item with an invalid ID.
-
-#     Verify that the `delete` method properly handles the deletion of an item with an invalid ID.
-#     """
-#     with pytest.raises(InvalidObjectIdError) as exc:
-#         item_repository.delete("invalid")
-#     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
-
-
-# def test_delete_with_non_existent_id(test_helpers, database_mock, item_repository):
-#     """
-#     Test deleting an item with an invalid ID.
-
-#     Verify that the `delete` method properly handles the deletion of an item with a non-existent ID.
-#     """
-#     item_id = str(ObjectId())
-
-#     # Mock `delete_one` to return that no document has been deleted
-#     test_helpers.mock_delete_one(database_mock.items, 0)
-
-#     with pytest.raises(MissingRecordError) as exc:
-#         item_repository.delete(item_id)
-#     assert str(exc.value) == f"No item found with ID: {item_id}"
-#     database_mock.items.delete_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=None)
-
-
-# def test_list(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items.
-
-#     Verify that the `list` method properly handles the retrieval of items
-#     """
-#     # pylint: disable=duplicate-code
-#     item_a = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-
-#     item_b = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-#     # pylint: enable=duplicate-code
-#     session = MagicMock()
-
-#     # Mock `find` to return a list of item documents
-#     test_helpers.mock_find(
-#         database_mock.items,
-#         [
-#             {
-#                 **FULL_ITEM_INFO,
-#                 **MOCK_CREATED_MODIFIED_TIME,
-#                 "_id": CustomObjectId(item_a.id),
-#                 "catalogue_item_id": CustomObjectId(item_a.catalogue_item_id),
-#                 "system_id": CustomObjectId(item_a.system_id),
-#                 "usage_status_id": CustomObjectId(item_a.usage_status_id),
-#                 "usage_status": item_a.usage_status,
-#             },
-#             {
-#                 **FULL_ITEM_INFO,
-#                 **MOCK_CREATED_MODIFIED_TIME,
-#                 "_id": CustomObjectId(item_b.id),
-#                 "catalogue_item_id": CustomObjectId(item_b.catalogue_item_id),
-#                 "system_id": CustomObjectId(item_b.system_id),
-#                 "usage_status_id": CustomObjectId(item_b.usage_status_id),
-#                 "usage_status": item_b.usage_status,
-#             },
-#         ],
-#     )
-
-#     retrieved_item = item_repository.list(None, None, session=session)
-
-#     database_mock.items.find.assert_called_once_with({}, session=session)
-#     assert retrieved_item == [item_a, item_b]
-
-
-# def test_list_with_system_id_filter(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items based on the provided system ID filter.
-
-#     Verify that the `list` method properly handles the retrieval of items based on
-#     the provided system ID filter
-#     """
-#     # pylint: disable=duplicate-code
-#     item = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-#     session = MagicMock()
-#     # pylint: enable=duplicate-code
-
-#     # Mock `find` to return a list of item documents
-#     test_helpers.mock_find(
-#         database_mock.items,
-#         [
-#             {
-#                 **FULL_ITEM_INFO,
-#                 **MOCK_CREATED_MODIFIED_TIME,
-#                 "_id": CustomObjectId(item.id),
-#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-#                 "system_id": CustomObjectId(item.system_id),
-#                 "usage_status_id": CustomObjectId(item.usage_status_id),
-#                 "usage_status": item.usage_status,
-#             }
-#         ],
-#     )
-
-#     retrieved_item = item_repository.list(item.system_id, None, session=session)
-
-#     database_mock.items.find.assert_called_once_with({"system_id": CustomObjectId(item.system_id)}, session=session)
-#     assert retrieved_item == [item]
-
-
-# def test_list_with_system_id_filter_no_matching_results(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items based on the provided system ID filter when there are no matching results in
-#     the database.
-
-#     Verify the `list` method properly handles the retrieval of items based on the provided
-#     system ID filter
-#     """
-#     session = MagicMock()
-
-#     # Mock `find` to return an empty list of item documents
-#     test_helpers.mock_find(database_mock.items, [])
-
-#     system_id = str(ObjectId())
-#     retrieved_items = item_repository.list(system_id, None, session=session)
-
-#     database_mock.items.find.assert_called_once_with({"system_id": CustomObjectId(system_id)}, session=session)
-#     assert retrieved_items == []
-
-
-# def test_list_with_invalid_system_id_filter(item_repository):
-#     """
-#     Test getting an item with an invalid system ID filter
-
-#     Verify that the `list` method properly handles the retrieval of items with the provided
-#     ID filter
-#     """
-#     with pytest.raises(InvalidObjectIdError) as exc:
-#         item_repository.list("Invalid", None)
-#     assert str(exc.value) == "Invalid ObjectId value 'Invalid'"
-
-
-# def test_list_with_catalogue_item_id_filter(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items based on the provided catalogue item ID filter.
-
-#     Verify that the `list` method properly handles the retrieval of items based on
-#     the provided catalogue item ID filter
-#     """
-#     # pylint: disable=duplicate-code
-#     item = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-#     session = MagicMock()
-#     # pylint: enable=duplicate-code
-
-#     # Mock `find` to return a list of item documents
-#     test_helpers.mock_find(
-#         database_mock.items,
-#         [
-#             {
-#                 **FULL_ITEM_INFO,
-#                 **MOCK_CREATED_MODIFIED_TIME,
-#                 "_id": CustomObjectId(item.id),
-#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-#                 "system_id": CustomObjectId(item.system_id),
-#                 "usage_status_id": CustomObjectId(item.usage_status_id),
-#                 "usage_status": item.usage_status,
-#             }
-#         ],
-#     )
-
-#     retrieved_item = item_repository.list(None, item.catalogue_item_id, session=session)
-
-#     database_mock.items.find.assert_called_once_with(
-#         {"catalogue_item_id": CustomObjectId(item.catalogue_item_id)}, session=session
-#     )
-#     assert retrieved_item == [item]
-
-
-# def test_with_catalogue_item_id_filter_no_matching_results(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items based on the provided catalogue item ID filter when there are no matching results in
-#     the database.
-
-#     Verify the `list` method properly handles the retrieval of items based on the provided
-#     catalogue item ID filter
-#     """
-#     session = MagicMock()
-
-#     # Mock `find` to return an empty list of item documents
-#     test_helpers.mock_find(database_mock.items, [])
-
-#     catalogue_item_id = str(ObjectId())
-#     retrieved_items = item_repository.list(None, catalogue_item_id, session=session)
-
-#     database_mock.items.find.assert_called_once_with(
-#         {"catalogue_item_id": CustomObjectId(catalogue_item_id)}, session=session
-#     )
-#     assert retrieved_items == []
-
-
-# def test_list_with_invalid_catalogue_item_id(item_repository):
-#     """
-#     Test getting an item with an invalid catalogue item ID filter
-
-#     Verify that the `list` method properly handles the retrieval of items with the provided
-#     ID filter
-#     """
-#     with pytest.raises(InvalidObjectIdError) as exc:
-#         item_repository.list(None, "Invalid")
-#     assert str(exc.value) == "Invalid ObjectId value 'Invalid'"
-
-
-# def test_list_with_both_system_catalogue_item_id_filters(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting an item with both system and catalogue item id filters.
-
-#     Verify that the `list` method properly handles the retrieval of items with the provided ID filters
-#     """
-#     # pylint: disable=duplicate-code
-#     item = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-#     session = MagicMock()
-#     # pylint: enable=duplicate-code
-
-#     # Mock `find` to return a list of item documents
-#     test_helpers.mock_find(
-#         database_mock.items,
-#         [
-#             {
-#                 **FULL_ITEM_INFO,
-#                 **MOCK_CREATED_MODIFIED_TIME,
-#                 "_id": CustomObjectId(item.id),
-#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-#                 "system_id": CustomObjectId(item.system_id),
-#                 "usage_status_id": CustomObjectId(item.usage_status_id),
-#                 "usage_status": item.usage_status,
-#             }
-#         ],
-#     )
-
-#     retrieved_item = item_repository.list(item.system_id, item.catalogue_item_id, session=session)
-
-#     database_mock.items.find.assert_called_once_with(
-#         {"system_id": CustomObjectId(item.system_id), "catalogue_item_id": CustomObjectId(item.catalogue_item_id)},
-#         session=session,
-#     )
-#     assert retrieved_item == [item]
-
-
-# def test_list_no_matching_result_both_filters(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items based on the provided system and catalogue item ID filters when there are no matching results in
-#     the database.
-
-#     Verify the `list` method properly handles the retrieval of items based on the provided
-#     system and catalogue item ID filters
-#     """
-#     session = MagicMock()
-
-#     # Mock `find` to return an empty list of item documents
-#     test_helpers.mock_find(database_mock.items, [])
-
-#     system_id = str(ObjectId())
-#     catalogue_item_id = str(ObjectId())
-#     retrieved_items = item_repository.list(system_id, catalogue_item_id, session=session)
-
-#     database_mock.items.find.assert_called_once_with(
-#         {"system_id": CustomObjectId(system_id), "catalogue_item_id": CustomObjectId(catalogue_item_id)},
-#         session=session,
-#     )
-#     assert retrieved_items == []
-
-
-# def test_list_two_filters_no_matching_results(test_helpers, database_mock, item_repository):
-#     """
-#     Test getting items based on the provided system and catalogue item ID filters when there are no matching results for
-#     one of the filters in the database.
-
-#     Verify the `list` method properly handles the retrieval of items based on the provided
-#     system and catalogue item ID filters
-#     """
-#     # pylint: disable=duplicate-code
-#     item = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-#     session = MagicMock()
-#     # pylint: enable=duplicate-code
-
-#     # Mock `find` to return a list of item documents
-#     test_helpers.mock_find(
-#         database_mock.items,
-#         [],
-#     )
-
-#     # catalogue item id no matching results
-#     rd_catalogue_item_id = str(ObjectId())
-#     retrieved_item = item_repository.list(item.system_id, rd_catalogue_item_id, session=session)
-
-#     database_mock.items.find.assert_called_with(
-#         {"system_id": CustomObjectId(item.system_id), "catalogue_item_id": CustomObjectId(rd_catalogue_item_id)},
-#         session=session,
-#     )
-#     assert retrieved_item == []
-
-#     # # Mock `find` to return a list of item documents
-#     test_helpers.mock_find(
-#         database_mock.items,
-#         [],
-#     )
-
-#     # system id no matching results
-#     rd_system_id = str(ObjectId())
-#     retrieved_item = item_repository.list(rd_system_id, item.catalogue_item_id, session=session)
-
-#     database_mock.items.find.assert_called_with(
-#         {"system_id": CustomObjectId(rd_system_id), "catalogue_item_id": CustomObjectId(item.catalogue_item_id)},
-#         session=session,
-#     )
-#     assert retrieved_item == []
-
-
-# def test_update(test_helpers, database_mock, item_repository):
-#     """
-#     Test updating an item.
-
-#     Verify that the `update` method properly handles the item to be updated.
-#     """
-#     # pylint: disable=duplicate-code
-#     item = ItemOut(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         id=str(ObjectId()),
-#         catalogue_item_id=str(ObjectId()),
-#         system_id=str(ObjectId()),
-#         usage_status_id=str(ObjectId()),
-#         usage_status="New",
-#     )
-#     session = MagicMock()
-#     # pylint: enable=duplicate-code
-
-#     # Mock `update_one` to return an object for the updated item document
-#     test_helpers.mock_update_one(database_mock.items)
-#     # Mock `find_one` to return the updated catalogue item document
-#     test_helpers.mock_find_one(
-#         database_mock.items,
-#         {
-#             **FULL_ITEM_INFO,
-#             **MOCK_CREATED_MODIFIED_TIME,
-#             "_id": CustomObjectId(item.id),
-#             "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-#             "system_id": CustomObjectId(item.system_id),
-#             "usage_status_id": CustomObjectId(item.usage_status_id),
-#             "usage_status": item.usage_status,
-#         },
-#     )
-
-#     item_in = ItemIn(
-#         **FULL_ITEM_INFO,
-#         **MOCK_CREATED_MODIFIED_TIME,
-#         catalogue_item_id=item.catalogue_item_id,
-#         system_id=item.system_id,
-#         usage_status_id=item.usage_status_id,
-#         usage_status=item.usage_status,
-#     )
-#     updated_item = item_repository.update(item.id, item_in, session=session)
-
-#     database_mock.items.update_one.assert_called_once_with(
-#         {"_id": CustomObjectId(item.id)},
-#         {
-#             "$set": {
-#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-#                 **item_in.model_dump(by_alias=True),
-#             }
-#         },
-#         session=session,
-#     )
-#     database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item.id)}, session=session)
-#     assert updated_item == item
-
-
-# def test_update_with_invalid_id(item_repository):
-#     """
-#     Test updating an item with an invalid ID.
-
-#     Verify that the `update` method properly handles the update of an item with an invalid ID.
-#     """
-#     updated_item = MagicMock()
-#     item_id = "invalid"
-
-#     with pytest.raises(InvalidObjectIdError) as exc:
-#         item_repository.update(item_id, updated_item)
-#     assert str(exc.value) == f"Invalid ObjectId value '{item_id}'"
+class ListDSL(ItemRepoDSL):
+    """Base class for `list` tests."""
+
+    _expected_items_out: list[ItemOut]
+    _system_id_filter: Optional[str]
+    _catalogue_item_id_filter: Optional[str]
+    _obtained_items_out: list[ItemOut]
+
+    def mock_list(self, items_in_data: list[dict]) -> None:
+        """Mocks database methods appropriately to test the `list` repo method
+
+        :param items_in_data: List of dictionaries containing the item data as would be required for a `ItemIn` database
+                              model (i.e. no ID or created and modified times required)
+        """
+
+        self._expected_items_out = [
+            ItemOut(**ItemIn(**item_in_data).model_dump(by_alias=True), id=ObjectId()) for item_in_data in items_in_data
+        ]
+
+        RepositoryTestHelpers.mock_find(
+            self.items_collection, [item_out.model_dump() for item_out in self._expected_items_out]
+        )
+
+    def call_list(self, system_id: Optional[str], catalogue_item_id: Optional[str]) -> None:
+        """
+        Calls the `ItemRepo` `list` method.
+
+        :param system_id: ID of the system to query by, or `None`.
+        :param catalogue_item_id: ID of the catalogue item to query by, or `None`.
+        """
+
+        self._system_id_filter = system_id
+        self._catalogue_item_id_filter = catalogue_item_id
+
+        self._obtained_items_out = self.item_repository.list(
+            system_id=system_id, catalogue_item_id=catalogue_item_id, session=self.mock_session
+        )
+
+    def check_list_success(self) -> None:
+        """Checks that a prior call to `call_list` worked as expected."""
+
+        expected_query = {}
+        if self._system_id_filter:
+            expected_query["system_id"] = CustomObjectId(self._system_id_filter)
+        if self._catalogue_item_id_filter:
+            expected_query["catalogue_item_id"] = CustomObjectId(self._catalogue_item_id_filter)
+
+        self.items_collection.find.assert_called_once_with(expected_query, session=self.mock_session)
+
+        assert self._obtained_items_out == self._expected_items_out
+
+
+class TestList(ListDSL):
+    """Tests for listing items."""
+
+    def test_list(self):
+        """Test listing all items."""
+
+        self.mock_list([ITEM_IN_DATA_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_A])
+        self.call_list(system_id=None, catalogue_item_id=None)
+        self.check_list_success()
+
+    def test_list_with_system_id_filter(self):
+        """Test listing all items with a given `system_id`."""
+
+        self.mock_list([ITEM_IN_DATA_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_A])
+        self.call_list(system_id=str(ObjectId()), catalogue_item_id=None)
+        self.check_list_success()
+
+    def test_list_with_catalogue_category_id_filter(self):
+        """Test listing all items with a given `catalogue_category_id`."""
+
+        self.mock_list([ITEM_IN_DATA_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_A])
+        self.call_list(system_id=None, catalogue_item_id=str(ObjectId()))
+        self.check_list_success()
+
+    def test_list_with_system_id_and_catalogue_category_id_with_no_results(self):
+        """Test listing all items with a `system_id` and `catalogue_category_id` filter returning no results."""
+
+        self.mock_list([])
+        self.call_list(system_id=str(ObjectId()), catalogue_item_id=str(ObjectId()))
+        self.check_list_success()
+
+    # TODO: Should these have invalid_id ones after all? Have in update - may effect other repo unit tests though
+
+
+class UpdateDSL(ItemRepoDSL):
+    """Base class for `update` tests."""
+
+    _item_in: ItemIn
+    _expected_item_out: ItemOut
+    _updated_item_id: str
+    _updated_item: ItemOut
+    _update_exception: pytest.ExceptionInfo
+
+    def set_update_data(self, new_item_in_data: dict):
+        """
+        Assigns the update data to use during a call to `call_update`.
+
+        :param new_item_in_data: New item data as would be required for a `ItemIn` database model to supply to the
+                                 `ItemRepo` `update` method.
+        """
+        self._item_in = ItemIn(**new_item_in_data)
+
+    def mock_update(
+        self,
+        item_id: str,
+        new_item_in_data: dict,
+    ) -> None:
+        """
+        Mocks database methods appropriately to test the `update` repo method.
+
+        :param item_id: ID of the item that will be updated.
+        :param new_item_in_data: Dictionary containing the new item data as would be required for a `ItemIn` database
+                                 model (i.e. no ID or created and modified times required).
+        """
+        self.set_update_data(new_item_in_data)
+
+        # Final item after update
+        self._expected_item_out = ItemOut(**self._item_in.model_dump(), id=CustomObjectId(item_id))
+        RepositoryTestHelpers.mock_find_one(self.items_collection, self._expected_item_out.model_dump(by_alias=True))
+
+    def call_update(self, item_id: str) -> None:
+        """
+        Calls the `ItemRepo` `update` method with the appropriate data from a prior call to `mock_update`
+        (or `set_update_data`).
+
+        :param item_id: ID of the catalogue item to be updated.
+        """
+
+        self._updated_item_id = item_id
+        self._updated_item = self.item_repository.update(item_id, self._item_in, session=self.mock_session)
+
+    def call_update_expecting_error(self, item_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ItemRepo` `update` method with the appropriate data from a prior call to `mock_update`
+        (or `set_update_data`) while expecting an error to be raised.
+
+        :param item_id: ID of the item to be updated.
+        :param error_type: Expected exception to be raised.
+        """
+
+        with pytest.raises(error_type) as exc:
+            self.item_repository.update(item_id, self._item_in)
+        self._update_exception = exc
+
+    def check_update_success(self) -> None:
+        """Checks that a prior call to `call_update` worked as expected."""
+
+        self.items_collection.update_one.assert_called_once_with(
+            {
+                "_id": CustomObjectId(self._updated_item_id),
+            },
+            {
+                "$set": self._item_in.model_dump(by_alias=True),
+            },
+            session=self.mock_session,
+        )
+
+        assert self._updated_item == self._expected_item_out
+
+    def check_update_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_update_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.items_collection.update_one.assert_not_called()
+
+        assert str(self._update_exception.value) == message
+
+
+class TestUpdate(UpdateDSL):
+    """Tests for updating an item."""
+
+    def test_update(self):
+        """Test updating an item."""
+
+        item_id = str(ObjectId())
+
+        self.mock_update(item_id, ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.call_update(item_id)
+        self.check_update_success()
+
+    def test_update_with_invalid_id(self):
+        """Test updating an item with an invalid ID."""
+
+        item_id = "invalid-id"
+
+        self.set_update_data(ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.call_update_expecting_error(item_id, InvalidObjectIdError)
+        self.check_update_failed_with_exception("Invalid ObjectId value 'invalid-id'")
+
+
+class DeleteDSL(ItemRepoDSL):
+    """Base class for `delete` tests."""
+
+    _delete_item_id: str
+    _delete_exception: pytest.ExceptionInfo
+
+    def mock_delete(
+        self,
+        deleted_count: int,
+    ) -> None:
+        """
+        Mocks database methods appropriately to test the `delete` repo method.
+
+        :param deleted_count: Number of documents deleted successfully.
+        """
+
+        RepositoryTestHelpers.mock_delete_one(self.items_collection, deleted_count)
+
+    def call_delete(self, item_id: str) -> None:
+        """
+        Calls the `ItemRepo` `delete` method.
+
+        :param item_id: ID of the item to be deleted.
+        """
+
+        self._delete_item_id = item_id
+        self.item_repository.delete(item_id, session=self.mock_session)
+
+    def call_delete_expecting_error(self, item_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ItemRepo` `delete` method while expecting an error to be raised.
+
+        :param item_id: ID of the catalogue item to be deleted.
+        :param error_type: Expected exception to be raised.
+        """
+
+        self._delete_item_id = item_id
+        with pytest.raises(error_type) as exc:
+            self.item_repository.delete(item_id)
+        self._delete_exception = exc
+
+    def check_delete_success(self) -> None:
+        """Checks that a prior call to `call_delete` worked as expected."""
+
+        self.items_collection.delete_one.assert_called_once_with(
+            {"_id": CustomObjectId(self._delete_item_id)}, session=self.mock_session
+        )
+
+    def check_delete_failed_with_exception(self, message: str, expecting_delete_one_called: bool = False) -> None:
+        """
+        Checks that a prior call to `call_delete_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        :param expecting_delete_one_called: Whether the `delete_one` method is expected to be called or not.
+        """
+
+        if not expecting_delete_one_called:
+            self.items_collection.delete_one.assert_not_called()
+        else:
+            self.items_collection.delete_one.assert_called_once_with(
+                {"_id": CustomObjectId(self._delete_item_id)}, session=None
+            )
+
+        assert str(self._delete_exception.value) == message
+
+class TestDelete(DeleteDSL):
+    """Tests for deleting an item."""
+
+    def test_delete(self):
+        """Test deleting an item."""
+
+        self.mock_delete(deleted_count=1)
+        self.call_delete(str(ObjectId()))
+        self.check_delete_success()
+
+    def test_delete_non_existent_id(self):
+        """Test deleting an item with a non-existent ID."""
+
+        item_id = str(ObjectId())
+
+        self.mock_delete(deleted_count=0)
+        self.call_delete_expecting_error(item_id, MissingRecordError)
+        self.check_delete_failed_with_exception(
+            f"No item found with ID: {item_id}", expecting_delete_one_called=True
+        )
+
+    def test_delete_invalid_id(self):
+        """Test deleting an item with an invalid ID."""
+
+        item_id = "invalid-id"
+
+        self.call_delete_expecting_error(item_id, InvalidObjectIdError)
+        self.check_delete_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
 
 # @patch("inventory_management_system_api.repositories.item.datetime")

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -2,8 +2,11 @@
 Unit tests for the `ItemRepo` repository.
 """
 
+from test.mock_data import ITEM_IN_DATA_REQUIRED_VALUES_ONLY, SYSTEM_IN_DATA_NO_PARENT_A
+from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME, MOCK_PROPERTY_A_INFO
-from unittest.mock import MagicMock, patch
+from typing import Optional
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from bson import ObjectId
@@ -12,677 +15,767 @@ from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.exceptions import InvalidObjectIdError, MissingRecordError
 from inventory_management_system_api.models.catalogue_item import PropertyIn
 from inventory_management_system_api.models.item import ItemIn, ItemOut
-
-# pylint: disable=duplicate-code
-FULL_SYSTEM_A_INFO = {
-    "parent_id": None,
-    "name": "System A",
-    "description": "System description",
-    "location": "Test location",
-    "owner": "Me",
-    "importance": "low",
-    "code": "system-a",
-}
-
-FULL_ITEM_INFO = {
-    "purchase_order_number": None,
-    "is_defective": False,
-    "warranty_end_date": "2015-11-15T23:59:59Z",
-    "asset_number": None,
-    "serial_number": "xyz123",
-    "delivered_date": "2012-12-05T12:00:00Z",
-    "notes": "Test notes",
-    "properties": [{"id": str(ObjectId()), "name": "Property A", "value": 21, "unit": "mm"}],
-}
-# pylint: enable=duplicate-code
+from inventory_management_system_api.models.system import SystemIn
+from inventory_management_system_api.repositories.item import ItemRepo
 
 
-def test_create(test_helpers, database_mock, item_repository):
-    """
-    Test creating an item.
-    """
-    # pylint: disable=duplicate-code
-    item_in = ItemIn(
-        **FULL_ITEM_INFO,
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    item_info = item_in.model_dump(by_alias=True)
-    item_out = ItemOut(
-        **item_info,
-        id=str(ObjectId()),
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
+class ItemRepoDSL:
+    """Base class for `ItemRepo` unit tests."""
 
-    # Mock `find_one` to return a system
-    test_helpers.mock_find_one(
-        database_mock.systems,
-        {
-            **FULL_SYSTEM_A_INFO,
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(item_out.system_id),
-        },
-    )
-    # Mock `insert_one` to return an object for the inserted item document
-    test_helpers.mock_insert_one(database_mock.items, CustomObjectId(item_out.id))
-    # Mock `find_one` to return the inserted item document
-    test_helpers.mock_find_one(
-        database_mock.items,
-        {
-            **item_info,
-            "_id": CustomObjectId(item_out.id),
-        },
-    )
+    mock_database: Mock
+    item_repository: ItemRepo
+    items_collection: Mock
+    systems_collection: Mock
 
-    created_item = item_repository.create(item_in, session=session)
+    mock_session = MagicMock()
 
-    database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(item_out.system_id)}, session=session)
-    database_mock.items.insert_one.assert_called_once_with(item_in.model_dump(by_alias=True), session=session)
-    assert created_item == item_out
+    @pytest.fixture(autouse=True)
+    def setup(self, database_mock):
+        """Setup fixtures"""
+
+        self.mock_database = database_mock
+        self.item_repository = ItemRepo(database_mock)
+        self.items_collection = database_mock.items
+        self.systems_collection = database_mock.systems
+
+        self.mock_session = MagicMock()
 
 
-def test_create_with_non_existent_system_id(test_helpers, database_mock, item_repository):
-    """
-    Test creating an item with a non-existent system ID.
-    """
-    system_id = str(ObjectId())
+class CreateDSL(ItemRepoDSL):
+    """Base class for `create` tests."""
 
-    # Mock `find_one` to return a system
-    test_helpers.mock_find_one(database_mock.systems, None)
+    _item_in: ItemIn
+    _expected_item_out: ItemOut
+    _created_item: ItemOut
+    _create_exception: pytest.ExceptionInfo
 
-    with pytest.raises(MissingRecordError) as exc:
-        item_repository.create(
-            ItemIn(
-                **FULL_ITEM_INFO,
-                catalogue_item_id=str(ObjectId()),
-                system_id=system_id,
-                usage_status_id=str(ObjectId()),
-                usage_status="New",
-            )
+    def mock_create(
+        self,
+        item_in_data: dict,
+        system_in_data: Optional[dict] = None,
+    ) -> None:
+        """Mocks database methods appropriately to test the `create` repo method.
+
+        :param item_in_data: Dictionary containing the catalogue item data as would be required for a `ItemIn` database
+                             model (i.e. no ID or created and modified times required).
+        :param system_in_data: Either `None` or a dictionary system data as would be required for a `SystemIn` database
+                               model.
+        """
+
+        inserted_item_id = CustomObjectId(str(ObjectId()))
+
+        # Pass through `ItemIn` first as need creation and modified times
+        self._item_in = ItemIn(**item_in_data)
+
+        self._expected_item_out = ItemOut(**self._item_in.model_dump(by_alias=True), id=inserted_item_id)
+
+        RepositoryTestHelpers.mock_find_one(
+            self.systems_collection,
+            (
+                {
+                    **SystemIn(**system_in_data).model_dump(),
+                    "_id": ObjectId(),
+                }
+                if system_in_data
+                else None
+            ),
         )
 
-    database_mock.systems.find_one.assert_called_once_with({"_id": CustomObjectId(system_id)}, session=None)
-    database_mock.items.insert_one.assert_not_called()
-    assert str(exc.value) == f"No system found with ID: {system_id}"
-
-
-def test_delete(test_helpers, database_mock, item_repository):
-    """
-    Test deleting an item.
-
-    Verify that the `delete` method properly handles the deletion of an item by ID.
-    """
-    item_id = str(ObjectId())
-    session = MagicMock()
-
-    # Mock `delete_one` to return that one document has been deleted
-    test_helpers.mock_delete_one(database_mock.items, 1)
-
-    item_repository.delete(item_id, session=session)
-
-    database_mock.items.delete_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=session)
-
-
-def test_delete_with_invalid_id(item_repository):
-    """
-    Test deleting an item with an invalid ID.
-
-    Verify that the `delete` method properly handles the deletion of an item with an invalid ID.
-    """
-    with pytest.raises(InvalidObjectIdError) as exc:
-        item_repository.delete("invalid")
-    assert str(exc.value) == "Invalid ObjectId value 'invalid'"
-
-
-def test_delete_with_non_existent_id(test_helpers, database_mock, item_repository):
-    """
-    Test deleting an item with an invalid ID.
-
-    Verify that the `delete` method properly handles the deletion of an item with a non-existent ID.
-    """
-    item_id = str(ObjectId())
-
-    # Mock `delete_one` to return that no document has been deleted
-    test_helpers.mock_delete_one(database_mock.items, 0)
-
-    with pytest.raises(MissingRecordError) as exc:
-        item_repository.delete(item_id)
-    assert str(exc.value) == f"No item found with ID: {item_id}"
-    database_mock.items.delete_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=None)
-
-
-def test_list(test_helpers, database_mock, item_repository):
-    """
-    Test getting items.
-
-    Verify that the `list` method properly handles the retrieval of items
-    """
-    # pylint: disable=duplicate-code
-    item_a = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-
-    item_b = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    # pylint: enable=duplicate-code
-    session = MagicMock()
-
-    # Mock `find` to return a list of item documents
-    test_helpers.mock_find(
-        database_mock.items,
-        [
-            {
-                **FULL_ITEM_INFO,
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(item_a.id),
-                "catalogue_item_id": CustomObjectId(item_a.catalogue_item_id),
-                "system_id": CustomObjectId(item_a.system_id),
-                "usage_status_id": CustomObjectId(item_a.usage_status_id),
-                "usage_status": item_a.usage_status,
-            },
-            {
-                **FULL_ITEM_INFO,
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(item_b.id),
-                "catalogue_item_id": CustomObjectId(item_b.catalogue_item_id),
-                "system_id": CustomObjectId(item_b.system_id),
-                "usage_status_id": CustomObjectId(item_b.usage_status_id),
-                "usage_status": item_b.usage_status,
-            },
-        ],
-    )
-
-    retrieved_item = item_repository.list(None, None, session=session)
-
-    database_mock.items.find.assert_called_once_with({}, session=session)
-    assert retrieved_item == [item_a, item_b]
-
-
-def test_list_with_system_id_filter(test_helpers, database_mock, item_repository):
-    """
-    Test getting items based on the provided system ID filter.
-
-    Verify that the `list` method properly handles the retrieval of items based on
-    the provided system ID filter
-    """
-    # pylint: disable=duplicate-code
-    item = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `find` to return a list of item documents
-    test_helpers.mock_find(
-        database_mock.items,
-        [
-            {
-                **FULL_ITEM_INFO,
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(item.id),
-                "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                "system_id": CustomObjectId(item.system_id),
-                "usage_status_id": CustomObjectId(item.usage_status_id),
-                "usage_status": item.usage_status,
-            }
-        ],
-    )
-
-    retrieved_item = item_repository.list(item.system_id, None, session=session)
-
-    database_mock.items.find.assert_called_once_with({"system_id": CustomObjectId(item.system_id)}, session=session)
-    assert retrieved_item == [item]
-
-
-def test_list_with_system_id_filter_no_matching_results(test_helpers, database_mock, item_repository):
-    """
-    Test getting items based on the provided system ID filter when there are no matching results in
-    the database.
-
-    Verify the `list` method properly handles the retrieval of items based on the provided
-    system ID filter
-    """
-    session = MagicMock()
-
-    # Mock `find` to return an empty list of item documents
-    test_helpers.mock_find(database_mock.items, [])
-
-    system_id = str(ObjectId())
-    retrieved_items = item_repository.list(system_id, None, session=session)
-
-    database_mock.items.find.assert_called_once_with({"system_id": CustomObjectId(system_id)}, session=session)
-    assert retrieved_items == []
-
-
-def test_list_with_invalid_system_id_filter(item_repository):
-    """
-    Test getting an item with an invalid system ID filter
-
-    Verify that the `list` method properly handles the retrieval of items with the provided
-    ID filter
-    """
-    with pytest.raises(InvalidObjectIdError) as exc:
-        item_repository.list("Invalid", None)
-    assert str(exc.value) == "Invalid ObjectId value 'Invalid'"
-
-
-def test_list_with_catalogue_item_id_filter(test_helpers, database_mock, item_repository):
-    """
-    Test getting items based on the provided catalogue item ID filter.
-
-    Verify that the `list` method properly handles the retrieval of items based on
-    the provided catalogue item ID filter
-    """
-    # pylint: disable=duplicate-code
-    item = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `find` to return a list of item documents
-    test_helpers.mock_find(
-        database_mock.items,
-        [
-            {
-                **FULL_ITEM_INFO,
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(item.id),
-                "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                "system_id": CustomObjectId(item.system_id),
-                "usage_status_id": CustomObjectId(item.usage_status_id),
-                "usage_status": item.usage_status,
-            }
-        ],
-    )
-
-    retrieved_item = item_repository.list(None, item.catalogue_item_id, session=session)
-
-    database_mock.items.find.assert_called_once_with(
-        {"catalogue_item_id": CustomObjectId(item.catalogue_item_id)}, session=session
-    )
-    assert retrieved_item == [item]
-
-
-def test_with_catalogue_item_id_filter_no_matching_results(test_helpers, database_mock, item_repository):
-    """
-    Test getting items based on the provided catalogue item ID filter when there are no matching results in
-    the database.
-
-    Verify the `list` method properly handles the retrieval of items based on the provided
-    catalogue item ID filter
-    """
-    session = MagicMock()
-
-    # Mock `find` to return an empty list of item documents
-    test_helpers.mock_find(database_mock.items, [])
-
-    catalogue_item_id = str(ObjectId())
-    retrieved_items = item_repository.list(None, catalogue_item_id, session=session)
-
-    database_mock.items.find.assert_called_once_with(
-        {"catalogue_item_id": CustomObjectId(catalogue_item_id)}, session=session
-    )
-    assert retrieved_items == []
-
-
-def test_list_with_invalid_catalogue_item_id(item_repository):
-    """
-    Test getting an item with an invalid catalogue item ID filter
-
-    Verify that the `list` method properly handles the retrieval of items with the provided
-    ID filter
-    """
-    with pytest.raises(InvalidObjectIdError) as exc:
-        item_repository.list(None, "Invalid")
-    assert str(exc.value) == "Invalid ObjectId value 'Invalid'"
-
-
-def test_list_with_both_system_catalogue_item_id_filters(test_helpers, database_mock, item_repository):
-    """
-    Test getting an item with both system and catalogue item id filters.
-
-    Verify that the `list` method properly handles the retrieval of items with the provided ID filters
-    """
-    # pylint: disable=duplicate-code
-    item = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `find` to return a list of item documents
-    test_helpers.mock_find(
-        database_mock.items,
-        [
-            {
-                **FULL_ITEM_INFO,
-                **MOCK_CREATED_MODIFIED_TIME,
-                "_id": CustomObjectId(item.id),
-                "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                "system_id": CustomObjectId(item.system_id),
-                "usage_status_id": CustomObjectId(item.usage_status_id),
-                "usage_status": item.usage_status,
-            }
-        ],
-    )
-
-    retrieved_item = item_repository.list(item.system_id, item.catalogue_item_id, session=session)
-
-    database_mock.items.find.assert_called_once_with(
-        {"system_id": CustomObjectId(item.system_id), "catalogue_item_id": CustomObjectId(item.catalogue_item_id)},
-        session=session,
-    )
-    assert retrieved_item == [item]
-
-
-def test_list_no_matching_result_both_filters(test_helpers, database_mock, item_repository):
-    """
-    Test getting items based on the provided system and catalogue item ID filters when there are no matching results in
-    the database.
-
-    Verify the `list` method properly handles the retrieval of items based on the provided
-    system and catalogue item ID filters
-    """
-    session = MagicMock()
-
-    # Mock `find` to return an empty list of item documents
-    test_helpers.mock_find(database_mock.items, [])
-
-    system_id = str(ObjectId())
-    catalogue_item_id = str(ObjectId())
-    retrieved_items = item_repository.list(system_id, catalogue_item_id, session=session)
-
-    database_mock.items.find.assert_called_once_with(
-        {"system_id": CustomObjectId(system_id), "catalogue_item_id": CustomObjectId(catalogue_item_id)},
-        session=session,
-    )
-    assert retrieved_items == []
-
-
-def test_list_two_filters_no_matching_results(test_helpers, database_mock, item_repository):
-    """
-    Test getting items based on the provided system and catalogue item ID filters when there are no matching results for
-    one of the filters in the database.
-
-    Verify the `list` method properly handles the retrieval of items based on the provided
-    system and catalogue item ID filters
-    """
-    # pylint: disable=duplicate-code
-    item = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `find` to return a list of item documents
-    test_helpers.mock_find(
-        database_mock.items,
-        [],
-    )
-
-    # catalogue item id no matching results
-    rd_catalogue_item_id = str(ObjectId())
-    retrieved_item = item_repository.list(item.system_id, rd_catalogue_item_id, session=session)
-
-    database_mock.items.find.assert_called_with(
-        {"system_id": CustomObjectId(item.system_id), "catalogue_item_id": CustomObjectId(rd_catalogue_item_id)},
-        session=session,
-    )
-    assert retrieved_item == []
-
-    # # Mock `find` to return a list of item documents
-    test_helpers.mock_find(
-        database_mock.items,
-        [],
-    )
-
-    # system id no matching results
-    rd_system_id = str(ObjectId())
-    retrieved_item = item_repository.list(rd_system_id, item.catalogue_item_id, session=session)
-
-    database_mock.items.find.assert_called_with(
-        {"system_id": CustomObjectId(rd_system_id), "catalogue_item_id": CustomObjectId(item.catalogue_item_id)},
-        session=session,
-    )
-    assert retrieved_item == []
-
-
-def test_get(test_helpers, database_mock, item_repository):
-    """
-    Test getting an item
-
-    Verify that the `get` method properly handles the retrieval of an item by ID.
-    """
-    # pylint: disable=duplicate-code
-    item = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `find_one` to return the inserted item document
-    test_helpers.mock_find_one(
-        database_mock.items,
-        {
-            **FULL_ITEM_INFO,
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(item.id),
-            "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-            "system_id": CustomObjectId(item.system_id),
-            "usage_status_id": CustomObjectId(item.usage_status_id),
-            "usage_status": item.usage_status,
-        },
-    )
-
-    retrieved_item = item_repository.get(item.id, session=session)
-
-    database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item.id)}, session=session)
-    assert retrieved_item == item
-
-
-def test_get_with_invalid_id(item_repository):
-    """
-    Test getting an item with an invalid ID.
-
-    Verify the `get` method properly handles the retrieval of an item with an invalid ID.
-    """
-    with pytest.raises(InvalidObjectIdError) as exc:
-        item_repository.get("invalid")
-    assert str(exc.value) == "Invalid ObjectId value 'invalid'"
-
-
-def test_get_with_non_existent_id(test_helpers, database_mock, item_repository):
-    """
-    Test getting an item with a non-existent ID.
-
-    Verify the `get` method properly handles the retrieval of an item with a non-existent ID.
-    """
-    item_id = str(ObjectId())
-
-    # Mock `find_one` to not return a catalogue item document
-    test_helpers.mock_find_one(database_mock.items, None)
-
-    retrieved_item = item_repository.get(item_id)
-
-    assert retrieved_item is None
-    database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=None)
-
-
-def test_update(test_helpers, database_mock, item_repository):
-    """
-    Test updating an item.
-
-    Verify that the `update` method properly handles the item to be updated.
-    """
-    # pylint: disable=duplicate-code
-    item = ItemOut(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        id=str(ObjectId()),
-        catalogue_item_id=str(ObjectId()),
-        system_id=str(ObjectId()),
-        usage_status_id=str(ObjectId()),
-        usage_status="New",
-    )
-    session = MagicMock()
-    # pylint: enable=duplicate-code
-
-    # Mock `update_one` to return an object for the updated item document
-    test_helpers.mock_update_one(database_mock.items)
-    # Mock `find_one` to return the updated catalogue item document
-    test_helpers.mock_find_one(
-        database_mock.items,
-        {
-            **FULL_ITEM_INFO,
-            **MOCK_CREATED_MODIFIED_TIME,
-            "_id": CustomObjectId(item.id),
-            "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-            "system_id": CustomObjectId(item.system_id),
-            "usage_status_id": CustomObjectId(item.usage_status_id),
-            "usage_status": item.usage_status,
-        },
-    )
-
-    item_in = ItemIn(
-        **FULL_ITEM_INFO,
-        **MOCK_CREATED_MODIFIED_TIME,
-        catalogue_item_id=item.catalogue_item_id,
-        system_id=item.system_id,
-        usage_status_id=item.usage_status_id,
-        usage_status=item.usage_status,
-    )
-    updated_item = item_repository.update(item.id, item_in, session=session)
-
-    database_mock.items.update_one.assert_called_once_with(
-        {"_id": CustomObjectId(item.id)},
-        {
-            "$set": {
-                "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
-                **item_in.model_dump(by_alias=True),
-            }
-        },
-        session=session,
-    )
-    database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item.id)}, session=session)
-    assert updated_item == item
-
-
-def test_update_with_invalid_id(item_repository):
-    """
-    Test updating an item with an invalid ID.
-
-    Verify that the `update` method properly handles the update of an item with an invalid ID.
-    """
-    updated_item = MagicMock()
-    item_id = "invalid"
-
-    with pytest.raises(InvalidObjectIdError) as exc:
-        item_repository.update(item_id, updated_item)
-    assert str(exc.value) == f"Invalid ObjectId value '{item_id}'"
-
-
-@patch("inventory_management_system_api.repositories.item.datetime")
-def test_insert_property_to_all_in(datetime_mock, test_helpers, database_mock, item_repository):
-    """
-    Test inserting a property
-
-    Verify that the `insert_property_to_all_matching` method properly handles the insertion of a
-    property
-    """
-    session = MagicMock()
-    catalogue_item_ids = [ObjectId(), ObjectId()]
-    property_in = PropertyIn(**MOCK_PROPERTY_A_INFO)
-
-    # Mock 'update_many'
-    test_helpers.mock_update_many(database_mock.items)
-
-    item_repository.insert_property_to_all_in(catalogue_item_ids, property_in, session=session)
-
-    database_mock.items.update_many.assert_called_once_with(
-        {"catalogue_item_id": {"$in": catalogue_item_ids}},
-        {
-            "$push": {"properties": property_in.model_dump(by_alias=True)},
-            "$set": {"modified_time": datetime_mock.now.return_value},
-        },
-        session=session,
-    )
-
-
-# pylint:disable=duplicate-code
-
-
-@patch("inventory_management_system_api.repositories.item.datetime")
-def test_update_names_of_all_properties_with_id(datetime_mock, test_helpers, database_mock, item_repository):
-    """
-    Test updating the names of all properties with a given id
-
-    Verify that the `update_names_of_all_properties_with_id` method properly handles the update of
-    property names
-    """
-    session = MagicMock()
-    property_id = str(ObjectId())
-    new_property_name = "new property name"
-
-    # Mock 'update_many'
-    test_helpers.mock_update_many(database_mock.items)
-
-    item_repository.update_names_of_all_properties_with_id(property_id, new_property_name, session=session)
-
-    database_mock.items.update_many.assert_called_once_with(
-        {"properties._id": CustomObjectId(property_id)},
-        {
-            "$set": {"properties.$[elem].name": new_property_name, "modified_time": datetime_mock.now.return_value},
-        },
-        array_filters=[{"elem._id": CustomObjectId(property_id)}],
-        session=session,
-    )
-
-
-# pylint:enable=duplicate-code
+        RepositoryTestHelpers.mock_insert_one(self.items_collection, inserted_item_id)
+        RepositoryTestHelpers.mock_find_one(
+            self.items_collection,
+            {**self._item_in.model_dump(by_alias=True), "_id": inserted_item_id},
+        )
+
+    def call_create(self) -> None:
+        """Calls the `ItemRepo` `create` method with the appropriate data from a prior call to `mock_create`."""
+
+        self._created_item = self.item_repository.create(self._item_in, session=self.mock_session)
+
+    def call_create_expecting_error(self, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ItemRepo` `create` method with the appropriate data from a prior call to `mock_create` while
+        expecting an error to be raised.
+
+        :param error_type: Expected exception to be raised.
+        """
+
+        with pytest.raises(error_type) as exc:
+            self.item_repository.create(self._item_in)
+        self._create_exception = exc
+
+    def check_create_success(self):
+        """Checks that a prior call to `call_create` worked as expected."""
+
+        item_in_data = self._item_in.model_dump(by_alias=True)
+
+        self.systems_collection.find_one.assert_called_with({"_id": self._item_in.system_id}, session=self.mock_session)
+
+        self.items_collection.find_one.assert_called_once_with(
+            {"_id": CustomObjectId(self._expected_item_out.id)}, session=self.mock_session
+        )
+
+        # TODO: Move this above line above - final find is after the insert... - Same for other repo tests...
+        self.items_collection.insert_one.assert_called_once_with(item_in_data, session=self.mock_session)
+        assert self._created_item == self._expected_item_out
+
+    def check_create_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_create_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.items_collection.insert_one.assert_not_called()
+
+        assert str(self._create_exception.value) == message
+
+
+class TestCreate(CreateDSL):
+    """Tests for creating an item."""
+
+    def test_create(self):
+        """Test creating an item."""
+
+        self.mock_create(ITEM_IN_DATA_REQUIRED_VALUES_ONLY, system_in_data=SYSTEM_IN_DATA_NO_PARENT_A)
+        self.call_create()
+        self.check_create_success()
+
+    def test_create_with_non_existent_system_id(self):
+        """Test creating an item with a non-existent system ID."""
+
+        self.mock_create(ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.call_create_expecting_error(MissingRecordError)
+        self.check_create_failed_with_exception(
+            f"No system found with ID: {ITEM_IN_DATA_REQUIRED_VALUES_ONLY["system_id"]}"
+        )
+
+
+class GetDSL(ItemRepoDSL):
+    """Base class for `get` tests"""
+
+    _obtained_item_id: str
+    _expected_item_out: Optional[ItemOut]
+    _obtained_item: Optional[ItemOut]
+    _get_exception: pytest.ExceptionInfo
+
+    def mock_get(self, item_id: str, item_in_data: Optional[dict]) -> None:
+        """Mocks database methods appropriately to test the `get` repo method.
+
+        :param item_id: ID of the item to be obtained.
+        :param item_in_data: Either `None` or a Dictionary containing the item data as would be required for a `ItemIn`
+                             database model (i.e. No ID or created and modified times required).
+        """
+
+        self._expected_item_out = (
+            ItemOut(
+                **ItemIn(**item_in_data).model_dump(by_alias=True),
+                id=CustomObjectId(item_id),
+            )
+            if item_in_data
+            else None
+        )
+
+        RepositoryTestHelpers.mock_find_one(
+            self.items_collection,
+            self._expected_item_out.model_dump() if self._expected_item_out else None,
+        )
+
+    def call_get(self, item_id: str) -> None:
+        """
+        Calls the `ItemRepo` `get` method with the appropriate data from a prior call to `mock_get`.
+
+        :param item_id: ID of the item to be obtained.
+        """
+
+        self._obtained_item_id = item_id
+        self._obtained_item = self.item_repository.get(item_id, session=self.mock_session)
+
+    def call_get_expecting_error(self, item_id: str, error_type: type[BaseException]) -> None:
+        """
+        Calls the `ItemRepo` `get` method with the appropriate data from a prior call to `mock_get` while expecting an
+        error to be raised.
+
+        :param item_id: ID of the item to be obtained.
+        :param error_type: Expected exception to be raised.
+        """
+
+        with pytest.raises(error_type) as exc:
+            self.item_repository.get(item_id)
+        self._get_exception = exc
+
+    def check_get_success(self) -> None:
+        """Checks that a prior call to `call_get` worked as expected."""
+
+        self.items_collection.find_one.assert_called_once_with(
+            {"_id": CustomObjectId(self._obtained_item_id)}, session=self.mock_session
+        )
+        assert self._obtained_item == self._expected_item_out
+
+    def check_get_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_get_expecting_error` worked as expected, raising an exception
+        with the correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.items_collection.find_one.assert_not_called()
+
+        assert str(self._get_exception.value) == message
+
+
+class TestGet(GetDSL):
+    """Tests for getting an item."""
+
+    def test_get(self):
+        """Test getting an item."""
+
+        item_id = str(ObjectId())
+
+        self.mock_get(item_id, ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.call_get(item_id)
+        self.check_get_success()
+
+    def test_get_with_non_existent_id(self):
+        """Test getting an item with a non-existent ID."""
+
+        item_id = str(ObjectId())
+
+        self.mock_get(item_id, None)
+        self.call_get(item_id)
+        self.check_get_success()
+
+    def test_get_with_invalid_id(self):
+        """Test getting an item with an invalid ID."""
+
+        item_id = "invalid-id"
+
+        self.call_get_expecting_error(item_id, InvalidObjectIdError)
+        self.check_get_failed_with_exception("Invalid ObjectId value 'invalid-id'")
+
+
+# FULL_ITEM_INFO = {
+#     "purchase_order_number": None,
+#     "is_defective": False,
+#     "warranty_end_date": "2015-11-15T23:59:59Z",
+#     "asset_number": None,
+#     "serial_number": "xyz123",
+#     "delivered_date": "2012-12-05T12:00:00Z",
+#     "notes": "Test notes",
+#     "properties": [{"id": str(ObjectId()), "name": "Property A", "value": 21, "unit": "mm"}],
+# }
+# # pylint: enable=duplicate-code
+
+
+# def test_delete(test_helpers, database_mock, item_repository):
+#     """
+#     Test deleting an item.
+
+#     Verify that the `delete` method properly handles the deletion of an item by ID.
+#     """
+#     item_id = str(ObjectId())
+#     session = MagicMock()
+
+#     # Mock `delete_one` to return that one document has been deleted
+#     test_helpers.mock_delete_one(database_mock.items, 1)
+
+#     item_repository.delete(item_id, session=session)
+
+#     database_mock.items.delete_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=session)
+
+
+# def test_delete_with_invalid_id(item_repository):
+#     """
+#     Test deleting an item with an invalid ID.
+
+#     Verify that the `delete` method properly handles the deletion of an item with an invalid ID.
+#     """
+#     with pytest.raises(InvalidObjectIdError) as exc:
+#         item_repository.delete("invalid")
+#     assert str(exc.value) == "Invalid ObjectId value 'invalid'"
+
+
+# def test_delete_with_non_existent_id(test_helpers, database_mock, item_repository):
+#     """
+#     Test deleting an item with an invalid ID.
+
+#     Verify that the `delete` method properly handles the deletion of an item with a non-existent ID.
+#     """
+#     item_id = str(ObjectId())
+
+#     # Mock `delete_one` to return that no document has been deleted
+#     test_helpers.mock_delete_one(database_mock.items, 0)
+
+#     with pytest.raises(MissingRecordError) as exc:
+#         item_repository.delete(item_id)
+#     assert str(exc.value) == f"No item found with ID: {item_id}"
+#     database_mock.items.delete_one.assert_called_once_with({"_id": CustomObjectId(item_id)}, session=None)
+
+
+# def test_list(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items.
+
+#     Verify that the `list` method properly handles the retrieval of items
+#     """
+#     # pylint: disable=duplicate-code
+#     item_a = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+
+#     item_b = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+#     # pylint: enable=duplicate-code
+#     session = MagicMock()
+
+#     # Mock `find` to return a list of item documents
+#     test_helpers.mock_find(
+#         database_mock.items,
+#         [
+#             {
+#                 **FULL_ITEM_INFO,
+#                 **MOCK_CREATED_MODIFIED_TIME,
+#                 "_id": CustomObjectId(item_a.id),
+#                 "catalogue_item_id": CustomObjectId(item_a.catalogue_item_id),
+#                 "system_id": CustomObjectId(item_a.system_id),
+#                 "usage_status_id": CustomObjectId(item_a.usage_status_id),
+#                 "usage_status": item_a.usage_status,
+#             },
+#             {
+#                 **FULL_ITEM_INFO,
+#                 **MOCK_CREATED_MODIFIED_TIME,
+#                 "_id": CustomObjectId(item_b.id),
+#                 "catalogue_item_id": CustomObjectId(item_b.catalogue_item_id),
+#                 "system_id": CustomObjectId(item_b.system_id),
+#                 "usage_status_id": CustomObjectId(item_b.usage_status_id),
+#                 "usage_status": item_b.usage_status,
+#             },
+#         ],
+#     )
+
+#     retrieved_item = item_repository.list(None, None, session=session)
+
+#     database_mock.items.find.assert_called_once_with({}, session=session)
+#     assert retrieved_item == [item_a, item_b]
+
+
+# def test_list_with_system_id_filter(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items based on the provided system ID filter.
+
+#     Verify that the `list` method properly handles the retrieval of items based on
+#     the provided system ID filter
+#     """
+#     # pylint: disable=duplicate-code
+#     item = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+#     session = MagicMock()
+#     # pylint: enable=duplicate-code
+
+#     # Mock `find` to return a list of item documents
+#     test_helpers.mock_find(
+#         database_mock.items,
+#         [
+#             {
+#                 **FULL_ITEM_INFO,
+#                 **MOCK_CREATED_MODIFIED_TIME,
+#                 "_id": CustomObjectId(item.id),
+#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
+#                 "system_id": CustomObjectId(item.system_id),
+#                 "usage_status_id": CustomObjectId(item.usage_status_id),
+#                 "usage_status": item.usage_status,
+#             }
+#         ],
+#     )
+
+#     retrieved_item = item_repository.list(item.system_id, None, session=session)
+
+#     database_mock.items.find.assert_called_once_with({"system_id": CustomObjectId(item.system_id)}, session=session)
+#     assert retrieved_item == [item]
+
+
+# def test_list_with_system_id_filter_no_matching_results(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items based on the provided system ID filter when there are no matching results in
+#     the database.
+
+#     Verify the `list` method properly handles the retrieval of items based on the provided
+#     system ID filter
+#     """
+#     session = MagicMock()
+
+#     # Mock `find` to return an empty list of item documents
+#     test_helpers.mock_find(database_mock.items, [])
+
+#     system_id = str(ObjectId())
+#     retrieved_items = item_repository.list(system_id, None, session=session)
+
+#     database_mock.items.find.assert_called_once_with({"system_id": CustomObjectId(system_id)}, session=session)
+#     assert retrieved_items == []
+
+
+# def test_list_with_invalid_system_id_filter(item_repository):
+#     """
+#     Test getting an item with an invalid system ID filter
+
+#     Verify that the `list` method properly handles the retrieval of items with the provided
+#     ID filter
+#     """
+#     with pytest.raises(InvalidObjectIdError) as exc:
+#         item_repository.list("Invalid", None)
+#     assert str(exc.value) == "Invalid ObjectId value 'Invalid'"
+
+
+# def test_list_with_catalogue_item_id_filter(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items based on the provided catalogue item ID filter.
+
+#     Verify that the `list` method properly handles the retrieval of items based on
+#     the provided catalogue item ID filter
+#     """
+#     # pylint: disable=duplicate-code
+#     item = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+#     session = MagicMock()
+#     # pylint: enable=duplicate-code
+
+#     # Mock `find` to return a list of item documents
+#     test_helpers.mock_find(
+#         database_mock.items,
+#         [
+#             {
+#                 **FULL_ITEM_INFO,
+#                 **MOCK_CREATED_MODIFIED_TIME,
+#                 "_id": CustomObjectId(item.id),
+#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
+#                 "system_id": CustomObjectId(item.system_id),
+#                 "usage_status_id": CustomObjectId(item.usage_status_id),
+#                 "usage_status": item.usage_status,
+#             }
+#         ],
+#     )
+
+#     retrieved_item = item_repository.list(None, item.catalogue_item_id, session=session)
+
+#     database_mock.items.find.assert_called_once_with(
+#         {"catalogue_item_id": CustomObjectId(item.catalogue_item_id)}, session=session
+#     )
+#     assert retrieved_item == [item]
+
+
+# def test_with_catalogue_item_id_filter_no_matching_results(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items based on the provided catalogue item ID filter when there are no matching results in
+#     the database.
+
+#     Verify the `list` method properly handles the retrieval of items based on the provided
+#     catalogue item ID filter
+#     """
+#     session = MagicMock()
+
+#     # Mock `find` to return an empty list of item documents
+#     test_helpers.mock_find(database_mock.items, [])
+
+#     catalogue_item_id = str(ObjectId())
+#     retrieved_items = item_repository.list(None, catalogue_item_id, session=session)
+
+#     database_mock.items.find.assert_called_once_with(
+#         {"catalogue_item_id": CustomObjectId(catalogue_item_id)}, session=session
+#     )
+#     assert retrieved_items == []
+
+
+# def test_list_with_invalid_catalogue_item_id(item_repository):
+#     """
+#     Test getting an item with an invalid catalogue item ID filter
+
+#     Verify that the `list` method properly handles the retrieval of items with the provided
+#     ID filter
+#     """
+#     with pytest.raises(InvalidObjectIdError) as exc:
+#         item_repository.list(None, "Invalid")
+#     assert str(exc.value) == "Invalid ObjectId value 'Invalid'"
+
+
+# def test_list_with_both_system_catalogue_item_id_filters(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting an item with both system and catalogue item id filters.
+
+#     Verify that the `list` method properly handles the retrieval of items with the provided ID filters
+#     """
+#     # pylint: disable=duplicate-code
+#     item = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+#     session = MagicMock()
+#     # pylint: enable=duplicate-code
+
+#     # Mock `find` to return a list of item documents
+#     test_helpers.mock_find(
+#         database_mock.items,
+#         [
+#             {
+#                 **FULL_ITEM_INFO,
+#                 **MOCK_CREATED_MODIFIED_TIME,
+#                 "_id": CustomObjectId(item.id),
+#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
+#                 "system_id": CustomObjectId(item.system_id),
+#                 "usage_status_id": CustomObjectId(item.usage_status_id),
+#                 "usage_status": item.usage_status,
+#             }
+#         ],
+#     )
+
+#     retrieved_item = item_repository.list(item.system_id, item.catalogue_item_id, session=session)
+
+#     database_mock.items.find.assert_called_once_with(
+#         {"system_id": CustomObjectId(item.system_id), "catalogue_item_id": CustomObjectId(item.catalogue_item_id)},
+#         session=session,
+#     )
+#     assert retrieved_item == [item]
+
+
+# def test_list_no_matching_result_both_filters(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items based on the provided system and catalogue item ID filters when there are no matching results in
+#     the database.
+
+#     Verify the `list` method properly handles the retrieval of items based on the provided
+#     system and catalogue item ID filters
+#     """
+#     session = MagicMock()
+
+#     # Mock `find` to return an empty list of item documents
+#     test_helpers.mock_find(database_mock.items, [])
+
+#     system_id = str(ObjectId())
+#     catalogue_item_id = str(ObjectId())
+#     retrieved_items = item_repository.list(system_id, catalogue_item_id, session=session)
+
+#     database_mock.items.find.assert_called_once_with(
+#         {"system_id": CustomObjectId(system_id), "catalogue_item_id": CustomObjectId(catalogue_item_id)},
+#         session=session,
+#     )
+#     assert retrieved_items == []
+
+
+# def test_list_two_filters_no_matching_results(test_helpers, database_mock, item_repository):
+#     """
+#     Test getting items based on the provided system and catalogue item ID filters when there are no matching results for
+#     one of the filters in the database.
+
+#     Verify the `list` method properly handles the retrieval of items based on the provided
+#     system and catalogue item ID filters
+#     """
+#     # pylint: disable=duplicate-code
+#     item = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+#     session = MagicMock()
+#     # pylint: enable=duplicate-code
+
+#     # Mock `find` to return a list of item documents
+#     test_helpers.mock_find(
+#         database_mock.items,
+#         [],
+#     )
+
+#     # catalogue item id no matching results
+#     rd_catalogue_item_id = str(ObjectId())
+#     retrieved_item = item_repository.list(item.system_id, rd_catalogue_item_id, session=session)
+
+#     database_mock.items.find.assert_called_with(
+#         {"system_id": CustomObjectId(item.system_id), "catalogue_item_id": CustomObjectId(rd_catalogue_item_id)},
+#         session=session,
+#     )
+#     assert retrieved_item == []
+
+#     # # Mock `find` to return a list of item documents
+#     test_helpers.mock_find(
+#         database_mock.items,
+#         [],
+#     )
+
+#     # system id no matching results
+#     rd_system_id = str(ObjectId())
+#     retrieved_item = item_repository.list(rd_system_id, item.catalogue_item_id, session=session)
+
+#     database_mock.items.find.assert_called_with(
+#         {"system_id": CustomObjectId(rd_system_id), "catalogue_item_id": CustomObjectId(item.catalogue_item_id)},
+#         session=session,
+#     )
+#     assert retrieved_item == []
+
+
+# def test_update(test_helpers, database_mock, item_repository):
+#     """
+#     Test updating an item.
+
+#     Verify that the `update` method properly handles the item to be updated.
+#     """
+#     # pylint: disable=duplicate-code
+#     item = ItemOut(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         id=str(ObjectId()),
+#         catalogue_item_id=str(ObjectId()),
+#         system_id=str(ObjectId()),
+#         usage_status_id=str(ObjectId()),
+#         usage_status="New",
+#     )
+#     session = MagicMock()
+#     # pylint: enable=duplicate-code
+
+#     # Mock `update_one` to return an object for the updated item document
+#     test_helpers.mock_update_one(database_mock.items)
+#     # Mock `find_one` to return the updated catalogue item document
+#     test_helpers.mock_find_one(
+#         database_mock.items,
+#         {
+#             **FULL_ITEM_INFO,
+#             **MOCK_CREATED_MODIFIED_TIME,
+#             "_id": CustomObjectId(item.id),
+#             "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
+#             "system_id": CustomObjectId(item.system_id),
+#             "usage_status_id": CustomObjectId(item.usage_status_id),
+#             "usage_status": item.usage_status,
+#         },
+#     )
+
+#     item_in = ItemIn(
+#         **FULL_ITEM_INFO,
+#         **MOCK_CREATED_MODIFIED_TIME,
+#         catalogue_item_id=item.catalogue_item_id,
+#         system_id=item.system_id,
+#         usage_status_id=item.usage_status_id,
+#         usage_status=item.usage_status,
+#     )
+#     updated_item = item_repository.update(item.id, item_in, session=session)
+
+#     database_mock.items.update_one.assert_called_once_with(
+#         {"_id": CustomObjectId(item.id)},
+#         {
+#             "$set": {
+#                 "catalogue_item_id": CustomObjectId(item.catalogue_item_id),
+#                 **item_in.model_dump(by_alias=True),
+#             }
+#         },
+#         session=session,
+#     )
+#     database_mock.items.find_one.assert_called_once_with({"_id": CustomObjectId(item.id)}, session=session)
+#     assert updated_item == item
+
+
+# def test_update_with_invalid_id(item_repository):
+#     """
+#     Test updating an item with an invalid ID.
+
+#     Verify that the `update` method properly handles the update of an item with an invalid ID.
+#     """
+#     updated_item = MagicMock()
+#     item_id = "invalid"
+
+#     with pytest.raises(InvalidObjectIdError) as exc:
+#         item_repository.update(item_id, updated_item)
+#     assert str(exc.value) == f"Invalid ObjectId value '{item_id}'"
+
+
+# @patch("inventory_management_system_api.repositories.item.datetime")
+# def test_insert_property_to_all_in(datetime_mock, test_helpers, database_mock, item_repository):
+#     """
+#     Test inserting a property
+
+#     Verify that the `insert_property_to_all_matching` method properly handles the insertion of a
+#     property
+#     """
+#     session = MagicMock()
+#     catalogue_item_ids = [ObjectId(), ObjectId()]
+#     property_in = PropertyIn(**MOCK_PROPERTY_A_INFO)
+
+#     # Mock 'update_many'
+#     test_helpers.mock_update_many(database_mock.items)
+
+#     item_repository.insert_property_to_all_in(catalogue_item_ids, property_in, session=session)
+
+#     database_mock.items.update_many.assert_called_once_with(
+#         {"catalogue_item_id": {"$in": catalogue_item_ids}},
+#         {
+#             "$push": {"properties": property_in.model_dump(by_alias=True)},
+#             "$set": {"modified_time": datetime_mock.now.return_value},
+#         },
+#         session=session,
+#     )
+
+
+# # pylint:disable=duplicate-code
+
+
+# @patch("inventory_management_system_api.repositories.item.datetime")
+# def test_update_names_of_all_properties_with_id(datetime_mock, test_helpers, database_mock, item_repository):
+#     """
+#     Test updating the names of all properties with a given id
+
+#     Verify that the `update_names_of_all_properties_with_id` method properly handles the update of
+#     property names
+#     """
+#     session = MagicMock()
+#     property_id = str(ObjectId())
+#     new_property_name = "new property name"
+
+#     # Mock 'update_many'
+#     test_helpers.mock_update_many(database_mock.items)
+
+#     item_repository.update_names_of_all_properties_with_id(property_id, new_property_name, session=session)
+
+#     database_mock.items.update_many.assert_called_once_with(
+#         {"properties._id": CustomObjectId(property_id)},
+#         {
+#             "$set": {"properties.$[elem].name": new_property_name, "modified_time": datetime_mock.now.return_value},
+#         },
+#         array_filters=[{"elem._id": CustomObjectId(property_id)}],
+#         session=session,
+#     )
+
+
+# # pylint:enable=duplicate-code

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -9,7 +9,6 @@ from test.mock_data import (
     SYSTEM_IN_DATA_NO_PARENT_A,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
-from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME, MOCK_PROPERTY_A_INFO
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
@@ -61,8 +60,8 @@ class CreateDSL(ItemRepoDSL):
     ) -> None:
         """Mocks database methods appropriately to test the `create` repo method.
 
-        :param item_in_data: Dictionary containing the catalogue item data as would be required for a `ItemIn` database
-                             model (i.e. no ID or created and modified times required).
+        :param item_in_data: Dictionary containing the item data as would be required for a `ItemIn` database model
+                             (i.e. no ID or created and modified times required).
         :param system_in_data: Either `None` or a dictionary system data as would be required for a `SystemIn` database
                                model.
         """
@@ -116,12 +115,11 @@ class CreateDSL(ItemRepoDSL):
 
         self.systems_collection.find_one.assert_called_with({"_id": self._item_in.system_id}, session=self.mock_session)
 
+        self.items_collection.insert_one.assert_called_once_with(item_in_data, session=self.mock_session)
         self.items_collection.find_one.assert_called_once_with(
             {"_id": CustomObjectId(self._expected_item_out.id)}, session=self.mock_session
         )
 
-        # TODO: Move this above line above - final find is after the insert... - Same for other repo tests...
-        self.items_collection.insert_one.assert_called_once_with(item_in_data, session=self.mock_session)
         assert self._created_item == self._expected_item_out
 
     def check_create_failed_with_exception(self, message: str) -> None:
@@ -344,8 +342,6 @@ class TestList(ListDSL):
         self.call_list(system_id=str(ObjectId()), catalogue_item_id=str(ObjectId()))
         self.check_list_success()
 
-    # TODO: Should these have invalid_id ones after all? Have in update - may effect other repo unit tests though
-
 
 class UpdateDSL(ItemRepoDSL):
     """Base class for `update` tests."""
@@ -388,7 +384,7 @@ class UpdateDSL(ItemRepoDSL):
         Calls the `ItemRepo` `update` method with the appropriate data from a prior call to `mock_update`
         (or `set_update_data`).
 
-        :param item_id: ID of the catalogue item to be updated.
+        :param item_id: ID of the item to be updated.
         """
 
         self._updated_item_id = item_id
@@ -489,7 +485,7 @@ class DeleteDSL(ItemRepoDSL):
         """
         Calls the `ItemRepo` `delete` method while expecting an error to be raised.
 
-        :param item_id: ID of the catalogue item to be deleted.
+        :param item_id: ID of the item to be deleted.
         :param error_type: Expected exception to be raised.
         """
 

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -136,11 +136,12 @@ class CreateDSL(ManufacturerRepoDSL):
             # This is the check for the newly inserted manufacturer get
             call({"_id": CustomObjectId(self._expected_manufacturer_out.id)}, session=self.mock_session),
         ]
-        self.manufacturers_collection.find_one.assert_has_calls(expected_find_one_calls)
 
         self.manufacturers_collection.insert_one.assert_called_once_with(
             manufacturer_in_data, session=self.mock_session
         )
+        self.manufacturers_collection.find_one.assert_has_calls(expected_find_one_calls)
+
         assert self._created_manufacturer == self._expected_manufacturer_out
 
     def check_create_failed_with_exception(self, message: str) -> None:

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -121,6 +121,7 @@ class SystemRepoDSL:
 
         :param system_in: `SystemIn` model containing the data about the system.
         :param expected_system_id: Expected `system_id` provided to `is_duplicate_system`.
+        :return: Expected `find_one` calls.
         """
 
         return call(
@@ -216,9 +217,10 @@ class CreateDSL(SystemRepoDSL):
                 session=self.mock_session,
             )
         )
-        self.systems_collection.find_one.assert_has_calls(expected_find_one_calls)
 
         self.systems_collection.insert_one.assert_called_once_with(system_in_data, session=self.mock_session)
+        self.systems_collection.find_one.assert_has_calls(expected_find_one_calls)
+
         assert self._created_system == self._expected_system_out
 
     def check_create_failed_with_exception(self, message: str) -> None:

--- a/test/unit/repositories/test_usage_status.py
+++ b/test/unit/repositories/test_usage_status.py
@@ -2,8 +2,8 @@
 Unit tests for the `UsageStatusRepo` repository
 """
 
+from test.mock_data import ITEM_DATA_REQUIRED_VALUES_ONLY
 from test.unit.repositories.mock_models import MOCK_CREATED_MODIFIED_TIME
-from test.unit.repositories.test_item import FULL_ITEM_INFO
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -237,7 +237,7 @@ def test_delete_usage_status_that_is_part_of_a_catalogue_item(test_helpers, data
     test_helpers.mock_find_one(
         database_mock.items,
         {
-            **FULL_ITEM_INFO,
+            **ITEM_DATA_REQUIRED_VALUES_ONLY,
             "_id": CustomObjectId(str(ObjectId())),
             "catalogue_category_id": CustomObjectId(catalogue_category_id),
             "usage_status_id": CustomObjectId(usage_status_id),


### PR DESCRIPTION
## Description
See #345.

### Notes
- I noticed we test the `system_id` existence in the create, but not in the update (we do that in the service layer) - we may want to change this later for consistency
- Removed `test_list_with_invalid_system_id_filter` none of the other repo tests do invalid id checks
- Removed `test_with_catalogue_item_id_filter_no_matching_results` and `test_list_with_system_id_filter_no_matching_results` and similar - they are instead tested at once in `test_list_with_system_id_and_catalogue_category_id_with_no_results`

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #345
