### PR TITLE
Add rules list endpoint #544

### DIFF
--- a/inventory_management_system_api/main.py
+++ b/inventory_management_system_api/main.py
@@ -17,6 +17,7 @@ from inventory_management_system_api.routers.v1 import (
     catalogue_item,
     item,
     manufacturer,
+    rule,
     system,
     system_type,
     unit,
@@ -94,6 +95,7 @@ app.include_router(system.router, dependencies=router_dependencies)
 app.include_router(system_type.router, dependencies=router_dependencies)
 app.include_router(unit.router, dependencies=router_dependencies)
 app.include_router(usage_status.router, dependencies=router_dependencies)
+app.include_router(rule.router, dependencies=router_dependencies)
 
 
 @app.get("/")

--- a/inventory_management_system_api/models/rule.py
+++ b/inventory_management_system_api/models/rule.py
@@ -1,0 +1,20 @@
+"""
+Module for defining the database models for representing rules.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from inventory_management_system_api.models.custom_object_id_data_types import StringObjectIdField
+
+
+class RuleOut(BaseModel):
+    """
+    Output database model for a rule.
+    """
+
+    id: StringObjectIdField = Field(alias="_id")
+    src_system_type_id: StringObjectIdField
+    dst_system_type_id: StringObjectIdField
+    dst_usage_status_id: StringObjectIdField
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/inventory_management_system_api/models/rule.py
+++ b/inventory_management_system_api/models/rule.py
@@ -2,9 +2,13 @@
 Module for defining the database models for representing rules.
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from inventory_management_system_api.models.custom_object_id_data_types import StringObjectIdField
+from inventory_management_system_api.models.system_type import SystemTypeOut
+from inventory_management_system_api.models.usage_status import UsageStatusOut
 
 
 class RuleOut(BaseModel):
@@ -13,8 +17,10 @@ class RuleOut(BaseModel):
     """
 
     id: StringObjectIdField = Field(alias="_id")
-    src_system_type_id: StringObjectIdField
-    dst_system_type_id: StringObjectIdField
-    dst_usage_status_id: StringObjectIdField
+    # We set these default values to None, as when they are not found in the MongoDB aggregate query, they wont be
+    # set and this saves us from making the query more complex
+    src_system_type: Optional[SystemTypeOut] = None
+    dst_system_type: Optional[SystemTypeOut] = None
+    dst_usage_status: Optional[UsageStatusOut] = None
 
     model_config = ConfigDict(populate_by_name=True)

--- a/inventory_management_system_api/models/system_type.py
+++ b/inventory_management_system_api/models/system_type.py
@@ -2,7 +2,7 @@
 Module for defining the database models for representing system types.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from inventory_management_system_api.models.custom_object_id_data_types import StringObjectIdField
 
@@ -14,3 +14,5 @@ class SystemTypeOut(BaseModel):
 
     id: StringObjectIdField = Field(alias="_id")
     value: str
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/inventory_management_system_api/repositories/catalogue_category.py
+++ b/inventory_management_system_api/repositories/catalogue_category.py
@@ -126,7 +126,7 @@ class CatalogueCategoryRepo:
         :return: A list of catalogue categories, or an empty list if no catalogue categories are returned by the
                  database.
         """
-        query = utils.list_query(parent_id, "catalogue categories")
+        query = utils.list_query({"parent_id": parent_id}, "catalogue categories")
 
         catalogue_categories = self._catalogue_categories_collection.find(query, session=session)
         return [CatalogueCategoryOut(**catalogue_category) for catalogue_category in catalogue_categories]

--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -9,6 +9,7 @@ from pymongo.collection import Collection
 
 from inventory_management_system_api.core.database import DatabaseDep
 from inventory_management_system_api.models.rule import RuleOut
+from inventory_management_system_api.repositories import utils
 
 
 class RuleRepo:
@@ -25,15 +26,27 @@ class RuleRepo:
         self._database = database
         self._rules_collection: Collection = self._database.rules
 
-    def list(self, session: Optional[ClientSession] = None) -> list[RuleOut]:
+    def list(
+        self,
+        src_system_type_id: Optional[str],
+        dst_system_type_id: Optional[str],
+        session: Optional[ClientSession] = None,
+    ) -> list[RuleOut]:
         """
         Retrieve rules from a MongoDB database based on the provided filters.
 
+        :param src_system_type_id: `src_system_type_id` to filter rules by.
+        :param dst_system_type_id: `dst_system_type_id` to filter rules by.
         :param session: PyMongo ClientSession to use for database operations.
         :return: List of rules or an empty list if no rules are retrieved.
         """
         result = self._rules_collection.aggregate(
             [
+                {
+                    "$match": utils.list_query(
+                        {"src_system_type_id": src_system_type_id, "dst_system_type_id": dst_system_type_id}, "rules"
+                    )
+                },
                 {
                     "$lookup": {
                         "from": "system_types",

--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -11,6 +11,40 @@ from inventory_management_system_api.core.database import DatabaseDep
 from inventory_management_system_api.models.rule import RuleOut
 from inventory_management_system_api.repositories import utils
 
+# Aggregation pipeline stages for looking up the entities inside rules and inserting them into the retrieved documents
+RULES_GET_AGGREGATION_PIPELINE_ENTITY_INSERT_STAGES = [
+    # Obtain the system types and usage statuses
+    {
+        "$lookup": {
+            "from": "system_types",
+            "localField": "src_system_type_id",
+            "foreignField": "_id",
+            "as": "src_system_type",
+        }
+    },
+    {
+        "$lookup": {
+            "from": "system_types",
+            "localField": "dst_system_type_id",
+            "foreignField": "_id",
+            "as": "dst_system_type",
+        }
+    },
+    {
+        "$lookup": {
+            "from": "usage_statuses",
+            "localField": "dst_usage_status_id",
+            "foreignField": "_id",
+            "as": "dst_usage_status",
+        }
+    },
+    # The above are returned as lists, unwind so they are a single value and ensure that where documents
+    # have a value of `null` in the relevant field, the document is still retained
+    {"$unwind": {"path": "$src_system_type", "preserveNullAndEmptyArrays": True}},
+    {"$unwind": {"path": "$dst_system_type", "preserveNullAndEmptyArrays": True}},
+    {"$unwind": {"path": "$dst_usage_status", "preserveNullAndEmptyArrays": True}},
+]
+
 
 class RuleRepo:
     """
@@ -35,45 +69,21 @@ class RuleRepo:
         """
         Retrieve rules from a MongoDB database based on the provided filters.
 
-        :param src_system_type_id: `src_system_type_id` to filter rules by.
-        :param dst_system_type_id: `dst_system_type_id` to filter rules by.
+        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
+        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
         :param session: PyMongo ClientSession to use for database operations.
         :return: List of rules or an empty list if no rules are retrieved.
         """
         result = self._rules_collection.aggregate(
             [
+                # Obtain just those matching the filters
                 {
                     "$match": utils.list_query(
                         {"src_system_type_id": src_system_type_id, "dst_system_type_id": dst_system_type_id}, "rules"
                     )
                 },
-                {
-                    "$lookup": {
-                        "from": "system_types",
-                        "localField": "src_system_type_id",
-                        "foreignField": "_id",
-                        "as": "src_system_type",
-                    }
-                },
-                {
-                    "$lookup": {
-                        "from": "system_types",
-                        "localField": "dst_system_type_id",
-                        "foreignField": "_id",
-                        "as": "dst_system_type",
-                    }
-                },
-                {
-                    "$lookup": {
-                        "from": "usage_statuses",
-                        "localField": "dst_usage_status_id",
-                        "foreignField": "_id",
-                        "as": "dst_usage_status",
-                    }
-                },
-                {"$unwind": {"path": "$src_system_type", "preserveNullAndEmptyArrays": True}},
-                {"$unwind": {"path": "$dst_system_type", "preserveNullAndEmptyArrays": True}},
-                {"$unwind": {"path": "$dst_usage_status", "preserveNullAndEmptyArrays": True}},
+                # Lookup and insert system types and usage statuses
+                *RULES_GET_AGGREGATION_PIPELINE_ENTITY_INSERT_STAGES,
             ],
             session=session,
         )

--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -1,0 +1,36 @@
+"""
+Module for providing a repository for managing rules in a MongoDB database.
+"""
+
+from typing import Optional
+
+from pymongo.client_session import ClientSession
+from pymongo.collection import Collection
+
+from inventory_management_system_api.core.database import DatabaseDep
+from inventory_management_system_api.models.rule import RuleOut
+
+
+class RuleRepo:
+    """
+    Repository for managing rules in a MongoDB database.
+    """
+
+    def __init__(self, database: DatabaseDep) -> None:
+        """
+        Initialise the `RulesRepo` with a MongoDB database instance.
+
+        :param database: Database to use.
+        """
+        self._database = database
+        self._rules_collection: Collection = self._database.rules
+
+    def list(self, session: Optional[ClientSession] = None) -> list[RuleOut]:
+        """
+        Retrieve rules from a MongoDB database based on the provided filters.
+
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: List of rules or an empty list if no rules are retrieved.
+        """
+        rules = self._rules_collection.find({}, session=session)
+        return [RuleOut(**rule) for rule in rules]

--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -69,8 +69,8 @@ class RuleRepo:
         """
         Retrieve rules from a MongoDB database based on the provided filters.
 
-        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
-        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
+        :param src_system_type_id: ID of the source system type to query by, or `None`.
+        :param dst_system_type_id: ID of the destination system type to query by, or `None`.
         :param session: PyMongo ClientSession to use for database operations.
         :return: List of rules or an empty list if no rules are retrieved.
         """

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -1,5 +1,5 @@
 """
-Module for providing a repository for managing systems in a MongoDB database
+Module for providing a repository for managing systems in a MongoDB database.
 """
 
 import logging
@@ -20,14 +20,14 @@ logger = logging.getLogger()
 
 class SystemRepo:
     """
-    Repository for managing systems in a MongoDB database
+    Repository for managing systems in a MongoDB database.
     """
 
     def __init__(self, database: DatabaseDep) -> None:
         """
-        Initialise the `SystemRepo` with a MongoDB database instance
+        Initialise the `SystemRepo` with a MongoDB database instance.
 
-        :param database: Database to use
+        :param database: Database to use.
         """
         self._database = database
         self._systems_collection: Collection = self._database.systems
@@ -35,17 +35,17 @@ class SystemRepo:
 
     def create(self, system: SystemIn, session: Optional[ClientSession] = None) -> SystemOut:
         """
-        Create a new system in a MongoDB database
+        Create a new system in a MongoDB database.
 
         If a parent system is specified by `parent_id`, then checks if that exists in the database and raises a
         `MissingRecordError` if it doesn't exist. It also checks if a duplicate system is found within the parent
         system and raises a `DuplicateRecordError` if it is.
 
-        :param system: System to be created
-        :param session: PyMongo ClientSession to use for database operations
-        :return: Created system
-        :raises MissingRecordError: If the parent system specified by `parent_id` doesn't exist
-        :raises DuplicateRecordError: If a duplicate system is found within the parent system
+        :param system: System to be created.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: Created system.
+        :raises MissingRecordError: If the parent system specified by `parent_id` doesn't exist.
+        :raises DuplicateRecordError: If a duplicate system is found within the parent system.
         """
         parent_id = str(system.parent_id) if system.parent_id else None
         if parent_id and not self.get(parent_id, session=session):
@@ -61,11 +61,11 @@ class SystemRepo:
 
     def get(self, system_id: str, session: Optional[ClientSession] = None) -> Optional[SystemOut]:
         """
-        Retrieve a system by its ID from a MongoDB database
+        Retrieve a system by its ID from a MongoDB database.
 
-        :param system_id: ID of the system to retrieve
-        :param session: PyMongo ClientSession to use for database operations
-        :return: Retrieved system or `None` if not found
+        :param system_id: ID of the system to retrieve.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: Retrieved system or `None` if not found.
         """
         system_id = CustomObjectId(system_id)
         logger.info("Retrieving system with ID: %s from the database", system_id)
@@ -76,11 +76,11 @@ class SystemRepo:
 
     def get_breadcrumbs(self, system_id: str, session: Optional[ClientSession] = None) -> BreadcrumbsGetSchema:
         """
-        Retrieve the breadcrumbs for a specific system
+        Retrieve the breadcrumbs for a specific system.
 
-        :param system_id: ID of the system to retrieve breadcrumbs for
-        :param session: PyMongo ClientSession to use for database operations
-        :return: Breadcrumbs
+        :param system_id: ID of the system to retrieve breadcrumbs for.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: Breadcrumbs.
         """
         logger.info("Querying breadcrumbs for system with id '%s'", system_id)
         return utils.compute_breadcrumbs(
@@ -96,11 +96,11 @@ class SystemRepo:
 
     def list(self, parent_id: Optional[str], session: Optional[ClientSession] = None) -> list[SystemOut]:
         """
-        Retrieve systems from a MongoDB database based on the provided filters
+        Retrieve systems from a MongoDB database based on the provided filters.
 
-        :param parent_id: parent_id to filter systems by
-        :param session: PyMongo ClientSession to use for database operations
-        :return: List of systems or an empty list if no systems are retrieved
+        :param parent_id: parent_id to filter systems by.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: List of systems or an empty list if no systems are retrieved.
         """
         query = utils.list_query(parent_id, "systems")
 
@@ -108,15 +108,16 @@ class SystemRepo:
         return [SystemOut(**system) for system in systems]
 
     def update(self, system_id: str, system: SystemIn, session: Optional[ClientSession] = None) -> SystemOut:
-        """Update a system by its ID in a MongoDB database
+        """
+        Update a system by its ID in a MongoDB database.
 
-        :param system_id: ID of the system to update
-        :param system: System containing the update data
-        :param session: PyMongo ClientSession to use for database operations
-        :return: The updated system
-        :raises MissingRecordError: If the parent system specified by `parent_id` doesn't exist
-        :raises DuplicateRecordError: If a duplicate system is found within the parent system
-        :raises InvalidActionError: If attempting to change the `parent_id` to one of its own child system ids
+        :param system_id: ID of the system to update.
+        :param system: System containing the update data.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: The updated system.
+        :raises MissingRecordError: If the parent system specified by `parent_id` doesn't exist.
+        :raises DuplicateRecordError: If a duplicate system is found within the parent system.
+        :raises InvalidActionError: If attempting to change the `parent_id` to one of its own child system ids.
         """
         system_id = CustomObjectId(system_id)
 
@@ -152,14 +153,14 @@ class SystemRepo:
 
     def delete(self, system_id: str, session: Optional[ClientSession] = None) -> None:
         """
-        Delete a system by its ID from a MongoDB database
+        Delete a system by its ID from a MongoDB database.
 
-        The method checks if the system has any child and raises a `ChildElementsExistError` if it does
+        The method checks if the system has any child and raises a `ChildElementsExistError` if it does.
 
-        :param system_id: ID of the system to delete
-        :param session: PyMongo ClientSession to use for database operations
-        :raises ChildElementsExistError: If the system has child elements
-        :raises MissingRecordError: If the system doesn't exist
+        :param system_id: ID of the system to delete.
+        :param session: PyMongo ClientSession to use for database operations.
+        :raises ChildElementsExistError: If the system has child elements.
+        :raises MissingRecordError: If the system doesn't exist.
         """
         logger.info("Deleting system with ID: %s from the database", system_id)
         result = self._systems_collection.delete_one({"_id": CustomObjectId(system_id)}, session=session)
@@ -174,13 +175,13 @@ class SystemRepo:
         session: Optional[ClientSession] = None,
     ) -> bool:
         """
-        Check if a system with the same code already exists within the parent system
+        Check if a system with the same code already exists within the parent system.
 
-        :param parent_id: ID of the parent system which can also be `None`
-        :param code: Code of the system to check for duplicates
+        :param parent_id: ID of the parent system which can also be `None`.
+        :param code: Code of the system to check for duplicates.
         :param system_id: The ID of the system to check if the duplicate system found is itself.
-        :param session: PyMongo ClientSession to use for database operations
-        :return: `True` if a duplicate system code is found under the given parent, `False` otherwise
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: `True` if a duplicate system code is found under the given parent, `False` otherwise.
         """
         logger.info("Checking if system with code '%s' already exists within the parent System", code)
         if parent_id:
@@ -193,11 +194,11 @@ class SystemRepo:
 
     def has_child_elements(self, system_id: str, session: Optional[ClientSession] = None) -> bool:
         """
-        Check if a system has any child system's or any Item's based on its ID
+        Check if a system has any child system's or any Item's based on its ID.
 
-        :param system_id: ID of the system to check
-        :param session: PyMongo ClientSession to use for database operations
-        :return: `True` if the system has child elements, `False` otherwise
+        :param system_id: ID of the system to check.
+        :param session: PyMongo ClientSession to use for database operations.
+        :return: `True` if the system has child elements, `False` otherwise.
         """
         logger.info("Checking if system with ID '%s' has child elements", system_id)
         system_id = CustomObjectId(system_id)

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -98,11 +98,11 @@ class SystemRepo:
         """
         Retrieve systems from a MongoDB database based on the provided filters.
 
-        :param parent_id: parent_id to filter systems by.
+        :param parent_id: `parent_id` to filter systems by.
         :param session: PyMongo ClientSession to use for database operations.
         :return: List of systems or an empty list if no systems are retrieved.
         """
-        query = utils.list_query(parent_id, "systems")
+        query = utils.list_query({"parent_id": parent_id}, "systems")
 
         systems = self._systems_collection.find(query, session=session)
         return [SystemOut(**system) for system in systems]

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -98,7 +98,7 @@ class SystemRepo:
         """
         Retrieve systems from a MongoDB database based on the provided filters.
 
-        :param parent_id: `parent_id` to filter the systems by or `None`.
+        :param parent_id: ID of the parent system to query by, or `None`.
         :param session: PyMongo ClientSession to use for database operations.
         :return: List of systems or an empty list if no systems are retrieved.
         """

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -98,7 +98,7 @@ class SystemRepo:
         """
         Retrieve systems from a MongoDB database based on the provided filters.
 
-        :param parent_id: `parent_id` to filter systems by.
+        :param parent_id: `parent_id` to filter the systems by or `None`.
         :param session: PyMongo ClientSession to use for database operations.
         :return: List of systems or an empty list if no systems are retrieved.
         """

--- a/inventory_management_system_api/repositories/utils.py
+++ b/inventory_management_system_api/repositories/utils.py
@@ -13,19 +13,23 @@ from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSc
 logger = logging.getLogger()
 
 
-def list_query(parent_id: Optional[str], entity_type: str) -> dict:
+def list_query(id_fields: dict[str, Optional[str]], entity_type: str) -> dict:
     """
-    Constructs filters for a pymongo collection based on a given `parent_id`
-    also logging the action
+    Constructs filters for a pymongo collection based on a given list of ID values to filter by while also logging the
+    action.
 
-    :param parent_id: `parent_id` to filter `entity_type` by (Converted to a uuid here - a string value of "null"
-                      indicates that the `parent_id` should be null, not that there shouldn't be a query)
+    :param id_fields: List of ID filters to filter `entity_type` by. Each key value is the name of the ID field,
+                      and each value is the value to filter by. The value is converted to a uuid here - a string value
+                      of "null" indicates that the relevant ID should be null, not that there shouldn't be a query on
+                      it.
     :param entity_type: Name of the entity type e.g. catalogue categories/systems (Used for logging)
-    :return: Dictionary representing the query to pass to a pymongo's Collection `find` function
+    :return: Dictionary representing the query to pass to a pymongo's Collection `find` function or aggregate pipeline
+             match stage.
     """
     query = {}
-    if parent_id:
-        query["parent_id"] = None if parent_id == "null" else CustomObjectId(parent_id)
+    for field_name, field_value in id_fields.items():
+        if field_value:
+            query[field_name] = None if field_value == "null" else CustomObjectId(field_value)
 
     message = f"Retrieving all {entity_type} from the database"
     if not query:

--- a/inventory_management_system_api/repositories/utils.py
+++ b/inventory_management_system_api/repositories/utils.py
@@ -19,9 +19,9 @@ def list_query(id_fields: dict[str, Optional[str]], entity_type: str) -> dict:
     action.
 
     :param id_fields: List of ID filters to filter `entity_type` by. Each key value is the name of the ID field,
-                      and each value is the value to filter by. The value is converted to a uuid here - a string value
-                      of "null" indicates that the relevant ID should be null, not that there shouldn't be a query on
-                      it.
+                      and each value is the value to filter by. The value is converted to a CustomObjectId here - a
+                      string value of "null" indicates that the relevant ID should be null, not that there shouldn't be
+                      a query on it.
     :param entity_type: Name of the entity type e.g. catalogue categories/systems (Used for logging)
     :return: Dictionary representing the query to pass to a pymongo's Collection `find` function or aggregate pipeline
              match stage.

--- a/inventory_management_system_api/repositories/utils.py
+++ b/inventory_management_system_api/repositories/utils.py
@@ -28,6 +28,7 @@ def list_query(id_fields: dict[str, Optional[str]], entity_type: str) -> dict:
     """
     query = {}
     for field_name, field_value in id_fields.items():
+        # Only add to query when the value is defined as the default value is always None when a user doesn't specify it
         if field_value:
             query[field_name] = None if field_value == "null" else CustomObjectId(field_value)
 

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -102,8 +102,8 @@ def get_catalogue_categories(
             CatalogueCategorySchema(**catalogue_category.model_dump()) for catalogue_category in catalogue_categories
         ]
     except InvalidObjectIdError:
-        # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
-        # the same as a valid one that doesn't exist i.e. return an empty list
+        # As this endpoint filters, and to hide the database behaviour, we treat any invalid id the same as a valid one
+        # that doesn't exist i.e. return an empty list
         return []
 
 

--- a/inventory_management_system_api/routers/v1/rule.py
+++ b/inventory_management_system_api/routers/v1/rule.py
@@ -1,0 +1,36 @@
+"""
+Module for providing an API router which defines routes for managing rules using the `RuleService` service.
+"""
+
+# We don't define docstrings in router methods as they would end up in the openapi/swagger docs. We also expect
+# some duplicate code inside routers as the code is similar between entities and error handling may be repeated.
+# pylint: disable=missing-function-docstring
+# pylint: disable=duplicate-code
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from inventory_management_system_api.core.exceptions import InvalidObjectIdError
+from inventory_management_system_api.schemas.rule import RuleSchema
+from inventory_management_system_api.services.rule import RuleService
+
+logger = logging.getLogger()
+
+router = APIRouter(prefix="/v1/rules", tags=["rules"])
+
+RuleServiceDep = Annotated[RuleService, Depends(RuleService)]
+
+
+@router.get("", summary="Get rules", response_description="List of rules")
+def get_rules(rule_service: RuleServiceDep) -> list[RuleSchema]:
+    logger.info("Getting rules")
+
+    try:
+        rules = rule_service.list()
+        return [RuleSchema(**rule.model_dump()) for rule in rules]
+    except InvalidObjectIdError:
+        # As this endpoint filters, and to hide the database behaviour, we treat any invalid id the same as a valid one
+        # that doesn't exist i.e. return an empty list
+        return []

--- a/inventory_management_system_api/routers/v1/rule.py
+++ b/inventory_management_system_api/routers/v1/rule.py
@@ -8,9 +8,9 @@ Module for providing an API router which defines routes for managing rules using
 # pylint: disable=duplicate-code
 
 import logging
-from typing import Annotated
+from typing import Annotated, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from inventory_management_system_api.core.exceptions import InvalidObjectIdError
 from inventory_management_system_api.schemas.rule import RuleSchema
@@ -24,11 +24,21 @@ RuleServiceDep = Annotated[RuleService, Depends(RuleService)]
 
 
 @router.get("", summary="Get rules", response_description="List of rules")
-def get_rules(rule_service: RuleServiceDep) -> list[RuleSchema]:
+def get_rules(
+    rule_service: RuleServiceDep,
+    src_system_type_id: Annotated[Optional[str], Query(description="Filter rules by the source system type ID")] = None,
+    dst_system_type_id: Annotated[
+        Optional[str], Query(description="Filter rules by the destination system type ID")
+    ] = None,
+) -> list[RuleSchema]:
     logger.info("Getting rules")
+    if src_system_type_id:
+        logger.debug("Source system type ID filter: '%s'", src_system_type_id)
+    if dst_system_type_id:
+        logger.debug("Destination system type ID filter: '%s'", dst_system_type_id)
 
     try:
-        rules = rule_service.list()
+        rules = rule_service.list(src_system_type_id, dst_system_type_id)
         return [RuleSchema(**rule.model_dump()) for rule in rules]
     except InvalidObjectIdError:
         # As this endpoint filters, and to hide the database behaviour, we treat any invalid id the same as a valid one

--- a/inventory_management_system_api/routers/v1/system.py
+++ b/inventory_management_system_api/routers/v1/system.py
@@ -71,7 +71,7 @@ def get_systems(
     system_service: SystemServiceDep,
     parent_id: Annotated[Optional[str], Query(description="Filter systems by parent ID")] = None,
 ) -> list[SystemSchema]:
-    logger.info("Getting Systems")
+    logger.info("Getting systems")
     if parent_id:
         logger.debug("Parent ID filter: '%s'", parent_id)
 
@@ -79,8 +79,8 @@ def get_systems(
         systems = system_service.list(parent_id)
         return [SystemSchema(**system.model_dump()) for system in systems]
     except InvalidObjectIdError:
-        # As this endpoint filters, and to hide the database behaviour, we treat any invalid id
-        # the same as a valid one that doesn't exist i.e. return an empty list
+        # As this endpoint filters, and to hide the database behaviour, we treat any invalid id the same as a valid one
+        # that doesn't exist i.e. return an empty list
         return []
 
 

--- a/inventory_management_system_api/schemas/rule.py
+++ b/inventory_management_system_api/schemas/rule.py
@@ -2,7 +2,12 @@
 Module for defining the API schema models for representing rules.
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
+
+from inventory_management_system_api.schemas.system_type import SystemTypeSchema
+from inventory_management_system_api.schemas.usage_status import UsageStatusSchema
 
 
 class RuleSchema(BaseModel):
@@ -11,6 +16,6 @@ class RuleSchema(BaseModel):
     """
 
     id: str = Field(description="ID of the rule")
-    src_system_type_id: str = Field(description="ID of the source system type of the rule")
-    dst_system_type_id: str = Field(description="ID of the destination system type of the rule")
-    dst_usage_status_id: str = Field(description="ID of the usage status to be used at the destination")
+    src_system_type: Optional[SystemTypeSchema] = Field(description="Source system type of the rule")
+    dst_system_type: Optional[SystemTypeSchema] = Field(description="Destination system type of the rule")
+    dst_usage_status: Optional[UsageStatusSchema] = Field(description="Usage status to be used at the destination")

--- a/inventory_management_system_api/schemas/rule.py
+++ b/inventory_management_system_api/schemas/rule.py
@@ -1,0 +1,16 @@
+"""
+Module for defining the API schema models for representing rules.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class RuleSchema(BaseModel):
+    """
+    Schema model for rule get request responses.
+    """
+
+    id: str = Field(description="ID of the rule")
+    src_system_type_id: str = Field(description="ID of the source system type of the rule")
+    dst_system_type_id: str = Field(description="ID of the destination system type of the rule")
+    dst_usage_status_id: str = Field(description="ID of the usage status to be used at the destination")

--- a/inventory_management_system_api/schemas/system.py
+++ b/inventory_management_system_api/schemas/system.py
@@ -46,7 +46,7 @@ class SystemPatchSchema(SystemPostSchema):
 
 class SystemSchema(CreatedModifiedSchemaMixin, SystemPostSchema):
     """
-    Schema model for system get request response.
+    Schema model for system get request responses.
     """
 
     id: str = Field(description="ID of the system")

--- a/inventory_management_system_api/services/rule.py
+++ b/inventory_management_system_api/services/rule.py
@@ -2,7 +2,7 @@
 Module for providing a service for managing rules using the `RuleRepo` repository.
 """
 
-from typing import Annotated
+from typing import Annotated, Optional
 
 from fastapi import Depends
 
@@ -23,10 +23,12 @@ class RuleService:
         """
         self._rule_repository = rule_repository
 
-    def list(self) -> list[RuleOut]:
+    def list(self, src_system_type_id: Optional[str], dst_system_type_id: Optional[str]) -> list[RuleOut]:
         """
         Retrieve rules based on the provided filters.
 
+        :param src_system_type_id: `src_system_type_id` to filter rules by.
+        :param dst_system_type_id: `dst_system_type_id` to filter rules by.
         :return: List of rules or an empty list if no rules are retrieved.
         """
-        return self._rule_repository.list()
+        return self._rule_repository.list(src_system_type_id, dst_system_type_id)

--- a/inventory_management_system_api/services/rule.py
+++ b/inventory_management_system_api/services/rule.py
@@ -27,8 +27,8 @@ class RuleService:
         """
         Retrieve rules based on the provided filters.
 
-        :param src_system_type_id: `src_system_type_id` to filter rules by.
-        :param dst_system_type_id: `dst_system_type_id` to filter rules by.
+        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
+        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
         :return: List of rules or an empty list if no rules are retrieved.
         """
         return self._rule_repository.list(src_system_type_id, dst_system_type_id)

--- a/inventory_management_system_api/services/rule.py
+++ b/inventory_management_system_api/services/rule.py
@@ -27,8 +27,8 @@ class RuleService:
         """
         Retrieve rules based on the provided filters.
 
-        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
-        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
+        :param src_system_type_id: ID of the source system type to query by, or `None`.
+        :param dst_system_type_id: ID of the destination system type to query by, or `None`.
         :return: List of rules or an empty list if no rules are retrieved.
         """
         return self._rule_repository.list(src_system_type_id, dst_system_type_id)

--- a/inventory_management_system_api/services/rule.py
+++ b/inventory_management_system_api/services/rule.py
@@ -1,0 +1,32 @@
+"""
+Module for providing a service for managing rules using the `RuleRepo` repository.
+"""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from inventory_management_system_api.models.rule import RuleOut
+from inventory_management_system_api.repositories.rule import RuleRepo
+
+
+class RuleService:
+    """
+    Service for managing rules.
+    """
+
+    def __init__(self, rule_repository: Annotated[RuleRepo, Depends(RuleRepo)]) -> None:
+        """
+        Initialise the `RuleService` with a `RuleRepo` repository.
+
+        :param rule_repository: `RuleRepo` repository to use.
+        """
+        self._rule_repository = rule_repository
+
+    def list(self) -> list[RuleOut]:
+        """
+        Retrieve rules based on the provided filters.
+
+        :return: List of rules or an empty list if no rules are retrieved.
+        """
+        return self._rule_repository.list()

--- a/inventory_management_system_api/services/system.py
+++ b/inventory_management_system_api/services/system.py
@@ -49,10 +49,10 @@ class SystemService:
 
     def create(self, system: SystemPostSchema) -> SystemOut:
         """
-        Create a new system
+        Create a new system.
 
-        :param system: System to be created
-        :return: Created system
+        :param system: System to be created.
+        :return: Created system.
         :raises MissingRecordError: If the system type specified by `type_id` doesn't exist.
         :raises MissingRecordError: If the parent system specified by `parent_id` doesn't exist.
         :raises InvalidActionError: If the system being created has a different `type_id` to its parent.
@@ -86,39 +86,39 @@ class SystemService:
 
     def get(self, system_id: str) -> Optional[SystemOut]:
         """
-        Retrieve a system by its ID
+        Retrieve a system by its ID.
 
-        :param system_id: ID of the system to retrieve
-        :return: Retrieved system or `None` if not found
+        :param system_id: ID of the system to retrieve.
+        :return: Retrieved system or `None` if not found.
         """
         return self._system_repository.get(system_id)
 
     def get_breadcrumbs(self, system_id: str) -> BreadcrumbsGetSchema:
         """
-        Retrieve the breadcrumbs for a specific system
+        Retrieve the breadcrumbs for a specific system.
 
-        :param system_id: ID of the system to retrieve breadcrumbs for
-        :return: Breadcrumbs
+        :param system_id: ID of the system to retrieve breadcrumbs for.
+        :return: Breadcrumbs.
         """
         return self._system_repository.get_breadcrumbs(system_id)
 
     def list(self, parent_id: Optional[str]) -> list[SystemOut]:
         """
-        Retrieve systems based on the provided filters
+        Retrieve systems based on the provided filters.
 
-        :param parent_id: `parent_id` to filter systems by
-        :return: List of systems or an empty list if no systems are retrieved
+        :param parent_id: `parent_id` to filter systems by.
+        :return: List of systems or an empty list if no systems are retrieved.
         """
         return self._system_repository.list(parent_id)
 
     def update(self, system_id: str, system: SystemPatchSchema) -> SystemOut:
         """
-        Update a system by its ID
+        Update a system by its ID.
 
-        :param system_id: ID of the system to updated
-        :param system: System containing the fields to be updated
-        :raises MissingRecordError: When the system with the given ID doesn't exist
-        :return: The updated system
+        :param system_id: ID of the system to updated.
+        :param system: System containing the fields to be updated.
+        :raises MissingRecordError: When the system with the given ID doesn't exist.
+        :return: The updated system.
         """
         stored_system = self.get(system_id)
         if not stored_system:
@@ -142,9 +142,9 @@ class SystemService:
 
     def delete(self, system_id: str, access_token: Optional[str] = None) -> None:
         """
-        Delete a system by its ID
+        Delete a system by its ID.
 
-        :param system_id: ID of the system to delete
+        :param system_id: ID of the system to delete.
         :param access_token: The JWT access token to use for auth with the Object Storage API if object storage enabled.
         """
         if self._system_repository.has_child_elements(system_id):
@@ -163,8 +163,8 @@ class SystemService:
         """
         Validate an update request that could modify the `type_id` or `parent_id` of the system.
 
-        :param system_id: ID of the system to updated
-        :param system: System containing the fields to be updated
+        :param system_id: ID of the system to updated.
+        :param system: System containing the fields to be updated.
         :param stored_system: Current stored system from the database.
         :param update_data: Dictionary containing the update data.
         :raises MissingRecordError: If the parent system specified by `parent_id` doesn't exist.

--- a/inventory_management_system_api/services/system.py
+++ b/inventory_management_system_api/services/system.py
@@ -106,7 +106,7 @@ class SystemService:
         """
         Retrieve systems based on the provided filters.
 
-        :param parent_id: `parent_id` to filter the systems by or `None`.
+        :param parent_id: ID of the parent system to query by, or `None`.
         :return: List of systems or an empty list if no systems are retrieved.
         """
         return self._system_repository.list(parent_id)

--- a/inventory_management_system_api/services/system.py
+++ b/inventory_management_system_api/services/system.py
@@ -106,7 +106,7 @@ class SystemService:
         """
         Retrieve systems based on the provided filters.
 
-        :param parent_id: `parent_id` to filter systems by.
+        :param parent_id: `parent_id` to filter the systems by or `None`.
         :return: List of systems or an empty list if no systems are retrieved.
         """
         return self._system_repository.list(parent_id)

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -427,8 +427,6 @@ class TestGet(GetDSL):
 class GetBreadcrumbsDSL(GetDSL):
     """Base class for breadcrumbs tests."""
 
-    _get_response_catalogue_category: Response
-
     _posted_catalogue_categories_get_data: list[dict]
 
     @pytest.fixture(autouse=True)

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -46,7 +46,7 @@ from test.mock_data import (
     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE1,
     SYSTEM_POST_DATA_NO_PARENT_A,
     UNIT_POST_DATA_MM,
-    USAGE_STATUS_OUT_DATA_IN_USE,
+    USAGE_STATUS_GET_DATA_IN_USE,
 )
 from typing import Any, Optional
 
@@ -811,7 +811,7 @@ class UpdateDSL(ListDSL):
             "notes": "Test notes",
             "catalogue_item_id": self._post_response_catalogue_item.json()["id"],
             "system_id": system_id,
-            "usage_status_id": USAGE_STATUS_OUT_DATA_IN_USE["id"],
+            "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"],
             "properties": [],
         }
         self.test_client.post("/v1/items", json=item_post)

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -38,7 +38,7 @@ from test.mock_data import (
     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE2,
     SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT,
     SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
-    USAGE_STATUS_OUT_DATA_NEW,
+    USAGE_STATUS_GET_DATA_NEW,
     USAGE_STATUS_POST_DATA_IN_USE,
 )
 from typing import Any, Optional
@@ -889,12 +889,12 @@ class TestUpdate(UpdateDSL):
 
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, {"usage_status_id": USAGE_STATUS_OUT_DATA_NEW["id"]})
+        self.patch_item(item_id, {"usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]})
         self.check_patch_item_success(
             {
                 **ITEM_GET_DATA_REQUIRED_VALUES_ONLY,
-                "usage_status_id": USAGE_STATUS_OUT_DATA_NEW["id"],
-                "usage_status": USAGE_STATUS_OUT_DATA_NEW["value"],
+                "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"],
+                "usage_status": USAGE_STATUS_GET_DATA_NEW["value"],
             }
         )
 

--- a/test/e2e/test_rules.py
+++ b/test/e2e/test_rules.py
@@ -1,0 +1,113 @@
+"""
+End-to-End tests for the rule router.
+"""
+
+# Expect some duplicate code inside tests as the tests for the different entities can be very similar
+# pylint: disable=duplicate-code
+
+
+from test.mock_data import (
+    RULE_GET_DATA_OPERATIONAL_TO_SCRAPPED,
+    RULE_GET_DATA_OPERATIONAL_TO_STORAGE,
+    RULE_GET_DATA_STORAGE_CREATION,
+    RULE_GET_DATA_STORAGE_DELETION,
+    RULES_GET_DATA,
+    SYSTEM_TYPE_GET_DATA_OPERATIONAL,
+    SYSTEM_TYPE_GET_DATA_STORAGE,
+)
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx import Response
+
+
+class ListDSL:
+    """Base class for list tests."""
+
+    test_client: TestClient
+
+    _get_response_rule: Response
+
+    @pytest.fixture(autouse=True)
+    def setup_rule_list_dsl(self, test_client):
+        """Setup fixtures."""
+
+        self.test_client = test_client
+
+    def get_rules(self, filters: dict) -> None:
+        """
+        Gets a list of rules with the given filters.
+
+        :param filters: Filters to use in the request.
+        """
+
+        self._get_response_rule = self.test_client.get("/v1/rules", params=filters)
+
+    def check_get_rules_success(self, expected_rules_get_data: list[dict]) -> None:
+        """
+        Checks that a prior call to `get_rules` gave a successful response with the expected data returned.
+
+        :param expected_rules_get_data: List of dictionaries containing the expected rule data returned as would be
+                                        required for `RuleSchema`'s.
+        """
+
+        assert self._get_response_rule.status_code == 200
+        assert self._get_response_rule.json() == expected_rules_get_data
+
+
+class TestList(ListDSL):
+    """Tests for getting a list of systems."""
+
+    def test_list_with_no_filters(self):
+        """Test getting a list of all rules with no filters provided."""
+
+        self.get_rules(filters={})
+        self.check_get_rules_success(RULES_GET_DATA)
+
+    def test_list_with_src_system_type_id_filter(self):
+        """Test getting a list of all rules with a `src_system_type_id` filter provided."""
+
+        self.get_rules(filters={"src_system_type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]})
+        self.check_get_rules_success([RULE_GET_DATA_OPERATIONAL_TO_STORAGE, RULE_GET_DATA_OPERATIONAL_TO_SCRAPPED])
+
+    def test_list_with_null_src_system_type_id_filter(self):
+        """Test getting a list of all rules with a `src_system_type_id` filter of `null` provided."""
+
+        self.get_rules(filters={"src_system_type_id": "null"})
+        self.check_get_rules_success([RULE_GET_DATA_STORAGE_CREATION])
+
+    def test_list_with_invalid_src_system_type_id_filter(self):
+        """Test getting a list of all rules with an invalid `src_system_type_id` filter provided."""
+
+        self.get_rules(filters={"src_system_type_id": "invalid-id"})
+        self.check_get_rules_success([])
+
+    def test_list_with_dst_system_type_id_filter(self):
+        """Test getting a list of all rules with a `dst_system_type_id` filter provided."""
+
+        self.get_rules(filters={"dst_system_type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"]})
+        self.check_get_rules_success([RULE_GET_DATA_STORAGE_CREATION, RULE_GET_DATA_OPERATIONAL_TO_STORAGE])
+
+    def test_list_with_null_dst_system_type_id_filter(self):
+        """Test getting a list of all rules with a `dst_system_type_id` filter of `null` provided."""
+
+        self.get_rules(filters={"dst_system_type_id": "null"})
+        self.check_get_rules_success([RULE_GET_DATA_STORAGE_DELETION])
+
+    def test_list_with_invalid_dst_system_type_id_filter(self):
+        """Test getting a list of all rules with an invalid `dst_system_type_id` filter provided."""
+
+        self.get_rules(filters={"dst_system_type_id": "invalid-id"})
+        self.check_get_rules_success([])
+
+    def test_list_with_src_and_dst_system_type_id_filter(self):
+        """Test getting a list of all rules with `src_system_type_id` and `dst_system_type_id` filters provided
+        when there are no matching results."""
+
+        self.get_rules(
+            filters={
+                "src_system_type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"],
+                "dst_system_type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"],
+            }
+        )
+        self.check_get_rules_success([])

--- a/test/e2e/test_system.py
+++ b/test/e2e/test_system.py
@@ -37,7 +37,7 @@ class CreateDSL:
 
     @pytest.fixture(autouse=True)
     def setup_system_create_dsl(self, test_client):
-        """Setup fixtures"""
+        """Setup fixtures."""
 
         self.test_client = test_client
 
@@ -226,8 +226,6 @@ class TestGet(GetDSL):
 
 class GetBreadcrumbsDSL(GetDSL):
     """Base class for breadcrumbs tests."""
-
-    _get_response_system: Response
 
     _posted_systems_get_data: list[dict]
 

--- a/test/e2e/test_usage_status.py
+++ b/test/e2e/test_usage_status.py
@@ -13,7 +13,6 @@ from test.mock_data import (
     USAGE_STATUS_GET_DATA_NEW,
     USAGE_STATUS_GET_DATA_SCRAPPED,
     USAGE_STATUS_GET_DATA_USED,
-    USAGE_STATUS_OUT_DATA_NEW,
     USAGE_STATUS_POST_DATA_CUSTOM,
 )
 from typing import Optional
@@ -256,7 +255,7 @@ class TestDelete(DeleteDSL):
 
     def test_delete_when_part_of_rule(self):
         """Test deleting a usage status when it is part of a rule."""
-        self.delete_usage_status(str(USAGE_STATUS_OUT_DATA_NEW["id"]))
+        self.delete_usage_status(str(USAGE_STATUS_GET_DATA_NEW["id"]))
         self.check_delete_usage_status_failed_with_detail(409, "The specified usage status is part of a rule")
 
     def test_delete_with_non_existent_id(self):

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -69,12 +69,13 @@ USAGE_STATUS_IN_DATA_NEW = {
     "code": "new",
 }
 
-USAGE_STATUS_OUT_DATA_NEW = UsageStatusOut(
-    **UsageStatusIn(**USAGE_STATUS_IN_DATA_NEW).model_dump(), _id=PREDEFINED_USAGE_STATUS_IDS[0]
-).model_dump()
+USAGE_STATUS_OUT_DATA_NEW = {
+    **UsageStatusIn(**USAGE_STATUS_IN_DATA_NEW).model_dump(),
+    "_id": PREDEFINED_USAGE_STATUS_IDS[0],
+}
 
 USAGE_STATUS_GET_DATA_NEW = {
-    **USAGE_STATUS_OUT_DATA_NEW,
+    **UsageStatusOut(**USAGE_STATUS_OUT_DATA_NEW).model_dump(),
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
 }
 
@@ -83,12 +84,13 @@ USAGE_STATUS_POST_DATA_IN_USE = {"value": "In Use"}
 
 USAGE_STATUS_IN_DATA_IN_USE = {**USAGE_STATUS_POST_DATA_IN_USE, "code": "in-use"}
 
-USAGE_STATUS_OUT_DATA_IN_USE = UsageStatusOut(
-    **UsageStatusIn(**USAGE_STATUS_IN_DATA_IN_USE).model_dump(), _id=PREDEFINED_USAGE_STATUS_IDS[1]
-).model_dump()
+USAGE_STATUS_OUT_DATA_IN_USE = {
+    **UsageStatusIn(**USAGE_STATUS_IN_DATA_IN_USE).model_dump(),
+    "_id": PREDEFINED_USAGE_STATUS_IDS[1],
+}
 
 USAGE_STATUS_GET_DATA_IN_USE = {
-    **USAGE_STATUS_OUT_DATA_IN_USE,
+    **UsageStatusOut(**USAGE_STATUS_OUT_DATA_IN_USE).model_dump(),
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
 }
 
@@ -100,12 +102,13 @@ USAGE_STATUS_IN_DATA_USED = {
     "code": "used",
 }
 
-USAGE_STATUS_OUT_DATA_USED = UsageStatusOut(
-    **UsageStatusIn(**USAGE_STATUS_IN_DATA_USED).model_dump(), _id=PREDEFINED_USAGE_STATUS_IDS[2]
-).model_dump()
+USAGE_STATUS_OUT_DATA_USED = {
+    **UsageStatusIn(**USAGE_STATUS_IN_DATA_USED).model_dump(),
+    "_id": PREDEFINED_USAGE_STATUS_IDS[2],
+}
 
 USAGE_STATUS_GET_DATA_USED = {
-    **USAGE_STATUS_OUT_DATA_USED,
+    **UsageStatusOut(**USAGE_STATUS_OUT_DATA_USED).model_dump(),
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
 }
 
@@ -117,12 +120,13 @@ USAGE_STATUS_IN_DATA_SCRAPPED = {
     "code": "scrapped",
 }
 
-USAGE_STATUS_OUT_DATA_SCRAPPED = UsageStatusOut(
-    **UsageStatusIn(**USAGE_STATUS_IN_DATA_SCRAPPED).model_dump(), _id=PREDEFINED_USAGE_STATUS_IDS[3]
-).model_dump()
+USAGE_STATUS_OUT_DATA_SCRAPPED = {
+    **UsageStatusIn(**USAGE_STATUS_IN_DATA_SCRAPPED).model_dump(),
+    "_id": PREDEFINED_USAGE_STATUS_IDS[3],
+}
 
 USAGE_STATUS_GET_DATA_SCRAPPED = {
-    **USAGE_STATUS_OUT_DATA_SCRAPPED,
+    **UsageStatusOut(**USAGE_STATUS_OUT_DATA_SCRAPPED).model_dump(),
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
 }
 
@@ -134,12 +138,10 @@ USAGE_STATUS_IN_DATA_CUSTOM = {
     "code": "custom",
 }
 
-USAGE_STATUS_OUT_DATA_CUSTOM = UsageStatusOut(
-    **UsageStatusIn(**USAGE_STATUS_IN_DATA_CUSTOM).model_dump(), _id=str(ObjectId())
-).model_dump()
+USAGE_STATUS_OUT_DATA_CUSTOM = {**UsageStatusIn(**USAGE_STATUS_IN_DATA_CUSTOM).model_dump(), "_id": ObjectId()}
 
 USAGE_STATUS_GET_DATA_CUSTOM = {
-    **USAGE_STATUS_OUT_DATA_CUSTOM,
+    **UsageStatusOut(**USAGE_STATUS_OUT_DATA_CUSTOM).model_dump(),
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
 }
@@ -676,21 +678,21 @@ BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES = CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTI
 
 ITEM_DATA_REQUIRED_VALUES_ONLY = {
     "is_defective": False,
-    "usage_status_id": USAGE_STATUS_OUT_DATA_IN_USE["id"],
+    "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"],
 }
 
 ITEM_IN_DATA_REQUIRED_VALUES_ONLY = {
     **ITEM_DATA_REQUIRED_VALUES_ONLY,
     "catalogue_item_id": str(ObjectId()),
     "system_id": str(ObjectId()),
-    "usage_status": USAGE_STATUS_OUT_DATA_IN_USE["value"],
+    "usage_status": USAGE_STATUS_GET_DATA_IN_USE["value"],
 }
 
 ITEM_GET_DATA_REQUIRED_VALUES_ONLY = {
     **ITEM_DATA_REQUIRED_VALUES_ONLY,
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
-    "usage_status": USAGE_STATUS_OUT_DATA_IN_USE["value"],
+    "usage_status": USAGE_STATUS_GET_DATA_IN_USE["value"],
     "purchase_order_number": None,
     "warranty_end_date": None,
     "asset_number": None,

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -837,6 +837,23 @@ SYSTEM_TYPE_OUT_DATA_OPERATIONAL = SYSTEM_TYPES_OUT_DATA[1]
 SYSTEM_TYPE_GET_DATA_STORAGE = SYSTEM_TYPES_GET_DATA[0]
 SYSTEM_TYPE_GET_DATA_OPERATIONAL = SYSTEM_TYPES_GET_DATA[1]
 
+# ---------------------------------- RULES ----------------------------------
+
+RULES_OUT_DATA = [
+    {
+        "_id": ObjectId(),
+        "src_system_type": None,
+        "dst_system_type": SYSTEM_TYPE_OUT_DATA_STORAGE,
+        "dst_usage_status": USAGE_STATUS_OUT_DATA_NEW,
+    },
+    {
+        "_id": ObjectId(),
+        "src_system_type": SYSTEM_TYPE_GET_DATA_STORAGE,
+        "dst_system_type": None,
+        "dst_usage_status": None,
+    },
+]
+
 # --------------------------------- SYSTEMS ---------------------------------
 
 # No parent, Required values only

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -20,6 +20,8 @@ from bson import ObjectId
 from inventory_management_system_api.models.setting import SparesDefinitionOut
 from inventory_management_system_api.models.usage_status import UsageStatusIn, UsageStatusOut
 
+# pylint: disable=too-many-lines
+
 # ---------------------------- GENERAL -----------------------------
 
 # Used for _GET_DATA's as when comparing these will not be possible to know at runtime
@@ -831,28 +833,15 @@ SYSTEM_TYPES_GET_DATA = [
 
 # Storage
 SYSTEM_TYPE_OUT_DATA_STORAGE = SYSTEM_TYPES_OUT_DATA[0]
-SYSTEM_TYPE_OUT_DATA_OPERATIONAL = SYSTEM_TYPES_OUT_DATA[1]
+SYSTEM_TYPE_GET_DATA_STORAGE = SYSTEM_TYPES_GET_DATA[0]
 
 # Operational
-SYSTEM_TYPE_GET_DATA_STORAGE = SYSTEM_TYPES_GET_DATA[0]
+SYSTEM_TYPE_OUT_DATA_OPERATIONAL = SYSTEM_TYPES_OUT_DATA[1]
 SYSTEM_TYPE_GET_DATA_OPERATIONAL = SYSTEM_TYPES_GET_DATA[1]
 
-# ---------------------------------- RULES ----------------------------------
-
-RULES_OUT_DATA = [
-    {
-        "_id": ObjectId(),
-        "src_system_type": None,
-        "dst_system_type": SYSTEM_TYPE_OUT_DATA_STORAGE,
-        "dst_usage_status": USAGE_STATUS_OUT_DATA_NEW,
-    },
-    {
-        "_id": ObjectId(),
-        "src_system_type": SYSTEM_TYPE_GET_DATA_STORAGE,
-        "dst_system_type": None,
-        "dst_usage_status": None,
-    },
-]
+# Scrapped
+SYSTEM_TYPE_OUT_DATA_SCRAPPED = SYSTEM_TYPES_OUT_DATA[2]
+SYSTEM_TYPE_GET_DATA_SCRAPPED = SYSTEM_TYPES_GET_DATA[2]
 
 # --------------------------------- SYSTEMS ---------------------------------
 
@@ -944,3 +933,97 @@ SETTING_SPARES_DEFINITION_IN_DATA_STORAGE_OR_OPERATIONAL = {
     "_id": SparesDefinitionOut.SETTING_ID,
     "system_type_ids": [SYSTEM_TYPE_GET_DATA_STORAGE["id"], SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]],
 }
+
+# ---------------------------------- RULES ----------------------------------
+
+# Creation in storage
+RULE_OUT_DATA_STORAGE_CREATION = {
+    "_id": ObjectId(),
+    "src_system_type": None,
+    "dst_system_type": SYSTEM_TYPE_OUT_DATA_STORAGE,
+    "dst_usage_status": USAGE_STATUS_OUT_DATA_NEW,
+}
+
+RULE_GET_DATA_STORAGE_CREATION = {
+    "id": ANY,
+    "src_system_type": None,
+    "dst_system_type": SYSTEM_TYPE_GET_DATA_STORAGE,
+    "dst_usage_status": USAGE_STATUS_GET_DATA_NEW,
+}
+
+# Deletion from storage
+RULE_OUT_DATA_STORAGE_DELETION = {
+    "_id": ObjectId(),
+    "src_system_type": SYSTEM_TYPE_OUT_DATA_STORAGE,
+    "dst_system_type": None,
+    "dst_usage_status": None,
+}
+
+RULE_GET_DATA_STORAGE_DELETION = {
+    "id": ANY,
+    "src_system_type": SYSTEM_TYPE_GET_DATA_STORAGE,
+    "dst_system_type": None,
+    "dst_usage_status": None,
+}
+
+# Storage to operational
+RULE_OUT_DATA_STORAGE_TO_OPERATIONAL = {
+    "_id": ObjectId(),
+    "src_system_type": SYSTEM_TYPE_OUT_DATA_STORAGE,
+    "dst_system_type": SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
+    "dst_usage_status": USAGE_STATUS_OUT_DATA_IN_USE,
+}
+
+RULE_GET_DATA_STORAGE_TO_OPERATIONAL = {
+    "id": ANY,
+    "src_system_type": SYSTEM_TYPE_GET_DATA_STORAGE,
+    "dst_system_type": SYSTEM_TYPE_GET_DATA_OPERATIONAL,
+    "dst_usage_status": USAGE_STATUS_GET_DATA_IN_USE,
+}
+
+# Operational to storage
+RULE_OUT_DATA_OPERATIONAL_TO_STORAGE = {
+    "_id": ObjectId(),
+    "src_system_type": SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
+    "dst_system_type": SYSTEM_TYPE_OUT_DATA_STORAGE,
+    "dst_usage_status": USAGE_STATUS_OUT_DATA_USED,
+}
+
+RULE_GET_DATA_OPERATIONAL_TO_STORAGE = {
+    "id": ANY,
+    "src_system_type": SYSTEM_TYPE_GET_DATA_OPERATIONAL,
+    "dst_system_type": SYSTEM_TYPE_GET_DATA_STORAGE,
+    "dst_usage_status": USAGE_STATUS_GET_DATA_USED,
+}
+
+# Operational to scrapped
+RULE_OUT_DATA_OPERATIONAL_TO_SCRAPPED = {
+    "_id": ObjectId(),
+    "src_system_type": SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
+    "dst_system_type": SYSTEM_TYPE_OUT_DATA_SCRAPPED,
+    "dst_usage_status": USAGE_STATUS_OUT_DATA_SCRAPPED,
+}
+
+RULE_GET_DATA_OPERATIONAL_TO_SCRAPPED = {
+    "id": ANY,
+    "src_system_type": SYSTEM_TYPE_GET_DATA_OPERATIONAL,
+    "dst_system_type": SYSTEM_TYPE_GET_DATA_SCRAPPED,
+    "dst_usage_status": USAGE_STATUS_GET_DATA_SCRAPPED,
+}
+
+
+RULES_OUT_DATA = [
+    RULE_OUT_DATA_STORAGE_CREATION,
+    RULE_OUT_DATA_STORAGE_DELETION,
+    RULE_OUT_DATA_STORAGE_TO_OPERATIONAL,
+    RULE_OUT_DATA_OPERATIONAL_TO_STORAGE,
+    RULE_OUT_DATA_OPERATIONAL_TO_SCRAPPED,
+]
+
+RULES_GET_DATA = [
+    RULE_GET_DATA_STORAGE_CREATION,
+    RULE_GET_DATA_STORAGE_DELETION,
+    RULE_GET_DATA_STORAGE_TO_OPERATIONAL,
+    RULE_GET_DATA_OPERATIONAL_TO_STORAGE,
+    RULE_GET_DATA_OPERATIONAL_TO_SCRAPPED,
+]

--- a/test/unit/repositories/test_catalogue_category.py
+++ b/test/unit/repositories/test_catalogue_category.py
@@ -517,7 +517,9 @@ class ListDSL(CatalogueCategoryRepoDSL):
     def check_list_success(self) -> None:
         """Checks that a prior call to `call_list` worked as expected."""
 
-        self.mock_utils.list_query.assert_called_once_with(self._parent_id_filter, "catalogue categories")
+        self.mock_utils.list_query.assert_called_once_with(
+            {"parent_id": self._parent_id_filter}, "catalogue categories"
+        )
         self.catalogue_categories_collection.find.assert_called_once_with(
             self.mock_utils.list_query.return_value, session=self.mock_session
         )

--- a/test/unit/repositories/test_rule.py
+++ b/test/unit/repositories/test_rule.py
@@ -63,8 +63,8 @@ class ListDSL(RuleRepoDSL):
         """
         Calls the `RuleRepo` `list` method.
 
-        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
-        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
+        :param src_system_type_id: ID of the source system type to query by, or `None`.
+        :param dst_system_type_id: ID of the destination system type to query by, or `None`.
         """
 
         self._src_system_type_id_filter = src_system_type_id

--- a/test/unit/repositories/test_rule.py
+++ b/test/unit/repositories/test_rule.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for the `RuleRepo` repository.
+"""
+
+from test.mock_data import RULES_OUT_DATA
+from typing import Optional
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from bson import ObjectId
+
+from inventory_management_system_api.models.rule import RuleOut
+from inventory_management_system_api.repositories.rule import (
+    RULES_GET_AGGREGATION_PIPELINE_ENTITY_INSERT_STAGES,
+    RuleRepo,
+)
+
+
+class RuleRepoDSL:
+    """Base class for `RuleRepo` unit tests."""
+
+    mock_database: Mock
+    mock_utils: Mock
+    rule_repository: RuleRepo
+    rules_collection: Mock
+
+    mock_session = MagicMock()
+
+    @pytest.fixture(autouse=True)
+    def setup(self, database_mock):
+        """Setup fixtures."""
+
+        self.mock_database = database_mock
+        self.rule_repository = RuleRepo(database_mock)
+        self.rules_collection = database_mock.rules
+
+        with patch("inventory_management_system_api.repositories.rule.utils") as mock_utils:
+            self.mock_utils = mock_utils
+            yield
+
+
+class ListDSL(RuleRepoDSL):
+    """Base class for `list` tests."""
+
+    _expected_rules_out: list[RuleOut]
+    _src_system_type_id_filter: Optional[str]
+    _dst_system_type_id_filter: Optional[str]
+    _obtained_rules_out: list[RuleOut]
+
+    def mock_list(self, rules_out_data: list[dict]):
+        """
+        Mocks database methods appropriately to test the `list` repo method.
+
+        :param rules_out_data: List of dictionaries containing the rule data as would be required for a `RuleOut`
+                               database model.
+        """
+
+        self._expected_rules_out = [RuleOut(**rule_out_data) for rule_out_data in rules_out_data]
+
+        self.rules_collection.aggregate.return_value = [rule_out.model_dump() for rule_out in self._expected_rules_out]
+
+    def call_list(self, src_system_type_id: Optional[str], dst_system_type_id: Optional[str]):
+        """
+        Calls the `RuleRepo` `list` method.
+
+        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
+        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
+        """
+
+        self._src_system_type_id_filter = src_system_type_id
+        self._dst_system_type_id_filter = dst_system_type_id
+
+        self._obtained_rules_out = self.rule_repository.list(
+            src_system_type_id, dst_system_type_id, session=self.mock_session
+        )
+
+    def check_list_success(self):
+        """Checks that a prior call to `call_list` worked as expected."""
+
+        self.mock_utils.list_query.assert_called_once_with(
+            {
+                "src_system_type_id": self._src_system_type_id_filter,
+                "dst_system_type_id": self._dst_system_type_id_filter,
+            },
+            "rules",
+        )
+        self.rules_collection.aggregate.assert_called_once_with(
+            [{"$match": self.mock_utils.list_query.return_value}, *RULES_GET_AGGREGATION_PIPELINE_ENTITY_INSERT_STAGES],
+            session=self.mock_session,
+        )
+
+
+class TestList(ListDSL):
+    """Tests for listing rules."""
+
+    def test_list(self):
+        """Test listing rules."""
+
+        self.mock_list(RULES_OUT_DATA)
+        self.call_list(src_system_type_id=None, dst_system_type_id=None)
+        self.check_list_success()
+
+    def test_list_with_src_system_id_filter(self):
+        """Test listing rules with a given `src_system_type_id`."""
+
+        self.mock_list(RULES_OUT_DATA)
+        self.call_list(src_system_type_id=str(ObjectId()), dst_system_type_id=None)
+        self.check_list_success()
+
+    def test_list_with_dst_system_id_filter(self):
+        """Test listing rules with a given `dst_system_type_id`."""
+
+        self.mock_list(RULES_OUT_DATA)
+        self.call_list(src_system_type_id=None, dst_system_type_id=str(ObjectId()))
+        self.check_list_success()
+
+    def test_list_with_src_and_dst_system_id_filter_with_no_results(self):
+        """Test listing rules with a `src_system_type_id` and `dst_system_type_id` filter returning no results."""
+
+        self.mock_list([])
+        self.call_list(src_system_type_id=str(ObjectId()), dst_system_type_id=str(ObjectId()))
+        self.check_list_success()

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -427,7 +427,7 @@ class ListDSL(SystemRepoDSL):
         """
         Calls the `SystemRepo` `list` method.
 
-        :param parent_id: `parent_id` to filter the systems by or `None`.
+        :param parent_id: ID of the parent system to query by, or `None`.
         """
 
         self._parent_id_filter = parent_id

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -427,12 +427,12 @@ class ListDSL(SystemRepoDSL):
         """
         Calls the `SystemRepo` `list` method.
 
-        :param parent_id: ID of the parent system to query by, or `None`.
+        :param parent_id: `parent_id` to filter the systems by or `None`.
         """
 
         self._parent_id_filter = parent_id
 
-        self._obtained_systems_out = self.system_repository.list(parent_id=parent_id, session=self.mock_session)
+        self._obtained_systems_out = self.system_repository.list(parent_id, session=self.mock_session)
 
     def check_list_success(self):
         """Checks that a prior call to `call_list` worked as expected."""

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -437,7 +437,7 @@ class ListDSL(SystemRepoDSL):
     def check_list_success(self):
         """Checks that a prior call to `call_list` worked as expected."""
 
-        self.mock_utils.list_query.assert_called_once_with(self._parent_id_filter, "systems")
+        self.mock_utils.list_query.assert_called_once_with({"parent_id": self._parent_id_filter}, "systems")
         self.systems_collection.find.assert_called_once_with(
             self.mock_utils.list_query.return_value, session=self.mock_session
         )

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -21,6 +21,7 @@ from inventory_management_system_api.repositories.catalogue_category import Cata
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.repositories.manufacturer import ManufacturerRepo
+from inventory_management_system_api.repositories.rule import RuleRepo
 from inventory_management_system_api.repositories.setting import SettingRepo
 from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.repositories.system_type import SystemTypeRepo
@@ -34,6 +35,7 @@ from inventory_management_system_api.services.catalogue_category_property import
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService
 from inventory_management_system_api.services.item import ItemService
 from inventory_management_system_api.services.manufacturer import ManufacturerService
+from inventory_management_system_api.services.rule import RuleService
 from inventory_management_system_api.services.setting import SettingService
 from inventory_management_system_api.services.system import SystemService
 from inventory_management_system_api.services.system_type import SystemTypeService
@@ -129,6 +131,16 @@ def fixture_setting_repository_mock() -> Mock:
     :return: Mocked `SettingRepo` instance.
     """
     return Mock(SettingRepo)
+
+
+@pytest.fixture(name="rule_repository_mock")
+def fixture_rule_repository_mock() -> Mock:
+    """
+    Fixture to create a mock of the `RuleRepo` dependency.
+
+    :return: Mocked `RuleRepo` instance.
+    """
+    return Mock(RuleRepo)
 
 
 @pytest.fixture(name="catalogue_category_service")
@@ -260,12 +272,12 @@ def fixture_system_service(
     system_repository_mock: Mock, system_type_repository_mock: Mock, setting_repository_mock: Mock
 ) -> SystemService:
     """
-    Fixture to create a `SystemService` instance with a mocked `SystemRepo` dependency.
+    Fixture to create a `SystemService` instance with mocked `SystemRepo` and `SystemTypeRepo` dependencies.
 
     :param system_repository_mock: Mocked `SystemRepo` instance.
     :param system_type_repository_mock: Mocked `SystemTypeRepo` instance.
     :param setting_repository_mock: Mocked `SettingRepo` instance.
-    :return: `SystemService` instance with the mocked dependency.
+    :return: `SystemService` instance with the mocked dependencies.
     """
     return SystemService(system_repository_mock, system_type_repository_mock, setting_repository_mock)
 
@@ -307,10 +319,22 @@ def fixture_setting_service(
     :param system_type_repository_mock: Mocked `SystemTypeRepo` instance.
     :param catalogue_item_repository_mock: Mocked `CatalogueItemRepo` instance.
     :param item_repository_mock: Mocked `ItemRepo` instance.
+    :return: `SettingService` instance with the mocked dependencies.
     """
     return SettingService(
         setting_repository_mock, system_type_repository_mock, catalogue_item_repository_mock, item_repository_mock
     )
+
+
+@pytest.fixture(name="rule_service")
+def fixture_rule_service(rule_repository_mock: Mock) -> RuleService:
+    """
+    Fixture to create a `RuleService` instance with a mocked `RuleRepo` dependency.
+
+    :param rule_repository_mock: Mocked `RuleRepo` instance.
+    :return: `RuleService` instance with the mocked dependencies.
+    """
+    return RuleService(rule_repository_mock)
 
 
 class ServiceTestHelpers:

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -17,9 +17,9 @@ from test.mock_data import (
     ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY,
     SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
     SYSTEM_IN_DATA_NO_PARENT_A,
+    USAGE_STATUS_GET_DATA_NEW,
     USAGE_STATUS_IN_DATA_IN_USE,
     USAGE_STATUS_IN_DATA_NEW,
-    USAGE_STATUS_OUT_DATA_NEW,
 )
 from test.unit.services.conftest import BaseCatalogueServiceDSL, ServiceTestHelpers
 from typing import List, Optional
@@ -1088,7 +1088,7 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data={"usage_status_id": USAGE_STATUS_OUT_DATA_NEW["id"]},
+            item_update_data={"usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
             stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,

--- a/test/unit/services/test_rule.py
+++ b/test/unit/services/test_rule.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for the `RuleService` service.
+"""
+
+from test.unit.services.conftest import ServiceTestHelpers
+from typing import Optional
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from bson import ObjectId
+
+from inventory_management_system_api.services.rule import RuleService
+
+
+class RuleServiceDSL:
+    """Base class for `RuleService` unit tests."""
+
+    mock_rule_repository: Mock
+    rule_service: RuleService
+
+    @pytest.fixture(autouse=True)
+    def setup(self, rule_repository_mock, rule_service):
+        """Setup fixtures."""
+
+        self.mock_rule_repository = rule_repository_mock
+        self.rule_service = rule_service
+
+
+class ListDSL(RuleServiceDSL):
+    """Base class for `list` tests."""
+
+    _src_system_type_id_filter: Optional[str]
+    _dst_system_type_id_filter: Optional[str]
+    _expected_rules: MagicMock
+    _obtained_rules: MagicMock
+
+    def mock_list(self) -> None:
+        """Mocks repo methods appropriately to test the `list` service method."""
+
+        # Simply a return currently, so no need to use actual data
+        self._expected_rules = MagicMock()
+        ServiceTestHelpers.mock_list(self.mock_rule_repository, self._expected_rules)
+
+    def call_list(self, src_system_type_id: Optional[str], dst_system_type_id: Optional[str]) -> None:
+        """
+        Calls the `RuleService` `list` method.
+
+        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
+        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
+        """
+
+        self._src_system_type_id_filter = src_system_type_id
+        self._dst_system_type_id_filter = dst_system_type_id
+        self._obtained_rules = self.rule_service.list(src_system_type_id, dst_system_type_id)
+
+    def check_list_success(self) -> None:
+        """Checks that a prior call to `call_list` worked as expected."""
+
+        self.mock_rule_repository.list.assert_called_once_with(
+            self._src_system_type_id_filter, self._dst_system_type_id_filter
+        )
+        assert self._obtained_rules == self._expected_rules
+
+
+class TestList(ListDSL):
+    """Tests for listing rules."""
+
+    def test_list(self):
+        """Test listing rules."""
+
+        self.mock_list()
+        self.call_list(str(ObjectId()), str(ObjectId()))
+        self.check_list_success()

--- a/test/unit/services/test_rule.py
+++ b/test/unit/services/test_rule.py
@@ -45,8 +45,8 @@ class ListDSL(RuleServiceDSL):
         """
         Calls the `RuleService` `list` method.
 
-        :param src_system_type_id: `src_system_type_id` to filter the rules by or `None`.
-        :param dst_system_type_id: `dst_system_type_id` to filter the rules by or `None`.
+        :param src_system_type_id: ID of the source system type to query by, or `None`.
+        :param dst_system_type_id: ID of the destination system type to query by, or `None`.
         """
 
         self._src_system_type_id_filter = src_system_type_id

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -410,7 +410,7 @@ class ListDSL(SystemServiceDSL):
         """
         Calls the `SystemService` `list` method.
 
-        :param parent_id: ID of the parent system to query by, or `None`.
+        :param parent_id: `parent_id` to filter the systems by or `None`.
         """
 
         self._parent_id_filter = parent_id

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -410,7 +410,7 @@ class ListDSL(SystemServiceDSL):
         """
         Calls the `SystemService` `list` method.
 
-        :param parent_id: `parent_id` to filter the systems by or `None`.
+        :param parent_id: ID of the parent system to query by, or `None`.
         """
 
         self._parent_id_filter = parent_id


### PR DESCRIPTION
## Description

Adds a `/rules` GET endpoint that returns a list of rules. The rules returned contain the full system type & usage status objects rather than just their IDs for ease of use. It also accepts filtering on the source and destination system types, with a value of `"null"` indicating they should have `null` as their ID (just like we do for `parent_id`'s). This is required so the front end can obtain a list of system types that are valid for creation, deletion and move operations.

## Other notes
- I noticed the usage status OUT models were using string `_id` values. Considering it is what is put into an Out model it should have been given as ObjectId's, so I fixed them.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #544
