### PR TITLE
Bump cryptography from 42.0.8 to 43.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 version = "1.0.0"
 
 dependencies = [
-    "cryptography==42.0.8",
+    "cryptography==43.0.1",
     "fastapi[all]==0.111.0",
     "PyJWT==2.8.0",
     "pymongo==4.8.0",


### PR DESCRIPTION
## Description
Bumps the `cryptography` library to address https://github.com/ral-facilities/inventory-management-system-api/security/dependabot/4 on `main`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage