### PR TITLE
Bump cryptography from 43.0.1 to 44.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 version = "1.0.1"
 
 dependencies = [
-    "cryptography==43.0.1",
+    "cryptography==44.0.2",
     "fastapi[all]==0.115.3",
     "PyJWT==2.8.0",
     "pymongo==4.8.0",


### PR DESCRIPTION
## Description
Bumps the `cryptography` library to address https://github.com/ral-facilities/inventory-management-system-api/security/dependabot/6 on `main`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage