### PR TITLE
Exclude migration script and router modules from test coverage measurement

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,5 @@ coverage:
         target: 75
 ignore:
   - "test/",
-  - "inventory_management_system_api/migrations/scripts/*" # ignore migration scripts
+  - "inventory_management_system_api/migrations/scripts/*", # ignore migration scripts
+  - "inventory_management_system_api/routers/v1/*" # ignore routers as they are tested in the e2e tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ dev = [
 [tool.coverage.run]
 omit = [
     # Exclude migration scripts from coverage measurement
-    "inventory_management_system_api/migrations/scripts/*"
+    "inventory_management_system_api/migrations/scripts/*",
+    # Exclude routers from coverage measurement as they are tested in the e2e tests
+    "inventory_management_system_api/routers/v1/*"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Description
Excludes the migration scripts and router modules from the code coverage measurement.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #560 