### PR TITLE
Add endpoint to get a list of system types #542

### DIFF
--- a/inventory_management_system_api/main.py
+++ b/inventory_management_system_api/main.py
@@ -19,6 +19,7 @@ from inventory_management_system_api.routers.v1 import (
     item,
     manufacturer,
     system,
+    system_type,
     unit,
     usage_status,
 )
@@ -107,6 +108,7 @@ app.include_router(catalogue_item.router, dependencies=router_dependencies)
 app.include_router(item.router, dependencies=router_dependencies)
 app.include_router(manufacturer.router, dependencies=router_dependencies)
 app.include_router(system.router, dependencies=router_dependencies)
+app.include_router(system_type.router, dependencies=router_dependencies)
 app.include_router(unit.router, dependencies=router_dependencies)
 app.include_router(usage_status.router, dependencies=router_dependencies)
 

--- a/inventory_management_system_api/models/system.py
+++ b/inventory_management_system_api/models/system.py
@@ -12,7 +12,7 @@ from inventory_management_system_api.models.mixins import CreatedModifiedTimeInM
 
 class SystemBase(BaseModel):
     """
-    Base database model for a system
+    Base database model for a system.
     """
 
     parent_id: Optional[CustomObjectIdField] = None
@@ -28,13 +28,13 @@ class SystemBase(BaseModel):
 
 class SystemIn(CreatedModifiedTimeInMixin, SystemBase):
     """
-    Input database model for a system
+    Input database model for a system.
     """
 
 
 class SystemOut(CreatedModifiedTimeOutMixin, SystemBase):
     """
-    Output database model for a system
+    Output database model for a system.
     """
 
     id: StringObjectIdField = Field(alias="_id")

--- a/inventory_management_system_api/models/system_type.py
+++ b/inventory_management_system_api/models/system_type.py
@@ -1,0 +1,16 @@
+"""
+Module for defining the database models for representing system types.
+"""
+
+from pydantic import BaseModel, Field
+
+from inventory_management_system_api.models.custom_object_id_data_types import StringObjectIdField
+
+
+class SystemTypeOut(BaseModel):
+    """
+    Output database model for a system type.
+    """
+
+    id: StringObjectIdField = Field(alias="_id")
+    value: str

--- a/inventory_management_system_api/repositories/system_type.py
+++ b/inventory_management_system_api/repositories/system_type.py
@@ -1,0 +1,40 @@
+"""
+Module for providing a repository for managing system types in a MongoDB database.
+"""
+
+import logging
+from typing import Optional
+
+from pymongo.client_session import ClientSession
+from pymongo.collection import Collection
+
+from inventory_management_system_api.core.database import DatabaseDep
+from inventory_management_system_api.models.system_type import SystemTypeOut
+
+logger = logging.getLogger()
+
+
+class SystemTypeRepo:
+    """
+    Repository for managing system types in a MongoDB database.
+    """
+
+    def __init__(self, database: DatabaseDep) -> None:
+        """
+        Initialise the `SystemTypeRepo` with a MongoDB database instance.
+
+        :param database: Database to use.
+        """
+        self._database = database
+        self._system_types_collection: Collection = self._database.system_types
+
+    def list(self, session: Optional[ClientSession] = None) -> list[SystemTypeOut]:
+        """
+        Retrieve system types from a MongoDB database.
+
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: List of system types or an empty list if no system types are retrieved.
+        """
+        logger.info("Retrieving all system types from the database")
+        system_types = self._system_types_collection.find(session=session)
+        return [SystemTypeOut(**system_type) for system_type in system_types]

--- a/inventory_management_system_api/repositories/unit.py
+++ b/inventory_management_system_api/repositories/unit.py
@@ -84,6 +84,7 @@ class UnitRepo:
         :param session: PyMongo ClientSession to use for database operations
         :return: List of Units or an empty list if no units are retrieved
         """
+        logger.info("Retrieving all units from the database")
         units = self._units_collection.find(session=session)
         return [UnitOut(**unit) for unit in units]
 

--- a/inventory_management_system_api/repositories/usage_status.py
+++ b/inventory_management_system_api/repositories/usage_status.py
@@ -86,6 +86,7 @@ class UsageStatusRepo:
         :param session: PyMongo ClientSession to use for database operations
         :return: List of Usage statuses or an empty list if no Usage statuses are retrieved
         """
+        logger.info("Retrieving all usage statuses from the database")
         usage_statuses = self._usage_statuses_collection.find(session=session)
         return [UsageStatusOut(**usage_status) for usage_status in usage_statuses]
 

--- a/inventory_management_system_api/routers/v1/system.py
+++ b/inventory_management_system_api/routers/v1/system.py
@@ -1,6 +1,5 @@
 """
-Module for providing an API router which defines routes for managing systems using the `SystemService`
-service.
+Module for providing an API router which defines routes for managing systems using the `SystemService` service.
 """
 
 import logging

--- a/inventory_management_system_api/routers/v1/system_type.py
+++ b/inventory_management_system_api/routers/v1/system_type.py
@@ -1,0 +1,28 @@
+"""
+Module for providing an API router which defines routes for managing system types using the `SystemTypeService` service.
+"""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from inventory_management_system_api.schemas.system_type import SystemTypeSchema
+from inventory_management_system_api.services.system_type import SystemTypeService
+
+logger = logging.getLogger()
+
+router = APIRouter(prefix="/v1/system-types", tags=["system types"])
+
+SystemTypeServiceDep = Annotated[SystemTypeService, Depends(SystemTypeService)]
+
+
+@router.get(path="", summary="Get system types", response_description="List of system types")
+def get_systems(
+    system_type_service: SystemTypeServiceDep,
+) -> list[SystemTypeSchema]:
+    # pylint: disable=missing-function-docstring
+    logger.info("Getting system types")
+
+    system_types = system_type_service.list()
+    return [SystemTypeSchema(**system_type.model_dump()) for system_type in system_types]

--- a/inventory_management_system_api/schemas/system.py
+++ b/inventory_management_system_api/schemas/system.py
@@ -12,7 +12,7 @@ from inventory_management_system_api.schemas.mixins import CreatedModifiedSchema
 
 class SystemImportanceType(str, Enum):
     """
-    Enumeration for system importance types
+    Enumeration for system importance types.
     """
 
     LOW = "low"
@@ -22,7 +22,7 @@ class SystemImportanceType(str, Enum):
 
 class SystemPostSchema(BaseModel):
     """
-    Schema model for a system creation request
+    Schema model for a system creation request.
     """
 
     parent_id: Optional[str] = Field(default=None, description="ID of the parent system (if applicable)")
@@ -35,7 +35,7 @@ class SystemPostSchema(BaseModel):
 
 class SystemPatchSchema(SystemPostSchema):
     """
-    Schema model for a system update request
+    Schema model for a system update request.
     """
 
     name: Optional[str] = Field(default=None, description="Name of the system")
@@ -44,7 +44,7 @@ class SystemPatchSchema(SystemPostSchema):
 
 class SystemSchema(CreatedModifiedSchemaMixin, SystemPostSchema):
     """
-    Schema model for system get request response
+    Schema model for system get request response.
     """
 
     id: str = Field(description="ID of the system")

--- a/inventory_management_system_api/schemas/system_type.py
+++ b/inventory_management_system_api/schemas/system_type.py
@@ -1,0 +1,14 @@
+"""
+Module for defining the API schema models for representing system types.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class SystemTypeSchema(BaseModel):
+    """
+    Schema model for system type get request response.
+    """
+
+    id: str = Field(description="ID of the system type")
+    value: str = Field(description="Value of the system type")

--- a/inventory_management_system_api/services/system.py
+++ b/inventory_management_system_api/services/system.py
@@ -2,7 +2,6 @@
 Module for providing a service for managing systems using the `SystemRepo` repository.
 """
 
-import logging
 from typing import Annotated, Optional
 
 from fastapi import Depends
@@ -16,8 +15,6 @@ from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
 from inventory_management_system_api.schemas.system import SystemPatchSchema, SystemPostSchema
 from inventory_management_system_api.services import utils
-
-logger = logging.getLogger()
 
 
 class SystemService:

--- a/inventory_management_system_api/services/system_type.py
+++ b/inventory_management_system_api/services/system_type.py
@@ -1,0 +1,32 @@
+"""
+Module for providing a service for managing systems using the `SystemRepo` repository.
+"""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from inventory_management_system_api.models.system_type import SystemTypeOut
+from inventory_management_system_api.repositories.system_type import SystemTypeRepo
+
+
+class SystemTypeService:
+    """
+    Service for managing system types.
+    """
+
+    def __init__(self, system_type_repository: Annotated[SystemTypeRepo, Depends(SystemTypeRepo)]) -> None:
+        """
+        Initialise the `SystemTypeService` with a `SystemTypeRepo` repository.
+
+        :param system_type_repository: `SystemTypeRepo` repository to use.
+        """
+        self._system_type_repository = system_type_repository
+
+    def list(self) -> list[SystemTypeOut]:
+        """
+        Retrieve system types.
+
+        :return: List of system types or an empty list if no system types are retrieved.
+        """
+        return self._system_type_repository.list()

--- a/test/e2e/test_system_type.py
+++ b/test/e2e/test_system_type.py
@@ -1,0 +1,54 @@
+"""
+End-to-End tests for the system type router.
+"""
+
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
+from test.mock_data import SYSTEM_TYPES_GET_DATA
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+
+
+class ListDSL:
+    """Base class for list tests."""
+
+    test_client: TestClient
+
+    _get_response_system_type: Response
+
+    @pytest.fixture(autouse=True)
+    def setup_system_create_dsl(self, test_client):
+        """Setup fixtures"""
+
+        self.test_client = test_client
+
+    def get_system_types(self) -> None:
+        """Gets a list of system types."""
+
+        self._get_response_system_type = self.test_client.get("/v1/system-types")
+        print("HELLO")
+        print(self._get_response_system_type)
+
+    def check_get_systems_success(self, expected_system_types_get_data: list[dict]) -> None:
+        """
+        Checks that a prior call to `get_system_types` gave a successful response with the expected data returned
+
+        :param expected_system_types_get_data: List of dictionaries containing the expected system type data returned
+                                               as would be required for `SystemTypeSchema`'s.
+        """
+
+        assert self._get_response_system_type.status_code == 200
+        assert self._get_response_system_type.json() == expected_system_types_get_data
+
+
+class TestList(ListDSL):
+    """Tests for getting a list of systems."""
+
+    def test_list(self):
+        """Test getting a list of all system types."""
+
+        self.get_system_types()
+        self.check_get_systems_success(SYSTEM_TYPES_GET_DATA)

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -767,6 +767,20 @@ MANUFACTURER_IN_DATA_B = {
     "code": "manufacturer-b",
 }
 
+
+# ---------------------------- SYSTEM TYPES -----------------------------
+
+SYSTEM_TYPES_OUT_DATA = [
+    {"_id": ObjectId("685e5dce6e347e39d459c5ea"), "value": "Storage"},
+    {"_id": ObjectId("685e5dce6e347e39d459c5eb"), "value": "Operational"},
+    {"_id": ObjectId("685d52f4b1095c1837c69dac"), "value": "Quarantine"},
+    {"_id": ObjectId("685d52f4b1095c1837c69dad"), "value": "Scrapped"},
+]
+
+SYSTEM_TYPES_GET_DATA = [
+    {"id": str(system_type_out["_id"]), "value": system_type_out["value"]} for system_type_out in SYSTEM_TYPES_OUT_DATA
+]
+
 # --------------------------------- SYSTEMS ---------------------------------
 
 # No parent, Required values only

--- a/test/unit/repositories/conftest.py
+++ b/test/unit/repositories/conftest.py
@@ -26,6 +26,7 @@ def fixture_database_mock() -> Mock:
     database_mock.items = Mock(Collection)
     database_mock.manufacturers = Mock(Collection)
     database_mock.systems = Mock(Collection)
+    database_mock.system_types = Mock(Collection)
     database_mock.units = Mock(Collection)
     database_mock.usage_statuses = Mock(Collection)
     database_mock.settings = Mock(Collection)

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -68,8 +68,6 @@ class CatalogueCategoryRepoDSL:
         self.catalogue_categories_collection = database_mock.catalogue_categories
         self.catalogue_items_collection = database_mock.catalogue_items
 
-        self.mock_session = MagicMock()
-
         with patch("inventory_management_system_api.repositories.catalogue_category.utils") as mock_utils:
             self.mock_utils = mock_utils
             yield

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -45,8 +45,6 @@ class CatalogueItemRepoDSL:
         self.catalogue_items_collection = database_mock.catalogue_items
         self.items_collection = database_mock.items
 
-        self.mock_session = MagicMock()
-
 
 class CreateDSL(CatalogueItemRepoDSL):
     """Base class for `create` tests."""

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -38,8 +38,6 @@ class ItemRepoDSL:
         self.item_repository = ItemRepo(database_mock)
         self.items_collection = database_mock.items
 
-        self.mock_session = MagicMock()
-
 
 class CreateDSL(ItemRepoDSL):
     """Base class for `create` tests."""

--- a/test/unit/repositories/test_manufacturer.py
+++ b/test/unit/repositories/test_manufacturer.py
@@ -42,7 +42,6 @@ class ManufacturerRepoDSL:
         self.manufacturers_collection = database_mock.manufacturers
         self.catalogue_items_collection = database_mock.catalogue_items
 
-        self.mock_session = MagicMock()
         yield
 
     def mock_is_duplicate_manufacturer(self, duplicate_manufacturer_in_data: Optional[dict] = None) -> None:

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -55,8 +55,6 @@ class SystemRepoDSL:
         self.systems_collection = database_mock.systems
         self.items_collection = database_mock.items
 
-        self.mock_session = MagicMock()
-
         with patch("inventory_management_system_api.repositories.system.utils") as mock_utils:
             self.mock_utils = mock_utils
             yield
@@ -421,7 +419,8 @@ class ListDSL(SystemRepoDSL):
     _obtained_systems_out: list[SystemOut]
 
     def mock_list(self, systems_in_data: list[dict]):
-        """Mocks database methods appropriately to test the `list` repo method.
+        """
+        Mocks database methods appropriately to test the `list` repo method.
 
         :param systems_in_data: List of dictionaries containing the system data as would be required for a
                                 `SystemIn` database model (i.e. no ID or created and modified times required).

--- a/test/unit/repositories/test_system_type.py
+++ b/test/unit/repositories/test_system_type.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for the `SystemTypeRepo` repository.
+"""
+
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
+from test.mock_data import SYSTEM_TYPES_OUT_DATA
+from test.unit.repositories.conftest import RepositoryTestHelpers
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from inventory_management_system_api.models.system_type import SystemTypeOut
+from inventory_management_system_api.repositories.system_type import SystemTypeRepo
+
+
+class SystemTypeRepoDSL:
+    """Base class for `SystemTypeRepo` unit tests."""
+
+    mock_database: Mock
+    system_type_repository: SystemTypeRepo
+    system_types_collection: Mock
+
+    mock_session = MagicMock()
+
+    @pytest.fixture(autouse=True)
+    def setup(self, database_mock):
+        """Setup fixtures."""
+
+        self.mock_database = database_mock
+        self.system_type_repository = SystemTypeRepo(database_mock)
+        self.system_types_collection = database_mock.system_types
+
+
+class ListDSL(SystemTypeRepoDSL):
+    """Base class for `list` tests."""
+
+    _expected_systems_types_out: list[SystemTypeOut]
+    _obtained_system_types_out: list[SystemTypeOut]
+
+    def mock_list(self, system_types_out_data: list[dict]):
+        """
+        Mocks database methods appropriately to test the `list` repo method.
+
+        :param system_types_out_data: List of dictionaries containing the system data as would be required for a
+                                      `SystemOut` database model.
+        """
+
+        self._expected_systems_types_out = [
+            SystemTypeOut(**system_type_out_data) for system_type_out_data in system_types_out_data
+        ]
+        RepositoryTestHelpers.mock_find(self.system_types_collection, system_types_out_data)
+
+    def call_list(self):
+        """Calls the `SystemTypeRepo` `list` method."""
+
+        self._obtained_system_types_out = self.system_type_repository.list(session=self.mock_session)
+
+    def check_list_success(self):
+        """Checks that a prior call to `call_list` worked as expected."""
+
+        self.system_types_collection.find.assert_called_once_with(session=self.mock_session)
+        assert self._obtained_system_types_out == self._expected_systems_types_out
+
+
+class TestList(ListDSL):
+    """Tests for listing system types."""
+
+    def test_list(self):
+        """Test listing all system types."""
+
+        self.mock_list(SYSTEM_TYPES_OUT_DATA)
+        self.call_list()
+        self.check_list_success()
+
+    def test_list_with_no_results(self):
+        """Test listing all system types returning no results."""
+
+        self.mock_list([])
+        self.call_list()
+        self.check_list_success()

--- a/test/unit/repositories/test_unit.py
+++ b/test/unit/repositories/test_unit.py
@@ -44,7 +44,6 @@ class UnitRepoDSL:
         self.units_collection = database_mock.units
         self.catalogue_categories_collection = database_mock.catalogue_categories
 
-        self.mock_session = MagicMock()
         yield
 
     def mock_is_duplicate_unit(self, duplicate_unit_in_data: Optional[dict] = None) -> None:

--- a/test/unit/repositories/test_usage_status.py
+++ b/test/unit/repositories/test_usage_status.py
@@ -42,7 +42,6 @@ class UsageStatusRepoDSL:
         self.usage_statuses_collection = database_mock.usage_statuses
         self.items_collection = database_mock.items
 
-        self.mock_session = MagicMock()
         yield
 
     def mock_is_duplicate_usage_status(self, duplicate_usage_status_in_data: Optional[dict] = None) -> None:

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -21,6 +21,7 @@ from inventory_management_system_api.repositories.catalogue_item import Catalogu
 from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
 from inventory_management_system_api.repositories.system import SystemRepo
+from inventory_management_system_api.repositories.system_type import SystemTypeRepo
 from inventory_management_system_api.repositories.unit import UnitRepo
 from inventory_management_system_api.repositories.usage_status import UsageStatusRepo
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
@@ -32,6 +33,7 @@ from inventory_management_system_api.services.catalogue_item import CatalogueIte
 from inventory_management_system_api.services.item import ItemService
 from inventory_management_system_api.services.manufacturer import ManufacturerService
 from inventory_management_system_api.services.system import SystemService
+from inventory_management_system_api.services.system_type import SystemTypeService
 from inventory_management_system_api.services.unit import UnitService
 from inventory_management_system_api.services.usage_status import UsageStatusService
 
@@ -74,6 +76,16 @@ def fixture_manufacturer_repository_mock() -> Mock:
     :return: Mocked `ManufacturerRepo` instance
     """
     return Mock(ManufacturerRepo)
+
+
+@pytest.fixture(name="system_type_repository_mock")
+def fixture_system_type_repository_mock() -> Mock:
+    """
+    Fixture to create a mock of the `SystemTypeRepo` dependency.
+
+    :return: Mocked `SystemTypeRepo` instance.
+    """
+    return Mock(SystemTypeRepo)
 
 
 @pytest.fixture(name="system_repository_mock")
@@ -198,6 +210,17 @@ def fixture_manufacturer_service(manufacturer_repository_mock: Mock) -> Manufact
     :return: `ManufacturerService` instance with mocked dependency.
     """
     return ManufacturerService(manufacturer_repository_mock)
+
+
+@pytest.fixture(name="system_type_service")
+def fixture_system_type_service(system_type_repository_mock: Mock) -> SystemTypeService:
+    """
+    Fixture to create a `SystemTypeService` instance with a mocked `SystemTypeRepo` dependency.
+
+    :param system_type_repository_mock: Mocked `SystemTypeRepo` instance.
+    :return: `SystemTypeService` instance with the mocked dependency.
+    """
+    return SystemTypeService(system_type_repository_mock)
 
 
 @pytest.fixture(name="system_service")

--- a/test/unit/services/test_system_type.py
+++ b/test/unit/services/test_system_type.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for the `SystemTypeService` service.
+"""
+
+from test.unit.services.conftest import ServiceTestHelpers
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from inventory_management_system_api.services.system_type import SystemTypeService
+
+
+class SystemTypeServiceDSL:
+    """Base class for `SystemTypeService` unit tests."""
+
+    mock_system_type_repository: Mock
+    system_type_service: SystemTypeService
+
+    @pytest.fixture(autouse=True)
+    def setup(self, system_type_repository_mock, system_type_service):
+        """Setup fixtures."""
+
+        self.mock_system_type_repository = system_type_repository_mock
+        self.system_type_service = system_type_service
+
+
+class ListDSL(SystemTypeServiceDSL):
+    """Base class for `list` tests."""
+
+    _expected_system_types: MagicMock
+    _obtained_system_types: MagicMock
+
+    def mock_list(self) -> None:
+        """Mocks repo methods appropriately to test the `list` service method."""
+
+        # Simply a return currently, so no need to use actual data
+        self._expected_system_types = MagicMock()
+        ServiceTestHelpers.mock_list(self.mock_system_type_repository, self._expected_system_types)
+
+    def call_list(self) -> None:
+        """Calls the `SystemTypeService` `list` method."""
+
+        self._obtained_system_types = self.system_type_service.list()
+
+    def check_list_success(self) -> None:
+        """Checks that a prior call to `call_list` worked as expected."""
+
+        self.mock_system_type_repository.list.assert_called_once_with()
+        assert self._obtained_system_types == self._expected_system_types
+
+
+class TestList(ListDSL):
+    """Tests for listing system types."""
+
+    def test_list(self):
+        """Test listing system types."""
+
+        self.mock_list()
+        self.call_list()
+        self.check_list_success()


### PR DESCRIPTION
## Description

See #542. Adds a GET `/system-types` that returns a list of available system types. I also noticed we were missing logging in the list methods in the repo layer of units and usage statuses compared to the others, so I added them in too.
 
## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #542 
