### PR TITLE
Update incorrect replica set initialisation command in readme #482

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ replacing `<hostname>` with the actual hostname for the replica set.
 For docker you may use
 
 ```bash
-docker exec -i ims_api_mongodb_container mongosh --username 'root' --password 'example' --authenticationDatabase=admin --eval "rs.initiate({ _id : 'rs0', members: [{ _id: 0, host: 'ims_api_mongodb_container:27017' }]})"
+docker exec -i ims_api_mongodb_container mongosh --username 'root' --password 'example' --authenticationDatabase=admin --eval "rs.initiate({ _id : 'rs0', members: [{ _id: 0, host: 'localhost:27017' }]})"
 ```
 
 ### Using mock data for testing [Optional]


### PR DESCRIPTION
## Description

Updates the README to fix an incorrect replica set initialisation command that lead to #482. The host should have been localhost for this setup as host networking is being used. The dev_cli script already reflected this change as its default is to use localhost but the manual command was still using the container name left over from before host networking was being used.

## Agile board tracking

Closes #482
