### PR TITLE
Edit exception message when editing certain fields of a catalogue item with children

### DIFF
--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -26,6 +26,7 @@ from inventory_management_system_api.schemas.catalogue_category import (
     CatalogueCategoryPropertyPostSchema,
     CatalogueCategoryPropertySchema,
     CatalogueCategorySchema,
+    CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS,
 )
 from inventory_management_system_api.services.catalogue_category import CatalogueCategoryService
 from inventory_management_system_api.services.catalogue_category_property import CatalogueCategoryPropertyService
@@ -185,7 +186,8 @@ def partial_update_catalogue_category(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except ChildElementsExistError as exc:
-        message = "Catalogue category has child elements and cannot be updated"
+        message = ("Catalogue category has child elements, so the following fields cannot be updated: "
+            + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS))
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except DuplicateRecordError as exc:

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -186,8 +186,9 @@ def partial_update_catalogue_category(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except ChildElementsExistError as exc:
-        message = ("Catalogue category has child elements, so the following fields cannot be updated: "
-            + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS))
+        message = "Catalogue category has child elements, so the following fields cannot be updated: " + ", ".join(
+            CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS
+        )
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except DuplicateRecordError as exc:

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -162,8 +162,9 @@ def partial_update_catalogue_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except ChildElementsExistError as exc:
-        message = ("Catalogue item has child elements, so the following fields cannot be updated: "
-            + ', '.join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS))
+        message = "Catalogue item has child elements, so the following fields cannot be updated: " + ", ".join(
+            CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS
+        )
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except InvalidActionError as exc:

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -21,6 +21,7 @@ from inventory_management_system_api.schemas.catalogue_item import (
     CatalogueItemPatchSchema,
     CatalogueItemPostSchema,
     CatalogueItemSchema,
+    CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS,
 )
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService
 
@@ -161,7 +162,8 @@ def partial_update_catalogue_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except ChildElementsExistError as exc:
-        message = "Catalogue item has child elements, so the manufacturer_id and properties fields cannot be updated"
+        message = ("Catalogue item has child elements, so the following fields cannot be updated: "
+            + ', '.join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS))
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except InvalidActionError as exc:

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -161,7 +161,7 @@ def partial_update_catalogue_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except ChildElementsExistError as exc:
-        message = "Catalogue item has child elements and cannot be updated"
+        message = "Catalogue item has child elements, so the manufacturer_id and properties fields cannot be updated"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except InvalidActionError as exc:

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -993,7 +993,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
+            + ", ".join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS),
         )
 
     def test_partial_update_leaf_all_valid_values_when_no_children(self):
@@ -1040,7 +1040,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
+            + ", ".join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS),
         )
 
     def test_partial_update_leaf_properties_when_has_child_catalogue_item(self):
@@ -1054,7 +1054,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
+            + ", ".join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS),
         )
 
     def test_partial_update_leaf_to_non_leaf_with_properties(self):
@@ -1099,7 +1099,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
+            + ", ".join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS),
         )
 
     def test_partial_update_leaf_properties(self):

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -36,6 +36,10 @@ from httpx import Response
 
 from inventory_management_system_api.core.consts import BREADCRUMBS_TRAIL_MAX_LENGTH
 
+from inventory_management_system_api.schemas.catalogue_category import (
+    CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS,
+)
+
 
 class CreateDSL:
     """Base class for create tests."""
@@ -989,7 +993,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + "is_leaf, properties"
+                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
         )
 
     def test_partial_update_leaf_all_valid_values_when_no_children(self):
@@ -1036,7 +1040,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + "is_leaf, properties"
+                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
         )
 
     def test_partial_update_leaf_properties_when_has_child_catalogue_item(self):
@@ -1050,7 +1054,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + "is_leaf, properties"
+                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
         )
 
     def test_partial_update_leaf_to_non_leaf_with_properties(self):
@@ -1095,7 +1099,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_category_failed_with_detail(
             409,
             "Catalogue category has child elements, so the following fields cannot be updated: "
-                + "is_leaf, properties"
+                + ', '.join(CATALOGUE_CATEGORY_WITH_CHILD_NON_EDITABLE_FIELDS)
         )
 
     def test_partial_update_leaf_properties(self):

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -987,7 +987,9 @@ class TestUpdate(UpdateDSL):
         self.patch_catalogue_category(catalogue_category_id, {"is_leaf": True})
 
         self.check_patch_catalogue_category_failed_with_detail(
-            409, "Catalogue category has child elements and cannot be updated"
+            409,
+            "Catalogue category has child elements, so the following fields cannot be updated: "
+                + "is_leaf, properties"
         )
 
     def test_partial_update_leaf_all_valid_values_when_no_children(self):
@@ -1032,7 +1034,9 @@ class TestUpdate(UpdateDSL):
         self.patch_catalogue_category(catalogue_category_id, {"is_leaf": False})
 
         self.check_patch_catalogue_category_failed_with_detail(
-            409, "Catalogue category has child elements and cannot be updated"
+            409,
+            "Catalogue category has child elements, so the following fields cannot be updated: "
+                + "is_leaf, properties"
         )
 
     def test_partial_update_leaf_properties_when_has_child_catalogue_item(self):
@@ -1044,7 +1048,9 @@ class TestUpdate(UpdateDSL):
         self.patch_catalogue_category(catalogue_category_id, {"properties": []})
 
         self.check_patch_catalogue_category_failed_with_detail(
-            409, "Catalogue category has child elements and cannot be updated"
+            409,
+            "Catalogue category has child elements, so the following fields cannot be updated: "
+                + "is_leaf, properties"
         )
 
     def test_partial_update_leaf_to_non_leaf_with_properties(self):
@@ -1087,7 +1093,9 @@ class TestUpdate(UpdateDSL):
 
         self.patch_catalogue_category(catalogue_category_id, {"is_leaf": True})
         self.check_patch_catalogue_category_failed_with_detail(
-            409, "Catalogue category has child elements and cannot be updated"
+            409,
+            "Catalogue category has child elements, so the following fields cannot be updated: "
+                + "is_leaf, properties"
         )
 
     def test_partial_update_leaf_properties(self):

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -53,6 +53,8 @@ import pytest
 from bson import ObjectId
 from httpx import Response
 
+from inventory_management_system_api.schemas.catalogue_item import CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS
+
 
 class CreateDSL(CatalogueCategoryCreateDSL, ManufacturerCreateDSL):
     """Base class for create tests."""
@@ -1186,7 +1188,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_item_failed_with_detail(
             409,
             "Catalogue item has child elements, so the following fields cannot be updated: "
-                + "manufacturer_id, properties"
+                + ', '.join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS)
         )
 
     def test_partial_update_manufacturer_id_with_non_existent_id(self):
@@ -1463,7 +1465,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_item_failed_with_detail(
             409,
             "Catalogue item has child elements, so the following fields cannot be updated: "
-                + "manufacturer_id, properties"
+                + ', '.join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS)
         )
 
     def test_partial_update_obsolete_replacement_catalogue_item_id(self):

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1184,7 +1184,9 @@ class TestUpdate(UpdateDSL):
 
         self.patch_catalogue_item(catalogue_item_id, {"manufacturer_id": new_manufacturer_id})
         self.check_patch_catalogue_item_failed_with_detail(
-            409, "Catalogue item has child elements, so the manufacturer_id and properties fields cannot be updated"
+            409,
+            "Catalogue item has child elements, so the following fields cannot be updated: "
+                + "manufacturer_id, properties"
         )
 
     def test_partial_update_manufacturer_id_with_non_existent_id(self):
@@ -1459,7 +1461,9 @@ class TestUpdate(UpdateDSL):
 
         self.patch_catalogue_item(catalogue_item_id, {"properties": []})
         self.check_patch_catalogue_item_failed_with_detail(
-            409, "Catalogue item has child elements, so the manufacturer_id and properties fields cannot be updated"
+            409,
+            "Catalogue item has child elements, so the following fields cannot be updated: "
+                + "manufacturer_id, properties"
         )
 
     def test_partial_update_obsolete_replacement_catalogue_item_id(self):

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1188,7 +1188,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_item_failed_with_detail(
             409,
             "Catalogue item has child elements, so the following fields cannot be updated: "
-                + ', '.join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS)
+            + ", ".join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS),
         )
 
     def test_partial_update_manufacturer_id_with_non_existent_id(self):
@@ -1465,7 +1465,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_catalogue_item_failed_with_detail(
             409,
             "Catalogue item has child elements, so the following fields cannot be updated: "
-                + ', '.join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS)
+            + ", ".join(CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS),
         )
 
     def test_partial_update_obsolete_replacement_catalogue_item_id(self):

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1184,7 +1184,7 @@ class TestUpdate(UpdateDSL):
 
         self.patch_catalogue_item(catalogue_item_id, {"manufacturer_id": new_manufacturer_id})
         self.check_patch_catalogue_item_failed_with_detail(
-            409, "Catalogue item has child elements and cannot be updated"
+            409, "Catalogue item has child elements, so the manufacturer_id and properties fields cannot be updated"
         )
 
     def test_partial_update_manufacturer_id_with_non_existent_id(self):
@@ -1459,7 +1459,7 @@ class TestUpdate(UpdateDSL):
 
         self.patch_catalogue_item(catalogue_item_id, {"properties": []})
         self.check_patch_catalogue_item_failed_with_detail(
-            409, "Catalogue item has child elements and cannot be updated"
+            409, "Catalogue item has child elements, so the manufacturer_id and properties fields cannot be updated"
         )
 
     def test_partial_update_obsolete_replacement_catalogue_item_id(self):


### PR DESCRIPTION
## Description

Edit the returned exception message to make it clearer when trying to update protected fields on a catalogue item or catalogue category that has a child element.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

Resolves #353 