### PR TITLE
Prevent deletion of catalogue items that are replacements for others #525

### DIFF
--- a/inventory_management_system_api/core/exceptions.py
+++ b/inventory_management_system_api/core/exceptions.py
@@ -70,9 +70,9 @@ class ChildElementsExistError(DatabaseError):
     """
 
 
-class IsAReplacementForError(DatabaseError):
+class ReplacementForObsoleteCatalogueItemError(DatabaseError):
     """
-    Exception raised when attempting to delete a catalogue item that is a replacement for another catalogue item.
+    Exception raised when attempting to delete a catalogue item that is the replacement for an obsolete catalogue item.
     """
 
 

--- a/inventory_management_system_api/core/exceptions.py
+++ b/inventory_management_system_api/core/exceptions.py
@@ -70,6 +70,12 @@ class ChildElementsExistError(DatabaseError):
     """
 
 
+class IsAReplacementForError(DatabaseError):
+    """
+    Exception raised when attempting to delete a catalogue item that is a replacement for another catalogue item.
+    """
+
+
 class PartOfCatalogueItemError(DatabaseError):
     """
     Exception raised when attempting to delete a manufacturer that is a part of a catalogue item

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -137,16 +137,17 @@ class CatalogueItemRepo:
         )
         return item is not None
 
-    def is_a_replacement_for(self, catalogue_item_id: str, session: Optional[ClientSession] = None) -> bool:
+    def is_replacement_for(self, catalogue_item_id: str, session: Optional[ClientSession] = None) -> bool:
         """
-        Check if a catalogue item is an obsolete replacement catalogue item for at least one catalogue item.
+        Check if a catalogue item is the replacement for at least one obsolete catalogue item.
 
         :param catalogue_item_id: The ID of the catalogue item to check.
         :param session: PyMongo ClientSession to use for database operations.
-        :return: True if the catalogue item is a replacement for another catalogue item, False otherwise.
+        :return: True if the catalogue item is the replacement for at least one obsolete catalogue item, False
+                 otherwise.
         """
         logger.info(
-            "Checking if catalogue item with ID '%s' is a replacement for any obsolete catalogue item",
+            "Checking if catalogue item with ID '%s' is the replacement for an obsolete catalogue item",
             catalogue_item_id,
         )
         item = self._catalogue_items_collection.find_one(

--- a/inventory_management_system_api/repositories/catalogue_item.py
+++ b/inventory_management_system_api/repositories/catalogue_item.py
@@ -127,13 +127,30 @@ class CatalogueItemRepo:
 
         Child elements in this case means whether a catalogue item has child items
 
-        :param catalogue_item_id: The ID of the catalogue item to check
-        :param session: PyMongo ClientSession to use for database operations
+        :param catalogue_item_id: The ID of the catalogue item to check.
+        :param session: PyMongo ClientSession to use for database operations.
         :return: True if the catalogue item has child elements, False otherwise.
         """
         logger.info("Checking if catalogue item with ID '%s' has child elements", catalogue_item_id)
         item = self._items_collection.find_one(
             {"catalogue_item_id": CustomObjectId(catalogue_item_id)}, session=session
+        )
+        return item is not None
+
+    def is_a_replacement_for(self, catalogue_item_id: str, session: Optional[ClientSession] = None) -> bool:
+        """
+        Check if a catalogue item is an obsolete replacement catalogue item for at least one catalogue item.
+
+        :param catalogue_item_id: The ID of the catalogue item to check.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: True if the catalogue item is a replacement for another catalogue item, False otherwise.
+        """
+        logger.info(
+            "Checking if catalogue item with ID '%s' is a replacement for any obsolete catalogue item",
+            catalogue_item_id,
+        )
+        item = self._catalogue_items_collection.find_one(
+            {"obsolete_replacement_catalogue_item_id": CustomObjectId(catalogue_item_id)}, session=session
         )
         return item is not None
 

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -201,7 +201,7 @@ def delete_catalogue_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except IsAReplacementForError as exc:
-        message = "Catalogue item is the replacement catalogue item for another catalogue item and cannot be deleted"
+        message = "Catalogue item is the replacement for an obsolete catalogue item and cannot be deleted"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
     # pylint: disable=duplicate-code

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -14,12 +14,12 @@ from inventory_management_system_api.core.exceptions import (
     InvalidActionError,
     InvalidObjectIdError,
     InvalidPropertyTypeError,
-    IsAReplacementForError,
     MissingMandatoryProperty,
     MissingRecordError,
     NonLeafCatalogueCategoryError,
     ObjectStorageAPIAuthError,
     ObjectStorageAPIServerError,
+    ReplacementForObsoleteCatalogueItemError,
 )
 from inventory_management_system_api.schemas.catalogue_item import (
     CATALOGUE_ITEM_WITH_CHILD_NON_EDITABLE_FIELDS,
@@ -200,7 +200,7 @@ def delete_catalogue_item(
         message = "Catalogue item has child elements and cannot be deleted"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
-    except IsAReplacementForError as exc:
+    except ReplacementForObsoleteCatalogueItemError as exc:
         message = "Catalogue item is the replacement for an obsolete catalogue item and cannot be deleted"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -12,6 +12,7 @@ from inventory_management_system_api.core.config import config
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     InvalidActionError,
+    IsAReplacementForError,
     MissingRecordError,
     NonLeafCatalogueCategoryError,
 )
@@ -220,10 +221,18 @@ class CatalogueItemService:
 
         :param catalogue_item_id: The ID of the catalogue item to delete.
         :param access_token: The JWT access token to use for auth with the Object Storage API if object storage enabled.
+        :raises ChildElementsExistError: If the catalogue item has child elements.
+        :raises IsAReplacementForError: If the catalogue item is a replacement for at least one other catalogue item.
         """
         if self._catalogue_item_repository.has_child_elements(catalogue_item_id):
             raise ChildElementsExistError(
                 f"Catalogue item with ID {catalogue_item_id} has child elements and cannot be deleted"
+            )
+
+        if self._catalogue_item_repository.is_a_replacement_for(catalogue_item_id):
+            raise IsAReplacementForError(
+                f"Catalogue item with ID {catalogue_item_id} is the replacement catalogue item for at least one "
+                "catalogue item and cannot be deleted"
             )
 
         # First, attempt to delete any attachments and/or images that might be associated with this catalogue item.

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1611,7 +1611,7 @@ class TestDelete(DeleteDSL):
 
         self.delete_catalogue_item(catalogue_item_id)
         self.check_delete_catalogue_item_failed_with_detail(
-            422, "Catalogue item is the replacement catalogue item for another catalogue item and cannot be deleted"
+            422, "Catalogue item is the replacement for an obsolete catalogue item and cannot be deleted"
         )
 
     def test_delete_with_non_existent_id(self):

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1530,6 +1530,20 @@ class DeleteDSL(UpdateDSL):
 
     _delete_response_catalogue_item: Response
 
+    def post_obsolete_catalogue_item(self) -> Optional[str]:
+        """Utility method that posts a obsolete catalogue item with an replacement of last catalogue item posted.
+
+        :return: ID of the created catalogue item (or `None` if not successful).
+        """
+
+        return self.post_catalogue_item(
+            {
+                **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+                "is_obsolete": True,
+                "obsolete_replacement_catalogue_item_id": self._post_response_catalogue_item.json()["id"],
+            }
+        )
+
     def delete_catalogue_item(self, catalogue_item_id: str) -> None:
         """
         Deletes a catalogue item with the given ID.
@@ -1585,6 +1599,19 @@ class TestDelete(DeleteDSL):
         self.delete_catalogue_item(catalogue_item_id)
         self.check_delete_catalogue_item_failed_with_detail(
             409, "Catalogue item has child elements and cannot be deleted"
+        )
+
+    def test_delete_when_is_a_replacement_for(self):
+        """Test deleting a catalogue item when it is the replacement for another catalogue item."""
+
+        catalogue_item_id = self.post_catalogue_item_and_prerequisites_no_properties(
+            CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY
+        )
+        self.post_obsolete_catalogue_item()
+
+        self.delete_catalogue_item(catalogue_item_id)
+        self.check_delete_catalogue_item_failed_with_detail(
+            422, "Catalogue item is the replacement catalogue item for another catalogue item and cannot be deleted"
         )
 
     def test_delete_with_non_existent_id(self):

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -6,6 +6,7 @@ Unit tests for the `CatalogueItemRepo` repository.
 # pylint: disable=duplicate-code
 
 from test.mock_data import (
+    CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
     CATALOGUE_ITEM_IN_DATA_NOT_OBSOLETE_NO_PROPERTIES,
     CATALOGUE_ITEM_IN_DATA_REQUIRED_VALUES_ONLY,
     ITEM_DATA_REQUIRED_VALUES_ONLY,
@@ -34,9 +35,6 @@ class CatalogueItemRepoDSL:
     items_collection: Mock
 
     mock_session = MagicMock()
-
-    # Internal data for utility functions
-    _mock_child_item_data: Optional[dict]
 
     @pytest.fixture(autouse=True)
     def setup(self, database_mock):
@@ -523,6 +521,7 @@ class TestDelete(DeleteDSL):
 class HasChildElementsDSL(CatalogueItemRepoDSL):
     """Base class for `has_child_elements` tests"""
 
+    _mock_child_item_data: Optional[dict]
     _has_child_elements_catalogue_item_id: str
     _has_child_elements_result: bool
     _has_child_elements_exception: pytest.ExceptionInfo
@@ -563,24 +562,15 @@ class HasChildElementsDSL(CatalogueItemRepoDSL):
             self.catalogue_item_repository.has_child_elements(catalogue_category_id)
         self._has_child_elements_exception = exc
 
-    def check_has_child_elements_performed_expected_calls(self, expected_catalogue_item_id: str) -> None:
-        """
-        Checks that a call to `has_child_elements` performed the expected function calls.
-
-        :param expected_catalogue_item_id: Expected `catalogue_item_id` used in the database calls.
-        """
-
-        self.items_collection.find_one.assert_called_once_with(
-            {"catalogue_item_id": CustomObjectId(expected_catalogue_item_id)}, session=self.mock_session
-        )
-
     def check_has_child_elements_success(self, expected_result: bool) -> None:
         """Checks that a prior call to `call_has_child_elements` worked as expected.
 
         :param expected_result: The expected result returned by `has_child_elements`.
         """
 
-        self.check_has_child_elements_performed_expected_calls(self._has_child_elements_catalogue_item_id)
+        self.items_collection.find_one.assert_called_once_with(
+            {"catalogue_item_id": CustomObjectId(self._has_child_elements_catalogue_item_id)}, session=self.mock_session
+        )
 
         assert self._has_child_elements_result == expected_result
 
@@ -621,6 +611,102 @@ class TestHasChildElements(HasChildElementsDSL):
 
         self.call_has_child_elements_expecting_error(catalogue_item_id, InvalidObjectIdError)
         self.check_has_child_elements_failed_with_exception("Invalid ObjectId value 'invalid-id'")
+
+
+class IsAReplacementForDSL(CatalogueItemRepoDSL):
+    """Base class for `is_a_replacement_for` tests"""
+
+    _mock_replacement_item_data: Optional[dict]
+    _is_a_replacement_for_catalogue_item_id: str
+    _is_a_replacement_for_result: bool
+    _is_a_replacement_for_exception: pytest.ExceptionInfo
+
+    def mock_is_a_replacement_for(self, replacement_item_data: Optional[dict] = None) -> None:
+        """
+        Mocks database methods appropriately for when the `is_a_replacement_for` repo method will be called.
+
+        :param replacement_item_data: Dictionary containing a replacement item's data (or `None`).
+        """
+
+        self._mock_replacement_item_data = replacement_item_data
+
+        RepositoryTestHelpers.mock_find_one(self.catalogue_items_collection, replacement_item_data)
+
+    def call_is_a_replacement_for(self, catalogue_item_id: str) -> None:
+        """Calls the `CatalogueItemRepo` `is_a_replacement_for` method.
+
+        :param catalogue_item_id: ID of the catalogue item to check.
+        """
+
+        self._is_a_replacement_for_catalogue_item_id = catalogue_item_id
+        self._is_a_replacement_for_result = self.catalogue_item_repository.is_a_replacement_for(
+            catalogue_item_id, session=self.mock_session
+        )
+
+    def call_is_a_replacement_for_expecting_error(
+        self, catalogue_category_id: str, error_type: type[BaseException]
+    ) -> None:
+        """
+        Calls the `CatalogueItemRepo` `is_a_replacement_for` method while expecting an error to be raised.
+
+        :param catalogue_category_id: ID of the catalogue item to check.
+        :param error_type: Expected exception to be raised.
+        """
+
+        with pytest.raises(error_type) as exc:
+            self.catalogue_item_repository.is_a_replacement_for(catalogue_category_id)
+        self._is_a_replacement_for_exception = exc
+
+    def check_is_a_replacement_for_success(self, expected_result: bool) -> None:
+        """Checks that a prior call to `call_is_a_replacement_for` worked as expected.
+
+        :param expected_result: The expected result returned by `is_a_replacement_for`.
+        """
+
+        self.catalogue_items_collection.find_one.assert_called_once_with(
+            {"obsolete_replacement_catalogue_item_id": CustomObjectId(self._is_a_replacement_for_catalogue_item_id)},
+            session=self.mock_session,
+        )
+
+        assert self._is_a_replacement_for_result == expected_result
+
+    def check_is_a_replacement_for_failed_with_exception(self, message: str) -> None:
+        """
+        Checks that a prior call to `call_is_a_replacement_for` worked as expected, raising an exception with the
+        correct message.
+
+        :param message: Expected message of the raised exception.
+        """
+
+        self.catalogue_items_collection.find_one.assert_not_called()
+
+        assert str(self._is_a_replacement_for_exception.value) == message
+
+
+class TestIsAReplacementFor(IsAReplacementForDSL):
+    """Tests for `is_a_replacement_for`."""
+
+    def test_is_a_replacement_for_when_not_a_replacement_for(self):
+        """Test `is_a_replacement_for` when the item is not a replacement for another catalogue item."""
+
+        self.mock_is_a_replacement_for(replacement_item_data=None)
+        self.call_is_a_replacement_for(str(ObjectId()))
+        self.check_is_a_replacement_for_success(expected_result=False)
+
+    def test_is_a_replacement_for_with_child_item(self):
+        """Test `is_a_replacement_for` when the item is a replacement for another catalogue item."""
+
+        self.mock_is_a_replacement_for(replacement_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.call_is_a_replacement_for(str(ObjectId()))
+        self.check_is_a_replacement_for_success(expected_result=True)
+
+    def test_is_a_replacement_for_with_invalid_id(self):
+        """Test `is_a_replacement_for` with an invalid ID."""
+
+        catalogue_item_id = "invalid-id"
+
+        self.call_is_a_replacement_for_expecting_error(catalogue_item_id, InvalidObjectIdError)
+        self.check_is_a_replacement_for_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
 
 class ListIDsDSL(CatalogueItemRepoDSL):

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -613,17 +613,17 @@ class TestHasChildElements(HasChildElementsDSL):
         self.check_has_child_elements_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
 
-class IsAReplacementForDSL(CatalogueItemRepoDSL):
-    """Base class for `is_a_replacement_for` tests"""
+class IsReplacementForDSL(CatalogueItemRepoDSL):
+    """Base class for `is_replacement_for` tests"""
 
     _mock_replacement_item_data: Optional[dict]
-    _is_a_replacement_for_catalogue_item_id: str
-    _is_a_replacement_for_result: bool
-    _is_a_replacement_for_exception: pytest.ExceptionInfo
+    _is_replacement_for_catalogue_item_id: str
+    _is_replacement_for_result: bool
+    _is_replacement_for_exception: pytest.ExceptionInfo
 
-    def mock_is_a_replacement_for(self, replacement_item_data: Optional[dict] = None) -> None:
+    def mock_is_replacement_for(self, replacement_item_data: Optional[dict] = None) -> None:
         """
-        Mocks database methods appropriately for when the `is_a_replacement_for` repo method will be called.
+        Mocks database methods appropriately for when the `is_replacement_for` repo method will be called.
 
         :param replacement_item_data: Dictionary containing a replacement item's data (or `None`).
         """
@@ -632,47 +632,47 @@ class IsAReplacementForDSL(CatalogueItemRepoDSL):
 
         RepositoryTestHelpers.mock_find_one(self.catalogue_items_collection, replacement_item_data)
 
-    def call_is_a_replacement_for(self, catalogue_item_id: str) -> None:
-        """Calls the `CatalogueItemRepo` `is_a_replacement_for` method.
+    def call_is_replacement_for(self, catalogue_item_id: str) -> None:
+        """Calls the `CatalogueItemRepo` `is_replacement_for` method.
 
         :param catalogue_item_id: ID of the catalogue item to check.
         """
 
-        self._is_a_replacement_for_catalogue_item_id = catalogue_item_id
-        self._is_a_replacement_for_result = self.catalogue_item_repository.is_a_replacement_for(
+        self._is_replacement_for_catalogue_item_id = catalogue_item_id
+        self._is_replacement_for_result = self.catalogue_item_repository.is_replacement_for(
             catalogue_item_id, session=self.mock_session
         )
 
-    def call_is_a_replacement_for_expecting_error(
+    def call_is_replacement_for_expecting_error(
         self, catalogue_category_id: str, error_type: type[BaseException]
     ) -> None:
         """
-        Calls the `CatalogueItemRepo` `is_a_replacement_for` method while expecting an error to be raised.
+        Calls the `CatalogueItemRepo` `is_replacement_for` method while expecting an error to be raised.
 
         :param catalogue_category_id: ID of the catalogue item to check.
         :param error_type: Expected exception to be raised.
         """
 
         with pytest.raises(error_type) as exc:
-            self.catalogue_item_repository.is_a_replacement_for(catalogue_category_id)
-        self._is_a_replacement_for_exception = exc
+            self.catalogue_item_repository.is_replacement_for(catalogue_category_id)
+        self._is_replacement_for_exception = exc
 
-    def check_is_a_replacement_for_success(self, expected_result: bool) -> None:
-        """Checks that a prior call to `call_is_a_replacement_for` worked as expected.
+    def check_is_replacement_for_success(self, expected_result: bool) -> None:
+        """Checks that a prior call to `call_is_replacement_for` worked as expected.
 
-        :param expected_result: The expected result returned by `is_a_replacement_for`.
+        :param expected_result: The expected result returned by `is_replacement_for`.
         """
 
         self.catalogue_items_collection.find_one.assert_called_once_with(
-            {"obsolete_replacement_catalogue_item_id": CustomObjectId(self._is_a_replacement_for_catalogue_item_id)},
+            {"obsolete_replacement_catalogue_item_id": CustomObjectId(self._is_replacement_for_catalogue_item_id)},
             session=self.mock_session,
         )
 
-        assert self._is_a_replacement_for_result == expected_result
+        assert self._is_replacement_for_result == expected_result
 
-    def check_is_a_replacement_for_failed_with_exception(self, message: str) -> None:
+    def check_is_replacement_for_failed_with_exception(self, message: str) -> None:
         """
-        Checks that a prior call to `call_is_a_replacement_for` worked as expected, raising an exception with the
+        Checks that a prior call to `call_is_replacement_for` worked as expected, raising an exception with the
         correct message.
 
         :param message: Expected message of the raised exception.
@@ -680,33 +680,33 @@ class IsAReplacementForDSL(CatalogueItemRepoDSL):
 
         self.catalogue_items_collection.find_one.assert_not_called()
 
-        assert str(self._is_a_replacement_for_exception.value) == message
+        assert str(self._is_replacement_for_exception.value) == message
 
 
-class TestIsAReplacementFor(IsAReplacementForDSL):
-    """Tests for `is_a_replacement_for`."""
+class TestIsAReplacementFor(IsReplacementForDSL):
+    """Tests for `is_replacement_for`."""
 
-    def test_is_a_replacement_for_when_not_a_replacement_for(self):
-        """Test `is_a_replacement_for` when the item is not a replacement for another catalogue item."""
+    def test_is_replacement_for_when_not_a_replacement_for(self):
+        """Test `is_replacement_for` when the item is not a replacement for another catalogue item."""
 
-        self.mock_is_a_replacement_for(replacement_item_data=None)
-        self.call_is_a_replacement_for(str(ObjectId()))
-        self.check_is_a_replacement_for_success(expected_result=False)
+        self.mock_is_replacement_for(replacement_item_data=None)
+        self.call_is_replacement_for(str(ObjectId()))
+        self.check_is_replacement_for_success(expected_result=False)
 
-    def test_is_a_replacement_for_with_child_item(self):
-        """Test `is_a_replacement_for` when the item is a replacement for another catalogue item."""
+    def test_is_replacement_for_with_child_item(self):
+        """Test `is_replacement_for` when the item is a replacement for another catalogue item."""
 
-        self.mock_is_a_replacement_for(replacement_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY)
-        self.call_is_a_replacement_for(str(ObjectId()))
-        self.check_is_a_replacement_for_success(expected_result=True)
+        self.mock_is_replacement_for(replacement_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.call_is_replacement_for(str(ObjectId()))
+        self.check_is_replacement_for_success(expected_result=True)
 
-    def test_is_a_replacement_for_with_invalid_id(self):
-        """Test `is_a_replacement_for` with an invalid ID."""
+    def test_is_replacement_for_with_invalid_id(self):
+        """Test `is_replacement_for` with an invalid ID."""
 
         catalogue_item_id = "invalid-id"
 
-        self.call_is_a_replacement_for_expecting_error(catalogue_item_id, InvalidObjectIdError)
-        self.check_is_a_replacement_for_failed_with_exception("Invalid ObjectId value 'invalid-id'")
+        self.call_is_replacement_for_expecting_error(catalogue_item_id, InvalidObjectIdError)
+        self.check_is_replacement_for_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
 
 class ListIDsDSL(CatalogueItemRepoDSL):


### PR DESCRIPTION
## Description

See #525. Prevents deletion of catalogue items that are assigned as the replacement of obsolete catalogue items.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #525