### PR TITLE
Usage Status Service Test Fix

### DIFF
--- a/test/unit/services/test_usage_status.py
+++ b/test/unit/services/test_usage_status.py
@@ -9,10 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from bson import ObjectId
 
-from inventory_management_system_api.models.usage_status import (
-    UsageStatusIn,
-    UsageStatusOut,
-)
+from inventory_management_system_api.models.usage_status import UsageStatusIn, UsageStatusOut
 from inventory_management_system_api.schemas.usage_status import UsageStatusPostSchema
 from inventory_management_system_api.services import utils
 from inventory_management_system_api.services.usage_status import UsageStatusService

--- a/test/unit/services/test_usage_status.py
+++ b/test/unit/services/test_usage_status.py
@@ -9,7 +9,10 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from bson import ObjectId
 
-from inventory_management_system_api.models.usage_status import UsageStatusIn, UsageStatusOut
+from inventory_management_system_api.models.usage_status import (
+    UsageStatusIn,
+    UsageStatusOut,
+)
 from inventory_management_system_api.schemas.usage_status import UsageStatusPostSchema
 from inventory_management_system_api.services import utils
 from inventory_management_system_api.services.usage_status import UsageStatusService
@@ -140,12 +143,12 @@ class ListDSL(UsageStatusServiceDSL):
 
     def call_list(self) -> None:
         """Calls the `UsageStatusService` `list` method."""
-        self._expected_usage_statuses = self.usage_status_service.list()
+        self._obtained_usage_statuses = self.usage_status_service.list()
 
     def check_list_success(self) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
         self.mock_usage_status_repository.list.assert_called_once()
-        assert self._expected_usage_statuses == self._expected_usage_statuses
+        assert self._obtained_usage_statuses == self._expected_usage_statuses
 
 
 class TestList(ListDSL):


### PR DESCRIPTION
## Description

Found a typo in the usage status service test, identified [here](https://github.com/ral-facilities/object-storage-api/pull/61#issuecomment-2444542676). Checked other unit tests for a similar error, no other instance found.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}