### PR TITLE
Fix `ims-migrate` migration script in production Docker image

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,15 +5,16 @@ WORKDIR /inventory-management-system-api-run
 # Requirement when using a different workdir to get scripts to import correctly
 ENV PYTHONPATH="${PYTHONPATH}:/inventory-management-system-api-run"
 
-COPY requirements.txt ./
+COPY pyproject.toml requirements.txt ./
 # Copy inventory_management_system_api source files
 COPY inventory_management_system_api/ inventory_management_system_api/
 
 RUN set -eux; \
     \
-    # Install pip dependencies \
+    # Ensure the project scripts defined in pyproject.toml file get installed \
+    python -m pip install .; \
+    # Ensure the pinned versions of the production dependencies and subdependencies are installed \
     python -m pip install --no-cache-dir --requirement requirements.txt; \
-    \
     # Create loging.ini from its .example file \
     cp inventory_management_system_api/logging.example.ini inventory_management_system_api/logging.ini; \
     \


### PR DESCRIPTION
## Description
The `requirements.txt` file with all the production dependencies pinned was introduced as part of https://github.com/ral-facilities/inventory-management-system-api/pull/471 so I thought that there is no need to copy the `pyproject.toml` file and do `pip install .` anymore. However, it turns out the `ims-migrate` migration script needs to be installed so we still have to do this.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #483 