### PR TITLE
Implement moving rules #541

### DIFF
--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -98,13 +98,14 @@ class RuleRepo:
         dst_usage_status_id: Optional[str],
         session: Optional[ClientSession] = None,
     ) -> bool:
-        """Checks whether a rule with the given system type and usage status IDs exists, for checking if an operation
-        is valid or not.
+        """
+        Checks whether a rule with the given system type and usage status IDs exists, for checking if an operation is
+        valid or not.
 
         :param src_system_type_id: ID of the source system type to query by.
         :param dst_system_type_id: ID of the destination system type to query by.
         :param dst_usage_status_id: ID of the destination usage status to query by.
-        :session: PyMongo ClientSession to use for database operations.
+        :param session: PyMongo ClientSession to use for database operations.
         :return: Whether at least one rule with the given parameters was found or not.
         """
         rule = self._rules_collection.find_one(

--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -7,6 +7,7 @@ from typing import Optional
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
 
+from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.core.database import DatabaseDep
 from inventory_management_system_api.models.rule import RuleOut
 from inventory_management_system_api.repositories import utils
@@ -89,3 +90,29 @@ class RuleRepo:
         )
         rules = list(result)
         return [RuleOut(**rule) for rule in rules]
+
+    def check_exists(
+        self,
+        src_system_type_id: Optional[str],
+        dst_system_type_id: Optional[str],
+        dst_usage_status_id: Optional[str],
+        session: Optional[ClientSession] = None,
+    ) -> bool:
+        """Checks whether a rule with the given system type and usage status IDs exists, for checking if an operation
+        is valid or not.
+
+        :param src_system_type_id: ID of the source system type to query by.
+        :param dst_system_type_id: ID of the destination system type to query by.
+        :param dst_usage_status_id: ID of the destination usage status to query by.
+        :session: PyMongo ClientSession to use for database operations.
+        :return: Whether at least one rule with the given parameters was found or not.
+        """
+        rule = self._rules_collection.find_one(
+            {
+                "src_system_type_id": CustomObjectId(src_system_type_id) if src_system_type_id else None,
+                "dst_system_type_id": CustomObjectId(dst_system_type_id) if dst_system_type_id else None,
+                "dst_usage_status_id": CustomObjectId(dst_usage_status_id) if dst_usage_status_id else None,
+            },
+            session=session,
+        )
+        return rule is not None

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -149,7 +149,7 @@ def partial_update_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
     except InvalidActionError as exc:
-        message = "Cannot change the catalogue item of an item"
+        message = str(exc)
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=message) from exc
     except WriteConflictError as exc:

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -130,13 +130,19 @@ class CatalogueItemService:
         """
         Update a catalogue item by its ID.
 
-        The method checks if the catalogue item exists in the database and raises a `MissingRecordError` if it does
-        not. If the catalogue category ID is being updated, it checks if catalogue category with such ID exists and
-        raises a MissingRecordError` if it does not. It also checks if the category is not a leaf category and raises a
-        `NonLeafCatalogueCategoryError` if it is. If the properties are being updated, it also processes them.
+        If the properties are being updated, it also processes them.
 
         :param catalogue_item_id: The ID of the catalogue item to update.
         :param catalogue_item: The catalogue item containing the fields that need to be updated.
+        :raises MissingRecordError: If the catalogue item doesn't exist.
+        :raises ChildElementsExistError: If updating a property that is not allowed to be edited when there are child
+                                         entities, and there are child entities currently.
+        :raises MissingRecordError: If the catalogue category doesn't exist.
+        :raises NonLeafCatalogueCategoryError: If the catalogue category isn't a leaf category.
+        :raises InvalidActionError: If moving the catalogue item between categories with different properties without
+                                    explicitly specifying them.
+        :raises MissingRecordError: If the manufacturer doesn't exist.
+        :raises MissingRecordError: If the obsolete replacement catalogue item doesn't exist.
         :return: The updated catalogue item.
         """
         update_data = catalogue_item.model_dump(exclude_unset=True)

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -146,8 +146,8 @@ class ItemService:
         """
         Update an item by its ID.
 
-        When updating properties, existing properties must all be supplied, or they will
-        be overwritten by the properties.
+        When updating properties, existing properties must all be supplied, or they will be overwritten by the
+        properties.
 
         :param item_id: The ID of the item to update.
         :param item: The item containing the fields that need to be updated.

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -29,6 +29,7 @@ from inventory_management_system_api.models.setting import SparesDefinitionOut
 from inventory_management_system_api.repositories.catalogue_category import CatalogueCategoryRepo
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
+from inventory_management_system_api.repositories.rule import RuleRepo
 from inventory_management_system_api.repositories.setting import SettingRepo
 from inventory_management_system_api.repositories.system import SystemRepo
 from inventory_management_system_api.repositories.usage_status import UsageStatusRepo
@@ -53,6 +54,7 @@ class ItemService:
         catalogue_item_repository: Annotated[CatalogueItemRepo, Depends(CatalogueItemRepo)],
         system_repository: Annotated[SystemRepo, Depends(SystemRepo)],
         usage_status_repository: Annotated[UsageStatusRepo, Depends(UsageStatusRepo)],
+        rule_repository: Annotated[RuleRepo, Depends(RuleRepo)],
         setting_repository: Annotated[SettingRepo, Depends(SettingRepo)],
     ) -> None:
         """
@@ -64,6 +66,7 @@ class ItemService:
         :param catalogue_item_repository: The `CatalogueItemRepo` repository to use.
         :param system_repository: The `SystemRepo` repository to use.
         :param usage_status_repository: The `UsageStatusRepo` repository to use.
+        :param rule_repository: The `RuleRepo` repository to use.
         :param setting_repository: The `SettingRepo` repository to use.
         """
         self._item_repository = item_repository
@@ -71,6 +74,7 @@ class ItemService:
         self._catalogue_item_repository = catalogue_item_repository
         self._system_repository = system_repository
         self._usage_status_repository = usage_status_repository
+        self._rule_repository = rule_repository
         self._setting_repository = setting_repository
 
     def create(self, item: ItemPostSchema) -> ItemOut:
@@ -82,6 +86,8 @@ class ItemService:
         :param item: The item to be created.
         :return: The created item.
         :raises MissingRecordError: If the catalogue item does not exist.
+        :raises DatabaseIntegrityError: If the catalogue category of the catalogue item doesn't exist.
+        :raises MissingRecordError: If the usage status does not exist.
         """
         catalogue_item_id = item.catalogue_item_id
         catalogue_item = self._catalogue_item_repository.get(catalogue_item_id)
@@ -137,18 +143,26 @@ class ItemService:
         return self._item_repository.list(system_id, catalogue_item_id)
 
     # pylint:disable=too-many-locals
+    # pylint:disable=too-many-branches
     def update(self, item_id: str, item: ItemPatchSchema) -> ItemOut:
         """
         Update an item by its ID.
 
-        The method checks if the item exists in the database and raises a `MissingRecordError` if it does
-        not. If the system ID is being updated, it checks if the system ID with such ID exists and raises
-        a `MissingRecordError` if it does not. It raises a `ChildElementsExistError` if a catalogue item
-        ID is supplied. When updating properties, existing properties must all be supplied, or they will
+        When updating properties, existing properties must all be supplied, or they will
         be overwritten by the properties.
 
         :param item_id: The ID of the item to update.
         :param item: The item containing the fields that need to be updated.
+        :raises MissingRecordError: If the item doesn't exist.
+        :raises InvalidActionError: If attempting to change the catalogue item of the item.
+        :raises InvalidActionError: If attempting to change the usage status without also moving the item between
+                                    systems.
+        :raises MissingRecordError: If the usage status doesn't exist.
+        :raises MissingRecordError: If the system doesn't exist.
+        :raises InvalidActionError: If moving the item between systems of different type and the moving rule doesn't
+                                    exist.
+        :raises InvalidActionError: If moving the item between systems of the same type and trying to change the usage
+                                    status.
         :return: The updated item.
         """
         update_data = item.model_dump(exclude_unset=True)
@@ -161,16 +175,42 @@ class ItemService:
             raise InvalidActionError("Cannot change the catalogue item the item belongs to")
 
         moving_system = "system_id" in update_data and item.system_id != stored_item.system_id
-        if moving_system:
-            system = self._system_repository.get(item.system_id)
-            if not system:
-                raise MissingRecordError(f"No system found with ID: {item.system_id}")
-        if "usage_status_id" in update_data and item.usage_status_id != stored_item.usage_status_id:
+        changing_usage_status = "usage_status_id" in update_data and item.usage_status_id != stored_item.usage_status_id
+
+        usage_status_id = stored_item.usage_status_id
+        if changing_usage_status:
+            if not moving_system:
+                raise InvalidActionError(
+                    "Cannot change usage status without moving between systems according to a defined rule"
+                )
+
             usage_status_id = item.usage_status_id
             usage_status = self._usage_status_repository.get(usage_status_id)
             if not usage_status:
                 raise MissingRecordError(f"No usage status found with ID: {usage_status_id}")
             update_data["usage_status"] = usage_status.value
+
+        if moving_system:
+            system = self._system_repository.get(item.system_id)
+            if not system:
+                raise MissingRecordError(f"No system found with ID: {item.system_id}")
+
+            if current_system.type_id != system.type_id:
+                # System type is changing - Ensure the moving operation is allowed by a rule
+                current_system = self._system_repository.get(stored_item.system_id)
+                if not self._rule_repository.check_exists(
+                    src_system_type_id=current_system.type_id,
+                    dst_system_type_id=system.type_id,
+                    dst_usage_status_id=usage_status_id,
+                ):
+                    raise InvalidActionError(
+                        "No rule found for moving between the given system's types with the same final usage status"
+                    )
+            elif changing_usage_status:
+                # When system type is not changing - Ensure the usage status is unchanged
+                raise InvalidActionError(
+                    "Cannot change usage status of an item when moving between two systems of the same type"
+                )
 
         # If catalogue item ID not supplied then it will be fetched, and its parent catalogue category.
         # the defined (at a catalogue category level) and supplied properties will be used to find
@@ -207,6 +247,7 @@ class ItemService:
 
         return self._item_repository.update(item_id, ItemIn(**{**stored_item.model_dump(), **update_data}))
 
+    # pylint:enable=too-many-branches
     # pylint:enable=too-many-locals
 
     def delete(self, item_id: str, access_token: Optional[str] = None) -> None:

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -175,10 +175,10 @@ class ItemService:
             raise InvalidActionError("Cannot change the catalogue item the item belongs to")
 
         moving_system = "system_id" in update_data and item.system_id != stored_item.system_id
-        changing_usage_status = "usage_status_id" in update_data and item.usage_status_id != stored_item.usage_status_id
+        updating_usage_status = "usage_status_id" in update_data and item.usage_status_id != stored_item.usage_status_id
 
         usage_status_id = stored_item.usage_status_id
-        if changing_usage_status:
+        if updating_usage_status:
             if not moving_system:
                 raise InvalidActionError(
                     "Cannot change usage status without moving between systems according to a defined rule"
@@ -195,9 +195,9 @@ class ItemService:
             if not system:
                 raise MissingRecordError(f"No system found with ID: {item.system_id}")
 
+            current_system = self._system_repository.get(stored_item.system_id)
             if current_system.type_id != system.type_id:
                 # System type is changing - Ensure the moving operation is allowed by a rule
-                current_system = self._system_repository.get(stored_item.system_id)
                 if not self._rule_repository.check_exists(
                     src_system_type_id=current_system.type_id,
                     dst_system_type_id=system.type_id,
@@ -206,7 +206,7 @@ class ItemService:
                     raise InvalidActionError(
                         "No rule found for moving between the given system's types with the same final usage status"
                     )
-            elif changing_usage_status:
+            elif updating_usage_status:
                 # When system type is not changing - Ensure the usage status is unchanged
                 raise InvalidActionError(
                     "Cannot change usage status of an item when moving between two systems of the same type"

--- a/test/e2e/test_catalogue_category_property.py
+++ b/test/e2e/test_catalogue_category_property.py
@@ -27,7 +27,7 @@ from test.mock_data import (
     CATALOGUE_CATEGORY_PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT,
     CATALOGUE_CATEGORY_PROPERTY_GET_DATA_STRING_MANDATORY,
     CATALOGUE_ITEM_GET_DATA_WITH_ALL_PROPERTIES,
-    ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+    ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
     PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE,
     PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE,
     PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_1,
@@ -210,7 +210,7 @@ class CreateDSL(ItemGetDSL, CatalogueCategoryGetDSL, CatalogueItemGetDSL):
         self.get_item(self.item_id)
         self.check_get_item_success(
             {
-                **ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [
                     PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE,
                     expected_property_get_data,
@@ -574,7 +574,7 @@ class UpdateDSL(CreateDSL):
         self.get_item(self.item_id)
         self.check_get_item_success(
             {
-                **ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [
                     PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE,
                     expected_property_get_data,

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -44,7 +44,7 @@ from test.mock_data import (
     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_1,
     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_42,
     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE1,
-    SYSTEM_POST_DATA_NO_PARENT_A,
+    SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
     UNIT_POST_DATA_MM,
     USAGE_STATUS_GET_DATA_IN_USE,
 )
@@ -800,7 +800,7 @@ class UpdateDSL(ListDSL):
         # pylint:disable=fixme
         # TODO: This should be cleaned up in future
 
-        response = self.test_client.post("/v1/systems", json=SYSTEM_POST_DATA_NO_PARENT_A)
+        response = self.test_client.post("/v1/systems", json=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A)
         system_id = response.json()["id"]
 
         item_post = {

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -20,12 +20,12 @@ from test.mock_data import (
     CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST,
     CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
     CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
-    ITEM_DATA_ALL_VALUES_NO_PROPERTIES,
-    ITEM_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_DATA_WITH_ALL_PROPERTIES,
-    ITEM_GET_DATA_ALL_VALUES_NO_PROPERTIES,
-    ITEM_GET_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+    ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_NEW_WITH_ALL_PROPERTIES,
+    ITEM_GET_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
+    ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
+    ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
     PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE,
     PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_1,
     PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_2,
@@ -36,12 +36,11 @@ from test.mock_data import (
     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_2,
     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1,
     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE2,
-    SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT,
-    SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+    SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT,
+    SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
     SYSTEM_TYPE_GET_DATA_SCRAPPED,
     USAGE_STATUS_GET_DATA_IN_USE,
-    USAGE_STATUS_GET_DATA_NEW,
     USAGE_STATUS_GET_DATA_SCRAPPED,
     USAGE_STATUS_POST_DATA_IN_USE,
 )
@@ -185,7 +184,7 @@ class CreateDSL(CatalogueItemCreateDSL, SystemCreateDSL, UsageStatusCreateDSL):
         self.catalogue_item_id = self.post_catalogue_item_and_prerequisites_no_properties(
             CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY
         )
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
 
         return self.post_item(item_data)
 
@@ -204,7 +203,7 @@ class CreateDSL(CatalogueItemCreateDSL, SystemCreateDSL, UsageStatusCreateDSL):
         self.catalogue_item_id = self.post_catalogue_item_and_prerequisites_with_properties(
             CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES
         )
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
 
         return self.post_item(item_data)
@@ -218,7 +217,7 @@ class CreateDSL(CatalogueItemCreateDSL, SystemCreateDSL, UsageStatusCreateDSL):
         """
         Utility method that posts an item with specific given properties and also its prerequisite system, usage status,
         catalogue item and catalogue category. Uses BASE_CATALOGUE_CATEGORY_DATA_WITH_PROPERTIES_MM and
-        ITEM_DATA_WITH_ALL_PROPERTIES as a base.
+        ITEM_DATA_NEW_WITH_ALL_PROPERTIES as a base.
 
         :param catalogue_category_properties_data: List of dictionaries containing the basic catalogue category property
                         data as would be required for a `CatalogueCategoryPostPropertySchema` but with any `unit_id`'s
@@ -235,10 +234,10 @@ class CreateDSL(CatalogueItemCreateDSL, SystemCreateDSL, UsageStatusCreateDSL):
         self.catalogue_item_id = self.post_catalogue_item_and_prerequisites_with_given_properties(
             catalogue_category_properties_data, catalogue_item_properties_data
         )
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
 
-        return self.post_item({**ITEM_DATA_WITH_ALL_PROPERTIES, "properties": item_properties_data})
+        return self.post_item({**ITEM_DATA_NEW_WITH_ALL_PROPERTIES, "properties": item_properties_data})
 
     def post_item_and_prerequisites_with_allowed_values(
         self,
@@ -262,11 +261,11 @@ class CreateDSL(CatalogueItemCreateDSL, SystemCreateDSL, UsageStatusCreateDSL):
         self.catalogue_item_id = self.post_catalogue_item_and_prerequisites_with_allowed_values(
             property_type, allowed_values_post_data, catalogue_item_property_value
         )
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
         return self.post_item(
             {
-                **ITEM_DATA_REQUIRED_VALUES_ONLY,
+                **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
                 "properties": [{"name": "property", "value": item_property_value}],
             }
         )
@@ -318,47 +317,53 @@ class TestCreate(CreateDSL):
     def test_create_with_only_required_values_provided(self):
         """Test creating an item with only required values provided."""
 
-        self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
-        self.check_post_item_success(ITEM_GET_DATA_REQUIRED_VALUES_ONLY)
+        self.check_post_item_success(ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY)
 
     def test_create_with_all_values_except_properties(self):
         """Test creating an item with all values provided except `properties`."""
 
-        self.post_item_and_prerequisites_no_properties(ITEM_DATA_ALL_VALUES_NO_PROPERTIES)
+        self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES)
 
-        self.check_post_item_success(ITEM_GET_DATA_ALL_VALUES_NO_PROPERTIES)
+        self.check_post_item_success(ITEM_GET_DATA_NEW_ALL_VALUES_NO_PROPERTIES)
 
     def test_create_with_no_properties_provided(self):
         """Test creating an item when none of the properties present in the catalogue item are defined in the item."""
 
-        self.post_item_and_prerequisites_with_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item_and_prerequisites_with_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
-        self.check_post_item_success(ITEM_GET_DATA_REQUIRED_VALUES_ONLY)
+        self.check_post_item_success(ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY)
 
     def test_create_with_some_properties_provided(self):
         """Test creating an item when only some properties present in the catalogue item are defined in the item."""
 
         self.post_item_and_prerequisites_with_properties(
-            {**ITEM_DATA_WITH_ALL_PROPERTIES, "properties": ITEM_DATA_WITH_ALL_PROPERTIES["properties"][1::]}
+            {**ITEM_DATA_NEW_WITH_ALL_PROPERTIES, "properties": ITEM_DATA_NEW_WITH_ALL_PROPERTIES["properties"][1::]}
         )
 
         self.check_post_item_success(
-            {**ITEM_GET_DATA_WITH_ALL_PROPERTIES, "properties": ITEM_GET_DATA_WITH_ALL_PROPERTIES["properties"][1::]}
+            {
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
+                "properties": ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES["properties"][1::],
+            }
         )
 
     def test_create_with_all_properties_provided(self):
         """Test creating an item when all properties present in the catalogue item are defined in the item."""
 
-        self.post_item_and_prerequisites_with_properties(ITEM_DATA_WITH_ALL_PROPERTIES)
+        self.post_item_and_prerequisites_with_properties(ITEM_DATA_NEW_WITH_ALL_PROPERTIES)
 
-        self.check_post_item_success(ITEM_GET_DATA_WITH_ALL_PROPERTIES)
+        self.check_post_item_success(ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES)
 
     def test_create_with_mandatory_property_given_none(self):
         """Test creating an item when a mandatory property is given a value of `None` in the item."""
 
         self.post_item_and_prerequisites_with_properties(
-            {**ITEM_DATA_WITH_ALL_PROPERTIES, "properties": [{**PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE, "value": None}]}
+            {
+                **ITEM_DATA_NEW_WITH_ALL_PROPERTIES,
+                "properties": [{**PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE, "value": None}],
+            }
         )
 
         self.check_post_item_failed_with_detail(
@@ -372,14 +377,14 @@ class TestCreate(CreateDSL):
 
         self.post_item_and_prerequisites_with_properties(
             {
-                **ITEM_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [{**PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": None}],
             }
         )
 
         self.check_post_item_success(
             {
-                **ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [{**PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": None}],
             }
         )
@@ -451,7 +456,7 @@ class TestCreate(CreateDSL):
         )
         self.check_post_item_success(
             {
-                **ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [
                     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_2,
                     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE2,
@@ -510,9 +515,9 @@ class TestCreate(CreateDSL):
         """Test creating an item with a non-existent catalogue item ID."""
 
         self.catalogue_item_id = str(ObjectId())
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
-        self.post_item(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.check_post_item_failed_with_detail(422, "The specified catalogue item does not exist")
 
@@ -520,9 +525,9 @@ class TestCreate(CreateDSL):
         """Test creating an item with an invalid catalogue item ID."""
 
         self.catalogue_item_id = "invalid-id"
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
-        self.post_item(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.check_post_item_failed_with_detail(422, "The specified catalogue item does not exist")
 
@@ -534,7 +539,7 @@ class TestCreate(CreateDSL):
         )
         self.system_id = str(ObjectId())
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
-        self.post_item(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.check_post_item_failed_with_detail(422, "The specified system does not exist")
 
@@ -546,7 +551,7 @@ class TestCreate(CreateDSL):
         )
         self.system_id = "invalid-id"
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
-        self.post_item(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.check_post_item_failed_with_detail(422, "The specified system does not exist")
 
@@ -556,8 +561,8 @@ class TestCreate(CreateDSL):
         self.catalogue_item_id = self.post_catalogue_item_and_prerequisites_no_properties(
             CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY
         )
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        self.post_item({**ITEM_DATA_REQUIRED_VALUES_ONLY, "usage_status_id": str(ObjectId())})
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        self.post_item({**ITEM_DATA_NEW_REQUIRED_VALUES_ONLY, "usage_status_id": str(ObjectId())})
 
         self.check_post_item_failed_with_detail(422, "The specified usage status does not exist")
 
@@ -567,9 +572,9 @@ class TestCreate(CreateDSL):
         self.catalogue_item_id = self.post_catalogue_item_and_prerequisites_no_properties(
             CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY
         )
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_usage_status(USAGE_STATUS_POST_DATA_IN_USE)
-        self.post_item({**ITEM_DATA_REQUIRED_VALUES_ONLY, "usage_status_id": "invalid-id"})
+        self.post_item({**ITEM_DATA_NEW_REQUIRED_VALUES_ONLY, "usage_status_id": "invalid-id"})
 
         self.check_post_item_failed_with_detail(422, "The specified usage status does not exist")
 
@@ -619,10 +624,10 @@ class TestGet(GetDSL):
     def test_get(self):
         """Test getting an item."""
 
-        catalogue_item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        catalogue_item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.get_item(catalogue_item_id)
-        self.check_get_item_success(ITEM_GET_DATA_REQUIRED_VALUES_ONLY)
+        self.check_get_item_success(ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY)
 
     def test_get_with_non_existent_id(self):
         """Test getting an item with a non-existent ID."""
@@ -661,32 +666,32 @@ class ListDSL(GetDSL):
         """
 
         # First item
-        self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         system_a_id = self.system_id
         catalogue_item_a_id = self.catalogue_item_id
 
         # Second item
-        system_b_id = self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "name": "Another system"})
-        self.post_item(ITEM_DATA_ALL_VALUES_NO_PROPERTIES)
+        system_b_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "name": "Another system"})
+        self.post_item(ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES)
 
         # Third item
         self.post_catalogue_item({**CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY, "name": "Another catalogue item"})
         catalogue_item_b_id = self.catalogue_item_id
-        self.post_item(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.post_item(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         return [
             {
-                **ITEM_GET_DATA_REQUIRED_VALUES_ONLY,
+                **ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
                 "catalogue_item_id": catalogue_item_a_id,
                 "system_id": system_a_id,
             },
             {
-                **ITEM_GET_DATA_ALL_VALUES_NO_PROPERTIES,
+                **ITEM_GET_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
                 "catalogue_item_id": catalogue_item_a_id,
                 "system_id": system_b_id,
             },
             {
-                **ITEM_GET_DATA_REQUIRED_VALUES_ONLY,
+                **ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
                 "catalogue_item_id": catalogue_item_b_id,
                 "system_id": system_b_id,
             },
@@ -850,15 +855,15 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_all_fields_except_ids_or_properties(self):
         """Test updating all fields of an item except any of its `_id` fields or properties."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, ITEM_DATA_ALL_VALUES_NO_PROPERTIES)
-        self.check_patch_item_success(ITEM_GET_DATA_ALL_VALUES_NO_PROPERTIES)
+        self.patch_item(item_id, ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES)
+        self.check_patch_item_success(ITEM_GET_DATA_NEW_ALL_VALUES_NO_PROPERTIES)
 
     def test_partial_update_catalogue_item_id(self):
         """Test updating the `catalogue_item_id` of an item."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.patch_item(item_id, {"catalogue_item_id": str(ObjectId())})
         self.check_patch_item_failed_with_detail(422, "Cannot change the catalogue item the item belongs to")
@@ -866,16 +871,16 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_system_id(self):
         """Test updating the `system_id` of an item."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
+        new_system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_item(item_id, {"system_id": new_system_id})
-        self.check_patch_item_success(ITEM_GET_DATA_REQUIRED_VALUES_ONLY)
+        self.check_patch_item_success(ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY)
 
     def test_partial_update_system_id_with_non_existent_id(self):
         """Test updating the `system_id` of an item to a non-existent system."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.patch_item(item_id, {"system_id": str(ObjectId())})
         self.check_patch_item_failed_with_detail(422, "The specified system does not exist")
@@ -883,7 +888,7 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_system_id_with_invalid_id(self):
         """Test updating the `system_id` of an item to an invalid ID."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.patch_item(item_id, {"system_id": "invalid-id"})
         self.check_patch_item_failed_with_detail(422, "The specified system does not exist")
@@ -891,15 +896,15 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_system_and_usage_status_ids(self):
         """Test updating the `system_id` and `usage_status_id` of an item."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(
-            {**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
+            {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
         )
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]})
         self.check_patch_item_success(
             {
-                **ITEM_GET_DATA_REQUIRED_VALUES_ONLY,
+                **ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
                 "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"],
                 "usage_status": USAGE_STATUS_GET_DATA_IN_USE["value"],
             }
@@ -909,9 +914,9 @@ class TestUpdate(UpdateDSL):
         """Test updating the `system_id` and `usage_status_id` of an item when there isn't a rule defined for the change
         of system types (due to the transition itself not being defined, not just the final usage status)."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(
-            {**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_SCRAPPED["id"]}
+            {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_SCRAPPED["id"]}
         )
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]})
@@ -923,9 +928,9 @@ class TestUpdate(UpdateDSL):
         """Test updating the `system_id` and `usage_status_id` of an item when there isn't a rule defined for the change
         of system types (due to the final usage status being wrong, not the transition itself)."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(
-            {**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
+            {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
         )
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]})
@@ -937,10 +942,10 @@ class TestUpdate(UpdateDSL):
         """Test updating the `system_id` and `usage_status_id` of an item when the current and new systems have the same
         type."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
+        new_system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
-        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]})
+        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]})
         self.check_patch_item_failed_with_detail(
             422, "Cannot change usage status of an item when moving between two systems of the same type"
         )
@@ -948,8 +953,8 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_system_and_usage_status_ids_with_non_existent_usage_status_id(self):
         """Test updating the `system_id` while also updating its `usage_status_id` to a non-existent usage status."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
+        new_system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": str(ObjectId())})
         self.check_patch_item_failed_with_detail(422, "The specified usage status does not exist")
@@ -957,8 +962,8 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_system_and_usage_status_ids_with_invalid_usage_status_id(self):
         """Test updating the `system_id` while also updating its `usage_status_id` to an invalid ID."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
+        new_system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": "invalid-id"})
         self.check_patch_item_failed_with_detail(422, "The specified usage status does not exist")
@@ -966,9 +971,9 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_usage_status_id(self):
         """Test updating the `usage_status_id` of an item."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, {"usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]})
+        self.patch_item(item_id, {"usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]})
         self.check_patch_item_failed_with_detail(
             422, "Cannot change usage status without moving between systems according to a defined rule"
         )
@@ -977,35 +982,42 @@ class TestUpdate(UpdateDSL):
         """Test updating the `properties` of an item to override none of the catalogue item properties."""
 
         # All properties overridden to start with, then set to empty list to reset
-        item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_WITH_ALL_PROPERTIES)
+        item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_NEW_WITH_ALL_PROPERTIES)
 
         self.patch_item(item_id, {"properties": []})
-        self.check_patch_item_success({**ITEM_GET_DATA_WITH_ALL_PROPERTIES, "properties": []})
+        self.check_patch_item_success({**ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES, "properties": []})
 
     def test_partial_update_properties_with_some_properties_provided(self):
         """Test updating the `properties` of an item to override some of the catalogue item properties."""
 
         # No properties overridden to start with, then override some of them
-        item_id = self.post_item_and_prerequisites_with_properties({**ITEM_DATA_WITH_ALL_PROPERTIES, "properties": []})
+        item_id = self.post_item_and_prerequisites_with_properties(
+            {**ITEM_DATA_NEW_WITH_ALL_PROPERTIES, "properties": []}
+        )
 
-        self.patch_item(item_id, {"properties": ITEM_GET_DATA_WITH_ALL_PROPERTIES["properties"][1::]})
+        self.patch_item(item_id, {"properties": ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES["properties"][1::]})
         self.check_patch_item_success(
-            {**ITEM_GET_DATA_WITH_ALL_PROPERTIES, "properties": ITEM_GET_DATA_WITH_ALL_PROPERTIES["properties"][1::]}
+            {
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
+                "properties": ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES["properties"][1::],
+            }
         )
 
     def test_partial_update_properties_with_all_properties_provided(self):
         """Test updating the `properties` of an item to override all of the catalogue item properties."""
 
         # No properties overridden to start with, then override all of them
-        item_id = self.post_item_and_prerequisites_with_properties({**ITEM_DATA_WITH_ALL_PROPERTIES, "properties": []})
+        item_id = self.post_item_and_prerequisites_with_properties(
+            {**ITEM_DATA_NEW_WITH_ALL_PROPERTIES, "properties": []}
+        )
 
-        self.patch_item(item_id, {"properties": ITEM_GET_DATA_WITH_ALL_PROPERTIES["properties"]})
-        self.check_patch_item_success(ITEM_GET_DATA_WITH_ALL_PROPERTIES)
+        self.patch_item(item_id, {"properties": ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES["properties"]})
+        self.check_patch_item_success(ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES)
 
     def test_partial_update_properties_with_mandatory_property_given_none(self):
         """Test updating the `properties` of an item to have a mandatory property with a value of `None`."""
 
-        item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_WITH_ALL_PROPERTIES)
+        item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_NEW_WITH_ALL_PROPERTIES)
 
         self.patch_item(item_id, {"properties": [{**PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE, "value": None}]})
         self.check_patch_item_failed_with_detail(
@@ -1017,12 +1029,12 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_properties_with_non_mandatory_property_given_none(self):
         """Test updating the `properties` of an item to have a non-mandatory property with a value of `None`."""
 
-        item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_WITH_ALL_PROPERTIES)
+        item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_NEW_WITH_ALL_PROPERTIES)
 
         self.patch_item(item_id, {"properties": [{**PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": None}]})
         self.check_patch_item_success(
             {
-                **ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [{**PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": None}],
             }
         )
@@ -1106,7 +1118,7 @@ class TestUpdate(UpdateDSL):
         )
         self.check_patch_item_success(
             {
-                **ITEM_GET_DATA_WITH_ALL_PROPERTIES,
+                **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
                 "properties": [
                     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_2,
                     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE2,
@@ -1222,7 +1234,7 @@ class TestDelete(DeleteDSL):
     def test_delete(self):
         """Test deleting an item."""
 
-        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
         self.delete_item(item_id)
         self.check_delete_item_success()

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -36,10 +36,9 @@ from test.mock_data import (
     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_2,
     PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1,
     PROPERTY_GET_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE2,
+    SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY,
     SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT,
     SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
-    SYSTEM_TYPE_GET_DATA_OPERATIONAL,
-    SYSTEM_TYPE_GET_DATA_SCRAPPED,
     USAGE_STATUS_GET_DATA_IN_USE,
     USAGE_STATUS_GET_DATA_SCRAPPED,
     USAGE_STATUS_POST_DATA_IN_USE,
@@ -172,8 +171,8 @@ class CreateDSL(CatalogueItemCreateDSL, SystemCreateDSL, UsageStatusCreateDSL):
 
     def post_item_and_prerequisites_no_properties(self, item_data: dict) -> Optional[str]:
         """
-        Utility method that posts an item with the given data and also its prerequisite system, catalogue item and
-        catalogue category. Uses CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY for the catalogue item.
+        Utility method that posts an item with the given data and also its prerequisite system (with a storage type),
+        catalogue item and catalogue category. Uses CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY for the catalogue item.
 
         :param item_data: Dictionary containing the basic item data as would be required for a `ItemPostSchema` but with
                           mandatory IDs other than `usage_status_id` missing and any `id`'s replaced by the `name` value
@@ -897,9 +896,7 @@ class TestUpdate(UpdateDSL):
         """Test updating the `system_id` and `usage_status_id` of an item."""
 
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(
-            {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
-        )
+        new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]})
         self.check_patch_item_success(
@@ -915,9 +912,7 @@ class TestUpdate(UpdateDSL):
         of system types (due to the transition itself not being defined, not just the final usage status)."""
 
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(
-            {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_SCRAPPED["id"]}
-        )
+        new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]})
         self.check_patch_item_failed_with_detail(
@@ -929,9 +924,7 @@ class TestUpdate(UpdateDSL):
         of system types (due to the final usage status being wrong, not the transition itself)."""
 
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
-        new_system_id = self.post_system(
-            {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
-        )
+        new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
         self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]})
         self.check_patch_item_failed_with_detail(

--- a/test/e2e/test_setting.py
+++ b/test/e2e/test_setting.py
@@ -12,10 +12,10 @@ from test.e2e.test_item import DeleteDSL as ItemDeleteDSL
 from test.mock_data import (
     CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
     CATALOGUE_ITEM_GET_DATA_WITH_ALL_PROPERTIES,
-    ITEM_DATA_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     SETTING_SPARES_DEFINITION_IN_DATA_STORAGE,
     SETTING_SPARES_DEFINITION_IN_DATA_STORAGE_OR_OPERATIONAL,
-    SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+    SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
     SYSTEM_TYPE_GET_DATA_STORAGE,
     USAGE_STATUS_GET_DATA_USED,
@@ -69,7 +69,7 @@ class SparesDefinitionDSL(ItemDeleteDSL, CatalogueItemGetDSL):
 
         system_id = self.post_system(
             {
-                **SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+                **SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
                 # Avoid duplicate error
                 "name": f"System {len(self._system_type_map)}",
                 "type_id": type_id,
@@ -93,7 +93,7 @@ class SparesDefinitionDSL(ItemDeleteDSL, CatalogueItemGetDSL):
 
         # Create an item in the chosen system and current catalogue category
         self.system_id = system_id
-        return self.post_item(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        return self.post_item(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
 
     def post_items_and_prerequisites_with_system_types(self, system_type_ids_lists: list[list[str]]) -> None:
         """

--- a/test/e2e/test_setting.py
+++ b/test/e2e/test_setting.py
@@ -18,6 +18,7 @@ from test.mock_data import (
     SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
     SYSTEM_TYPE_GET_DATA_STORAGE,
+    USAGE_STATUS_GET_DATA_USED,
 )
 from typing import Optional
 
@@ -124,19 +125,20 @@ class SparesDefinitionDSL(ItemDeleteDSL, CatalogueItemGetDSL):
             for system_type_id in system_type_ids:
                 self.post_item_in_system_with_type_id(system_type_id)
 
-    def patch_item_system_id_to_one_with_type_id(self, item_id: str, system_type_id: str) -> None:
+    def patch_item_system_id_to_one_with_type_id(self, item_id: str, system_type_id: str, usage_status_id: str) -> None:
         """
         Utility method that patches an item's `system_id` to one that has the specified type ID.
 
         :param item_id: ID of the item to patch.
         :param system_type_id: Type ID of the system the item should be put in.
+        :param usage_status_id: Usage status ID to use when moving the item.
         """
 
         # First ensure there is a system to place the item in
         system_id = self._system_type_map.get(system_type_id)
         if not system_id:
             system_id = self.post_system_with_type_id(system_type_id)
-        self.patch_item(item_id, {"system_id": system_id})
+        self.patch_item(item_id, {"system_id": system_id, "usage_status_id": usage_status_id})
 
     def check_catalogue_item_spares(self, expected_number_of_spares_list: list[Optional[int]]) -> None:
         """
@@ -223,7 +225,9 @@ class TestSparesDefinitionDSL(SparesDefinitionDSL):
         self.check_catalogue_item_spares([0, 1])
 
         # Update the item's `system_id` so it becomes a spare and ensure only its catalogue item is updated
-        self.patch_item_system_id_to_one_with_type_id(item_id, SYSTEM_TYPE_GET_DATA_STORAGE["id"])
+        self.patch_item_system_id_to_one_with_type_id(
+            item_id, SYSTEM_TYPE_GET_DATA_STORAGE["id"], USAGE_STATUS_GET_DATA_USED["id"]
+        )
         self.check_catalogue_item_spares([0, 2])
 
     def test_delete_item_after_spares_definition_set(self):

--- a/test/e2e/test_system.py
+++ b/test/e2e/test_system.py
@@ -10,12 +10,12 @@ from test.e2e.conftest import E2ETestHelpers
 from test.mock_data import (
     CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_DATA_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY,
-    SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT,
-    SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY,
-    SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT,
-    SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+    SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT,
+    SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY,
+    SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT,
+    SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
 )
 from typing import Optional
@@ -93,41 +93,41 @@ class TestCreate(CreateDSL):
     def test_create_with_only_required_values_provided(self):
         """Test creating a system with only required values provided."""
 
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        self.check_post_system_success(SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        self.check_post_system_success(SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY)
 
     def test_create_with_all_values_provided(self):
         """Test creating a system with all values provided."""
 
-        self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
-        self.check_post_system_success(SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT)
+        self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
+        self.check_post_system_success(SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
     def test_create_with_valid_parent_id(self):
         """Test creating a system with a valid `parent_id`."""
 
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
-        self.check_post_system_success({**SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
+        self.check_post_system_success({**SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
 
     def test_create_with_non_existent_parent_id(self):
         """Test creating a system with a non-existent `parent_id`."""
 
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "parent_id": str(ObjectId())})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": str(ObjectId())})
         self.check_post_system_failed_with_detail(422, "The specified parent system does not exist")
 
     def test_create_with_invalid_parent_id(self):
         """Test creating a system with an invalid `parent_id`."""
 
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "parent_id": "invalid-id"})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": "invalid-id"})
         self.check_post_system_failed_with_detail(422, "The specified parent system does not exist")
 
     def test_create_with_duplicate_name_within_parent(self):
         """Test creating a system with the same name as another within the parent system."""
 
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         # 2nd post should be the duplicate
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
         self.check_post_system_failed_with_detail(
             409, "A system with the same name already exists within the parent system"
         )
@@ -135,10 +135,10 @@ class TestCreate(CreateDSL):
     def test_create_with_different_type_id_to_parent(self):
         """Test creating a system with a different `type_id` to its parent."""
 
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_system(
             {
-                **SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+                **SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
                 "parent_id": parent_id,
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
             }
@@ -148,19 +148,19 @@ class TestCreate(CreateDSL):
     def test_create_with_non_existent_type_id(self):
         """Test creating a system with a non-existent `type_id`."""
 
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "type_id": str(ObjectId())})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "type_id": str(ObjectId())})
         self.check_post_system_failed_with_detail(422, "The specified system type does not exist")
 
     def test_create_with_invalid_type_id(self):
         """Test creating a system with an invalid `type_id`."""
 
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "type_id": "invalid-id"})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "type_id": "invalid-id"})
         self.check_post_system_failed_with_detail(422, "The specified system type does not exist")
 
     def test_create_with_invalid_importance(self):
         """Test creating a system with an invalid importance."""
 
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "importance": "invalid-importance"})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "importance": "invalid-importance"})
         self.check_post_system_failed_with_validation_message(422, "Input should be 'low', 'medium' or 'high'")
 
 
@@ -207,9 +207,9 @@ class TestGet(GetDSL):
     def test_get(self):
         """Test getting a system."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.get_system(system_id)
-        self.check_get_system_success(SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT)
+        self.check_get_system_success(SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
     def test_get_with_non_existent_id(self):
         """Test getting a system with a non-existent ID."""
@@ -246,7 +246,7 @@ class GetBreadcrumbsDSL(GetDSL):
         parent_id = None
         for i in range(0, number):
             system_id = self.post_system(
-                {**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "name": f"System {i}", "parent_id": parent_id}
+                {**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "name": f"System {i}", "parent_id": parent_id}
             )
             self._posted_systems_get_data.append(self._post_response_system.json())
             parent_id = system_id
@@ -373,10 +373,13 @@ class ListDSL(GetBreadcrumbsDSL):
                  `SystemSchema`.
         """
 
-        parent_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": parent_id})
 
-        return [SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT, {**SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY, "parent_id": parent_id}]
+        return [
+            SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT,
+            {**SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY, "parent_id": parent_id},
+        ]
 
     def check_get_systems_success(self, expected_systems_get_data: list[dict]) -> None:
         """
@@ -478,7 +481,7 @@ class UpdateDSL(ListDSL):
         catalogue_item_id = response.json()["id"]
 
         item_post = {
-            **ITEM_DATA_REQUIRED_VALUES_ONLY,
+            **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             "catalogue_item_id": catalogue_item_id,
             "system_id": self._post_response_system.json()["id"],
         }
@@ -517,28 +520,30 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_all_fields(self):
         """Test updating every field of a system."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        self.patch_system(system_id, SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
-        self.check_patch_system_success(SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        self.patch_system(system_id, SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
+        self.check_patch_system_success(SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
     def test_partial_update_parent_id_from_none(self):
         """Test updating the `parent_id` of a system froma  value of None."""
 
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_system(system_id, {"parent_id": parent_id})
-        self.check_patch_system_success({**SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        self.check_patch_system_success({**SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
 
     def test_partial_update_parent_id_to_one_with_a_duplicate_name(self):
         """Test updating the `parent_id` of a system so that its name conflicts with one already in that other
         system."""
 
         # System with child
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "name": "Conflicting Name", "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        self.post_system(
+            {**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "name": "Conflicting Name", "parent_id": parent_id}
+        )
 
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "name": "Conflicting Name"})
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "name": "Conflicting Name"})
 
         self.patch_system(system_id, {"parent_id": parent_id})
         self.check_patch_system_failed_with_detail(
@@ -549,9 +554,9 @@ class TestUpdate(UpdateDSL):
         """Test updating the `parent_id` of a system to one that has a different type."""
 
         parent_id = self.post_system(
-            {**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
+            {**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]}
         )
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_system(system_id, {"parent_id": parent_id})
         self.check_patch_system_failed_with_detail(422, "Cannot move a system into one with a different type")
@@ -561,12 +566,12 @@ class TestUpdate(UpdateDSL):
         match."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "type_id": type_id})
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        parent_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "type_id": type_id})
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_system(system_id, {"parent_id": parent_id, "type_id": type_id})
         self.check_patch_system_success(
-            {**SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id, "type_id": type_id}
+            {**SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id, "type_id": type_id}
         )
 
     def test_partial_update_parent_id_to_one_with_a_different_type_while_changing_type_with_subsystem(self):
@@ -574,9 +579,9 @@ class TestUpdate(UpdateDSL):
         match while the system has a subsystem."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "type_id": type_id})
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
-        self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": system_id})
+        parent_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "type_id": type_id})
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": system_id})
 
         self.patch_system(system_id, {"parent_id": parent_id, "type_id": type_id})
         self.check_patch_system_failed_with_detail(422, "Cannot change the type of a system when it has children")
@@ -586,8 +591,8 @@ class TestUpdate(UpdateDSL):
         match while the system has an item."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "type_id": type_id})
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        parent_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "type_id": type_id})
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.post_child_item_to_system()
 
         self.patch_system(system_id, {"parent_id": parent_id, "type_id": type_id})
@@ -596,30 +601,32 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_parent_id_to_none(self):
         """Test updating the `parent_id` of a system to None."""
 
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
 
         self.patch_system(system_id, {"parent_id": None})
-        self.check_patch_system_success({**SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT, "parent_id": None})
+        self.check_patch_system_success({**SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": None})
 
     def test_partial_update_parent_id_to_none_while_changing_type(self):
         """Test updating the `parent_id` of a system to None while also changing the `type_id`."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
 
         self.patch_system(system_id, {"parent_id": None, "type_id": type_id})
-        self.check_patch_system_success({**SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT, "parent_id": None, "type_id": type_id})
+        self.check_patch_system_success(
+            {**SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": None, "type_id": type_id}
+        )
 
     def test_partial_update_parent_id_to_none_while_changing_type_with_subsystem(self):
         """Test updating the `parent_id` of a system to None while also changing the `type_id` while the system has
         a subsystem."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
-        self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": system_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": system_id})
 
         self.patch_system(system_id, {"parent_id": None, "type_id": type_id})
         self.check_patch_system_failed_with_detail(422, "Cannot change the type of a system when it has children")
@@ -629,8 +636,8 @@ class TestUpdate(UpdateDSL):
         an item."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
         self.post_child_item_to_system()
 
         self.patch_system(system_id, {"parent_id": None, "type_id": type_id})
@@ -646,23 +653,23 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_parent_id_to_non_existent(self):
         """Test updating the `parent_id` of a system to a non-existent system."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.patch_system(system_id, {"parent_id": str(ObjectId())})
         self.check_patch_system_failed_with_detail(422, "The specified parent system does not exist")
 
     def test_partial_update_parent_id_to_invalid_id(self):
         """Test updating the `parent_id` of a system to an invalid ID."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.patch_system(system_id, {"parent_id": "invalid-id"})
         self.check_patch_system_failed_with_detail(422, "The specified parent system does not exist")
 
     def test_partial_update_name_to_duplicate(self):
         """Test updating the name of a system to conflict with a pre-existing one."""
 
-        self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
-        self.patch_system(system_id, {"name": SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY["name"]})
+        self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
+        self.patch_system(system_id, {"name": SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY["name"]})
         self.check_patch_system_failed_with_detail(
             409, "A system with the same name already exists within the parent system"
         )
@@ -671,17 +678,17 @@ class TestUpdate(UpdateDSL):
         """Test updating the `type_id` of a system when it doesn't have a parent system."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
         self.patch_system(system_id, {"type_id": type_id})
-        self.check_patch_system_success({**SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT, "type_id": type_id})
+        self.check_patch_system_success({**SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT, "type_id": type_id})
 
     def test_partial_update_type_id_without_parent_with_subsystem(self):
         """Test updating the `type_id` of a system when it doesn't have a parent system but has a subsystem."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
-        self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": system_id})
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": system_id})
 
         self.patch_system(system_id, {"type_id": type_id})
         self.check_patch_system_failed_with_detail(422, "Cannot change the type of a system when it has children")
@@ -690,7 +697,7 @@ class TestUpdate(UpdateDSL):
         """Test updating the `type_id` of a system when it doesn't have a parent system but has an item."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.post_child_item_to_system()
 
         self.patch_system(system_id, {"type_id": type_id})
@@ -700,8 +707,8 @@ class TestUpdate(UpdateDSL):
         """Test updating the `type_id` of a system when it doesn't have a parent system."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
 
         self.patch_system(system_id, {"type_id": type_id})
         self.check_patch_system_failed_with_detail(422, "Cannot update the system's type to be different to its parent")
@@ -710,9 +717,9 @@ class TestUpdate(UpdateDSL):
         """Test updating the `type_id` of a system when it has a parent system and a subsystem."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
-        self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": system_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": system_id})
 
         self.patch_system(system_id, {"type_id": type_id})
         self.check_patch_system_failed_with_detail(422, "Cannot change the type of a system when it has children")
@@ -721,8 +728,8 @@ class TestUpdate(UpdateDSL):
         """Test updating the `type_id` of a system when it has a parent system and an item."""
 
         type_id = SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]
-        parent_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
-        system_id = self.post_system({**SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
+        parent_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT, "parent_id": parent_id})
         self.post_child_item_to_system()
 
         self.patch_system(system_id, {"type_id": type_id})
@@ -731,14 +738,14 @@ class TestUpdate(UpdateDSL):
     def test_partial_update_type_id_to_non_existent(self):
         """Test updating the `type_id` of a system to a non-existent system type."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.patch_system(system_id, {"type_id": str(ObjectId())})
         self.check_patch_system_failed_with_detail(422, "The specified system type does not exist")
 
     def test_partial_update_type_id_to_invalid_id(self):
         """Test updating the `type_id` of a system to an invalid ID."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
         self.patch_system(system_id, {"type_id": "invalid-id"})
         self.check_patch_system_failed_with_detail(422, "The specified system type does not exist")
 
@@ -746,10 +753,10 @@ class TestUpdate(UpdateDSL):
         """Test updating the capitalisation of the name of a system (to ensure it the check doesn't confuse with
         duplicates)."""
 
-        system_id = self.post_system({**SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY, "name": "Test system"})
+        system_id = self.post_system({**SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY, "name": "Test system"})
         self.patch_system(system_id, {"name": "Test System"})
         self.check_patch_system_success(
-            {**SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY, "name": "Test System", "code": "test-system"}
+            {**SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY, "name": "Test System", "code": "test-system"}
         )
 
     def test_partial_update_with_non_existent_id(self):
@@ -803,7 +810,7 @@ class TestDelete(DeleteDSL):
     def test_delete(self):
         """Test deleting a system."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.delete_system(system_id)
         self.check_delete_system_success()
 
@@ -821,7 +828,7 @@ class TestDelete(DeleteDSL):
     def test_delete_with_child_item(self):
         """Test deleting a system with a child system."""
 
-        system_id = self.post_system(SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         self.post_child_item_to_system()
 
         self.delete_system(system_id)

--- a/test/e2e/test_usage_status.py
+++ b/test/e2e/test_usage_status.py
@@ -5,9 +5,9 @@ End-to-End tests for the usage status router.
 from test.mock_data import (
     CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_DATA_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY,
-    SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+    SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     USAGE_STATUS_GET_DATA_CUSTOM,
     USAGE_STATUS_GET_DATA_IN_USE,
     USAGE_STATUS_GET_DATA_NEW,
@@ -228,7 +228,7 @@ class TestDelete(DeleteDSL):
         )
         catalogue_category = response.json()
 
-        response = self.test_client.post("/v1/systems", json=SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY)
+        response = self.test_client.post("/v1/systems", json=SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY)
         system_id = response.json()["id"]
 
         response = self.test_client.post("/v1/manufacturers", json=MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
@@ -243,7 +243,7 @@ class TestDelete(DeleteDSL):
         catalogue_item = response.json()
 
         item_post = {
-            **ITEM_DATA_REQUIRED_VALUES_ONLY,
+            **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             "catalogue_item_id": catalogue_item["id"],
             "system_id": system_id,
             "usage_status_id": usage_status_id,

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -702,7 +702,7 @@ ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY = {
     "properties": [],
 }
 
-# All values, no properties
+# New, All values, no properties
 
 ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES = {
     **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
@@ -850,7 +850,7 @@ SYSTEM_TYPE_GET_DATA_SCRAPPED = SYSTEM_TYPES_GET_DATA[2]
 # Storage, No parent, Required values only
 
 SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY = {
-    "name": "System Test Required Values Only",
+    "name": "Storage System Required Values Only",
     "type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"],
     "importance": "low",
 }
@@ -863,7 +863,7 @@ SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY = {
     "description": None,
     "location": None,
     "owner": None,
-    "code": "system-test-required-values-only",
+    "code": "storage-system-required-values-only",
 }
 
 # Storage, No parent, All values
@@ -871,7 +871,7 @@ SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY = {
 SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT = {
     **SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     "parent_id": None,
-    "name": "System Test All Values",
+    "name": "Storage System All Values",
     "description": "Test description",
     "location": "Test location",
     "owner": "Test owner",
@@ -882,7 +882,7 @@ SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT = {
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
     "parent_id": None,
-    "code": "system-test-all-values",
+    "code": "storage-system-all-values",
 }
 
 # Storage, No parent
@@ -915,6 +915,22 @@ SYSTEM_POST_DATA_STORAGE_NO_PARENT_B = {
 SYSTEM_IN_DATA_STORAGE_NO_PARENT_B = {
     **SYSTEM_POST_DATA_STORAGE_NO_PARENT_B,
     "code": "test-name-b",
+}
+
+# Operational, No parent, Required values only
+
+SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY = {
+    "name": "Operational System Required Values Only",
+    "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+    "importance": "low",
+}
+
+# Scrapped, No parent, Required values only
+
+SYSTEM_POST_DATA_SCRAPPED_REQUIRED_VALUES_ONLY = {
+    "name": "Scrapped System Required Values Only",
+    "type_id": SYSTEM_TYPE_GET_DATA_SCRAPPED["id"],
+    "importance": "low",
 }
 
 # --------------------------------- SETTINGS ---------------------------------

--- a/test/mock_data.py
+++ b/test/mock_data.py
@@ -674,25 +674,25 @@ CATALOGUE_ITEM_GET_DATA_WITH_MANDATORY_PROPERTIES_ONLY = {
 BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES = CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES
 
 
-# Required values only
+# New, Required values only
 
-ITEM_DATA_REQUIRED_VALUES_ONLY = {
+ITEM_DATA_NEW_REQUIRED_VALUES_ONLY = {
     "is_defective": False,
-    "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"],
+    "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"],
 }
 
-ITEM_IN_DATA_REQUIRED_VALUES_ONLY = {
-    **ITEM_DATA_REQUIRED_VALUES_ONLY,
+ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY = {
+    **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     "catalogue_item_id": str(ObjectId()),
     "system_id": str(ObjectId()),
-    "usage_status": USAGE_STATUS_GET_DATA_IN_USE["value"],
+    "usage_status": USAGE_STATUS_GET_DATA_NEW["value"],
 }
 
-ITEM_GET_DATA_REQUIRED_VALUES_ONLY = {
-    **ITEM_DATA_REQUIRED_VALUES_ONLY,
+ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY = {
+    **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
-    "usage_status": USAGE_STATUS_GET_DATA_IN_USE["value"],
+    "usage_status": USAGE_STATUS_GET_DATA_NEW["value"],
     "purchase_order_number": None,
     "warranty_end_date": None,
     "asset_number": None,
@@ -704,8 +704,8 @@ ITEM_GET_DATA_REQUIRED_VALUES_ONLY = {
 
 # All values, no properties
 
-ITEM_DATA_ALL_VALUES_NO_PROPERTIES = {
-    **ITEM_DATA_REQUIRED_VALUES_ONLY,
+ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES = {
+    **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     "purchase_order_number": "1234-123",
     "warranty_end_date": "2015-11-15T23:59:59Z",
     "asset_number": "1234-123456",
@@ -714,33 +714,33 @@ ITEM_DATA_ALL_VALUES_NO_PROPERTIES = {
     "notes": "Test notes",
 }
 
-ITEM_IN_DATA_ALL_VALUES_NO_PROPERTIES = {
-    **ITEM_DATA_ALL_VALUES_NO_PROPERTIES,
+ITEM_IN_DATA_NEW_ALL_VALUES_NO_PROPERTIES = {
+    **ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
     "catalogue_item_id": str(ObjectId()),
     "system_id": str(ObjectId()),
-    "usage_status": USAGE_STATUS_OUT_DATA_IN_USE["value"],
+    "usage_status": USAGE_STATUS_OUT_DATA_NEW["value"],
 }
 
-ITEM_GET_DATA_ALL_VALUES_NO_PROPERTIES = {
-    **ITEM_DATA_ALL_VALUES_NO_PROPERTIES,
+ITEM_GET_DATA_NEW_ALL_VALUES_NO_PROPERTIES = {
+    **ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
-    "usage_status": USAGE_STATUS_OUT_DATA_IN_USE["value"],
+    "usage_status": USAGE_STATUS_OUT_DATA_NEW["value"],
     "properties": [],
 }
 
 
-# Only mandatory properties
+# New, Only mandatory properties
 
-ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY = {
-    **ITEM_DATA_REQUIRED_VALUES_ONLY,
+ITEM_DATA_NEW_WITH_MANDATORY_PROPERTIES_ONLY = {
+    **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     "properties": [PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE],
 }
 
-# All properties
+# New, All properties
 
-ITEM_DATA_WITH_ALL_PROPERTIES = {
-    **ITEM_DATA_REQUIRED_VALUES_ONLY,
+ITEM_DATA_NEW_WITH_ALL_PROPERTIES = {
+    **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     "properties": [
         PROPERTY_DATA_BOOLEAN_MANDATORY_FALSE,
         PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1,
@@ -748,9 +748,9 @@ ITEM_DATA_WITH_ALL_PROPERTIES = {
     ],
 }
 
-ITEM_GET_DATA_WITH_ALL_PROPERTIES = {
-    **ITEM_GET_DATA_REQUIRED_VALUES_ONLY,
-    "usage_status": USAGE_STATUS_OUT_DATA_IN_USE["value"],
+ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES = {
+    **ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
+    "usage_status": USAGE_STATUS_OUT_DATA_NEW["value"],
     "properties": [
         PROPERTY_GET_DATA_BOOLEAN_MANDATORY_FALSE,
         PROPERTY_GET_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1,
@@ -847,16 +847,16 @@ SYSTEM_TYPE_GET_DATA_SCRAPPED = SYSTEM_TYPES_GET_DATA[2]
 
 # --------------------------------- SYSTEMS ---------------------------------
 
-# No parent, Required values only
+# Storage, No parent, Required values only
 
-SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY = {
+SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY = {
     "name": "System Test Required Values Only",
     "type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"],
     "importance": "low",
 }
 
-SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY = {
-    **SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+SYSTEM_GET_DATA_STORAGE_REQUIRED_VALUES_ONLY = {
+    **SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
     "parent_id": None,
@@ -866,10 +866,10 @@ SYSTEM_GET_DATA_REQUIRED_VALUES_ONLY = {
     "code": "system-test-required-values-only",
 }
 
-# No parent, All values
+# Storage, No parent, All values
 
-SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT = {
-    **SYSTEM_POST_DATA_REQUIRED_VALUES_ONLY,
+SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT = {
+    **SYSTEM_POST_DATA_STORAGE_REQUIRED_VALUES_ONLY,
     "parent_id": None,
     "name": "System Test All Values",
     "description": "Test description",
@@ -877,17 +877,17 @@ SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT = {
     "owner": "Test owner",
 }
 
-SYSTEM_GET_DATA_ALL_VALUES_NO_PARENT = {
-    **SYSTEM_POST_DATA_ALL_VALUES_NO_PARENT,
+SYSTEM_GET_DATA_STORAGE_ALL_VALUES_NO_PARENT = {
+    **SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT,
     **CREATED_MODIFIED_GET_DATA_EXPECTED,
     "id": ANY,
     "parent_id": None,
     "code": "system-test-all-values",
 }
 
-# No parent
+# Storage, No parent
 
-SYSTEM_POST_DATA_NO_PARENT_A = {
+SYSTEM_POST_DATA_STORAGE_NO_PARENT_A = {
     "parent_id": None,
     "name": "Test name A",
     "type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"],
@@ -897,12 +897,12 @@ SYSTEM_POST_DATA_NO_PARENT_A = {
     "importance": "low",
 }
 
-SYSTEM_IN_DATA_NO_PARENT_A = {
-    **SYSTEM_POST_DATA_NO_PARENT_A,
+SYSTEM_IN_DATA_STORAGE_NO_PARENT_A = {
+    **SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
     "code": "test-name-a",
 }
 
-SYSTEM_POST_DATA_NO_PARENT_B = {
+SYSTEM_POST_DATA_STORAGE_NO_PARENT_B = {
     "parent_id": None,
     "name": "Test name B",
     "type_id": SYSTEM_TYPE_GET_DATA_STORAGE["id"],
@@ -912,8 +912,8 @@ SYSTEM_POST_DATA_NO_PARENT_B = {
     "importance": "low",
 }
 
-SYSTEM_IN_DATA_NO_PARENT_B = {
-    **SYSTEM_POST_DATA_NO_PARENT_B,
+SYSTEM_IN_DATA_STORAGE_NO_PARENT_B = {
+    **SYSTEM_POST_DATA_STORAGE_NO_PARENT_B,
     "code": "test-name-b",
 }
 

--- a/test/unit/repositories/test_catalogue_item.py
+++ b/test/unit/repositories/test_catalogue_item.py
@@ -9,7 +9,7 @@ from test.mock_data import (
     CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
     CATALOGUE_ITEM_IN_DATA_NOT_OBSOLETE_NO_PROPERTIES,
     CATALOGUE_ITEM_IN_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_DATA_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
     PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
@@ -598,7 +598,7 @@ class TestHasChildElements(HasChildElementsDSL):
     def test_has_child_elements_with_child_item(self):
         """Test `has_child_elements` when there is a child item."""
 
-        self.mock_has_child_elements(child_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.mock_has_child_elements(child_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_has_child_elements(str(ObjectId()))
         self.check_has_child_elements_success(expected_result=True)
 

--- a/test/unit/repositories/test_item.py
+++ b/test/unit/repositories/test_item.py
@@ -3,10 +3,10 @@ Unit tests for the `ItemRepo` repository.
 """
 
 from test.mock_data import (
-    ITEM_IN_DATA_ALL_VALUES_NO_PROPERTIES,
-    ITEM_IN_DATA_REQUIRED_VALUES_ONLY,
+    ITEM_IN_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
+    ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY,
     PROPERTY_DATA_STRING_MANDATORY_TEXT,
-    SYSTEM_IN_DATA_NO_PARENT_A,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
 )
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from typing import Optional
@@ -139,17 +139,17 @@ class TestCreate(CreateDSL):
     def test_create(self):
         """Test creating an item."""
 
-        self.mock_create(ITEM_IN_DATA_REQUIRED_VALUES_ONLY, system_in_data=SYSTEM_IN_DATA_NO_PARENT_A)
+        self.mock_create(ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY, system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A)
         self.call_create()
         self.check_create_success()
 
     def test_create_with_non_existent_system_id(self):
         """Test creating an item with a non-existent system ID."""
 
-        self.mock_create(ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.mock_create(ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_create_expecting_error(MissingRecordError)
         self.check_create_failed_with_exception(
-            f"No system found with ID: {ITEM_IN_DATA_REQUIRED_VALUES_ONLY["system_id"]}"
+            f"No system found with ID: {ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY["system_id"]}"
         )
 
 
@@ -235,7 +235,7 @@ class TestGet(GetDSL):
 
         item_id = str(ObjectId())
 
-        self.mock_get(item_id, ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.mock_get(item_id, ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_get(item_id)
         self.check_get_success()
 
@@ -315,21 +315,21 @@ class TestList(ListDSL):
     def test_list(self):
         """Test listing all items."""
 
-        self.mock_list([ITEM_IN_DATA_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_ALL_VALUES_NO_PROPERTIES])
+        self.mock_list([ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_NEW_ALL_VALUES_NO_PROPERTIES])
         self.call_list(system_id=None, catalogue_item_id=None)
         self.check_list_success()
 
     def test_list_with_system_id_filter(self):
         """Test listing all items with a given `system_id`."""
 
-        self.mock_list([ITEM_IN_DATA_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_ALL_VALUES_NO_PROPERTIES])
+        self.mock_list([ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_NEW_ALL_VALUES_NO_PROPERTIES])
         self.call_list(system_id=str(ObjectId()), catalogue_item_id=None)
         self.check_list_success()
 
     def test_list_with_catalogue_category_id_filter(self):
         """Test listing all items with a given `catalogue_category_id`."""
 
-        self.mock_list([ITEM_IN_DATA_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_ALL_VALUES_NO_PROPERTIES])
+        self.mock_list([ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY, ITEM_IN_DATA_NEW_ALL_VALUES_NO_PROPERTIES])
         self.call_list(system_id=None, catalogue_item_id=str(ObjectId()))
         self.check_list_success()
 
@@ -437,7 +437,7 @@ class TestUpdate(UpdateDSL):
 
         item_id = str(ObjectId())
 
-        self.mock_update(item_id, ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.mock_update(item_id, ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_update(item_id)
         self.check_update_success()
 
@@ -446,7 +446,7 @@ class TestUpdate(UpdateDSL):
 
         item_id = "invalid-id"
 
-        self.set_update_data(ITEM_IN_DATA_REQUIRED_VALUES_ONLY)
+        self.set_update_data(ITEM_IN_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_update_expecting_error(item_id, InvalidObjectIdError)
         self.check_update_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 

--- a/test/unit/repositories/test_rule.py
+++ b/test/unit/repositories/test_rule.py
@@ -2,13 +2,15 @@
 Unit tests for the `RuleRepo` repository.
 """
 
-from test.mock_data import RULES_OUT_DATA
+from test.mock_data import RULE_OUT_DATA_STORAGE_CREATION, RULES_OUT_DATA
+from test.unit.repositories.conftest import RepositoryTestHelpers
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from bson import ObjectId
 
+from inventory_management_system_api.core.custom_object_id import CustomObjectId
 from inventory_management_system_api.models.rule import RuleOut
 from inventory_management_system_api.repositories.rule import (
     RULES_GET_AGGREGATION_PIPELINE_ENTITY_INSERT_STAGES,
@@ -120,3 +122,77 @@ class TestList(ListDSL):
         self.mock_list([])
         self.call_list(src_system_type_id=str(ObjectId()), dst_system_type_id=str(ObjectId()))
         self.check_list_success()
+
+
+class CheckExistsDSL(RuleRepoDSL):
+    """Base class for `check_exists` tests."""
+
+    _expected_result: bool
+    _src_system_type_id: Optional[str]
+    _dst_system_type_id: Optional[str]
+    _dst_usage_status_id: Optional[str]
+    _obtained_result: bool
+
+    def mock_check_exists(self, result: bool):
+        """
+        Mocks database methods appropriately to test the `check_exists` repo method.
+
+        :param result: The result to mock for.
+        """
+
+        self._expected_result = result
+        # Actual returned value doesn't matter here just as long as its not None
+        RepositoryTestHelpers.mock_find_one(self.rules_collection, RULE_OUT_DATA_STORAGE_CREATION if result else None)
+
+    def call_check_exists(
+        self, src_system_type_id: Optional[str], dst_system_type_id: Optional[str], dst_usage_status_id: Optional[str]
+    ):
+        """
+        Calls the `RuleRepo` `check_exists` method.
+
+        :param src_system_type_id: ID of the source system type to query by.
+        :param dst_system_type_id: ID of the destination system type to query by.
+        :param dst_usage_status_id: ID of the destination usage status to query by.
+        """
+
+        self._src_system_type_id = src_system_type_id
+        self._dst_system_type_id = dst_system_type_id
+        self._dst_usage_status_id = dst_usage_status_id
+
+        self._obtained_result = self.rule_repository.check_exists(
+            src_system_type_id, dst_system_type_id, dst_usage_status_id, session=self.mock_session
+        )
+
+    def check_check_exists_success(self):
+        """Checks that a prior call to `call_check_exists` worked as expected."""
+
+        self.rules_collection.find_one.assert_called_with(
+            {
+                "src_system_type_id": CustomObjectId(self._src_system_type_id) if self._src_system_type_id else None,
+                "dst_system_type_id": CustomObjectId(self._dst_system_type_id) if self._dst_system_type_id else None,
+                "dst_usage_status_id": CustomObjectId(self._dst_usage_status_id) if self._dst_usage_status_id else None,
+            },
+            session=self.mock_session,
+        )
+
+        assert self._obtained_result == self._expected_result
+
+
+class TestCheckExists(CheckExistsDSL):
+    """Tests for checking if a rule exists."""
+
+    def test_check_exists_with_all_ids_given(self):
+        """Test checking the existence of a rule with specific IDs given for each parameter."""
+
+        self.mock_check_exists(True)
+        self.call_check_exists(
+            src_system_type_id=str(ObjectId()), dst_system_type_id=str(ObjectId()), dst_usage_status_id=str(ObjectId())
+        )
+        self.check_check_exists_success()
+
+    def test_check_exists_with_all_ids_none(self):
+        """Test checking the existence of a rule with no IDs given for each parameter."""
+
+        self.mock_check_exists(False)
+        self.call_check_exists(src_system_type_id=None, dst_system_type_id=None, dst_usage_status_id=None)
+        self.check_check_exists_success()

--- a/test/unit/repositories/test_system.py
+++ b/test/unit/repositories/test_system.py
@@ -6,7 +6,11 @@ Unit tests for the `SystemRepo` repository.
 # pylint: disable=duplicate-code
 # pylint: disable=too-many-lines
 
-from test.mock_data import ITEM_DATA_REQUIRED_VALUES_ONLY, SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B
+from test.mock_data import (
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+)
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from test.unit.repositories.test_utils import (
     MOCK_BREADCRUMBS_QUERY_RESULT_LESS_THAN_MAX_LENGTH,
@@ -204,7 +208,7 @@ class TestCreate(CreateDSL):
     def test_create(self):
         """Test creating a system."""
 
-        self.mock_create(SYSTEM_IN_DATA_NO_PARENT_A)
+        self.mock_create(SYSTEM_IN_DATA_STORAGE_NO_PARENT_A)
         self.call_create()
         self.check_create_success()
 
@@ -212,8 +216,8 @@ class TestCreate(CreateDSL):
         """Test creating a system with a valid `parent_id`."""
 
         self.mock_create(
-            {**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            {**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
         )
         self.call_create()
         self.check_create_success()
@@ -223,7 +227,7 @@ class TestCreate(CreateDSL):
 
         parent_id = str(ObjectId())
 
-        self.mock_create({**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": parent_id}, parent_system_in_data=None)
+        self.mock_create({**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": parent_id}, parent_system_in_data=None)
         self.call_create_expecting_error(MissingRecordError)
         self.check_create_failed_with_exception(f"No parent system found with ID: {parent_id}")
 
@@ -231,9 +235,9 @@ class TestCreate(CreateDSL):
         """Test creating a system with a duplicate system being found in the parent system."""
 
         self.mock_create(
-            {**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
-            duplicate_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            {**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+            duplicate_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
         )
         self.call_create_expecting_error(DuplicateRecordError)
         self.check_create_failed_with_exception("Duplicate system found within the parent system")
@@ -318,7 +322,7 @@ class TestGet(GetDSL):
 
         system_id = str(ObjectId())
 
-        self.mock_get(system_id, SYSTEM_IN_DATA_NO_PARENT_A)
+        self.mock_get(system_id, SYSTEM_IN_DATA_STORAGE_NO_PARENT_A)
         self.call_get(system_id)
         self.check_get_success()
 
@@ -451,21 +455,21 @@ class TestList(ListDSL):
     def test_list(self):
         """Test listing all systems."""
 
-        self.mock_list([SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B])
+        self.mock_list([SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, SYSTEM_IN_DATA_STORAGE_NO_PARENT_B])
         self.call_list(parent_id=None)
         self.check_list_success()
 
     def test_list_with_parent_id_filter(self):
         """Test listing all systems with a given `parent_id`."""
 
-        self.mock_list([SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B])
+        self.mock_list([SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, SYSTEM_IN_DATA_STORAGE_NO_PARENT_B])
         self.call_list(parent_id=str(ObjectId()))
         self.check_list_success()
 
     def test_list_with_null_parent_id_filter(self):
         """Test listing all systems with a 'null' `parent_id`."""
 
-        self.mock_list([SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B])
+        self.mock_list([SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, SYSTEM_IN_DATA_STORAGE_NO_PARENT_B])
         self.call_list(parent_id="null")
         self.check_list_success()
 
@@ -664,7 +668,7 @@ class TestUpdate(UpdateDSL):
 
         system_id = str(ObjectId())
 
-        self.mock_update(system_id, SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_B)
+        self.mock_update(system_id, SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, SYSTEM_IN_DATA_STORAGE_NO_PARENT_B)
         self.call_update(system_id)
         self.check_update_success()
 
@@ -673,7 +677,7 @@ class TestUpdate(UpdateDSL):
 
         system_id = str(ObjectId())
 
-        self.mock_update(system_id, SYSTEM_IN_DATA_NO_PARENT_A, SYSTEM_IN_DATA_NO_PARENT_A)
+        self.mock_update(system_id, SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, SYSTEM_IN_DATA_STORAGE_NO_PARENT_A)
         self.call_update(system_id)
         self.check_update_success()
 
@@ -684,9 +688,9 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             system_id=system_id,
-            new_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
-            new_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            new_system_in_data={**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+            new_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             duplicate_system_in_data=None,
             valid_move_result=True,
         )
@@ -700,9 +704,9 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             system_id=system_id,
-            new_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
-            new_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            new_system_in_data={**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+            new_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             duplicate_system_in_data=None,
             valid_move_result=False,
         )
@@ -717,8 +721,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             system_id,
-            {**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": new_parent_id},
-            SYSTEM_IN_DATA_NO_PARENT_A,
+            {**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": new_parent_id},
+            SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             new_parent_system_in_data=None,
         )
         self.call_update_expecting_error(system_id, MissingRecordError)
@@ -732,9 +736,9 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             system_id,
-            {**SYSTEM_IN_DATA_NO_PARENT_A, "name": duplicate_name},
-            SYSTEM_IN_DATA_NO_PARENT_A,
-            duplicate_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_A, "name": duplicate_name},
+            {**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "name": duplicate_name},
+            SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+            duplicate_system_in_data={**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "name": duplicate_name},
         )
         self.call_update_expecting_error(system_id, DuplicateRecordError)
         self.check_update_failed_with_exception("Duplicate system found within the parent system")
@@ -748,10 +752,10 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             system_id,
-            {**SYSTEM_IN_DATA_NO_PARENT_A, "parent_id": new_parent_id},
-            SYSTEM_IN_DATA_NO_PARENT_A,
-            new_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
-            duplicate_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            {**SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, "parent_id": new_parent_id},
+            SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+            new_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+            duplicate_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
         )
         self.call_update_expecting_error(system_id, DuplicateRecordError)
         self.check_update_failed_with_exception("Duplicate system found within the parent system")
@@ -761,7 +765,7 @@ class TestUpdate(UpdateDSL):
 
         system_id = "invalid-id"
 
-        self.set_update_data(SYSTEM_IN_DATA_NO_PARENT_A)
+        self.set_update_data(SYSTEM_IN_DATA_STORAGE_NO_PARENT_A)
         self.call_update_expecting_error(system_id, InvalidObjectIdError)
         self.check_update_failed_with_exception("Invalid ObjectId value 'invalid-id'")
 
@@ -961,14 +965,14 @@ class TestHasChildElements(HasChildElementsDSL):
     def test_has_child_elements_with_child_system(self):
         """Test `has_child_elements` when there is a child system but no child items."""
 
-        self.mock_has_child_elements(child_system_data=SYSTEM_IN_DATA_NO_PARENT_A, child_item_data=None)
+        self.mock_has_child_elements(child_system_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A, child_item_data=None)
         self.call_has_child_elements(str(ObjectId()))
         self.check_has_child_elements_success(expected_result=True)
 
     def test_has_child_elements_with_child_item(self):
         """Test `has_child_elements` when there are no child systems but there is a child item."""
 
-        self.mock_has_child_elements(child_system_data=None, child_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.mock_has_child_elements(child_system_data=None, child_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_has_child_elements(str(ObjectId()))
         self.check_has_child_elements_success(expected_result=True)
 
@@ -1037,6 +1041,6 @@ class TestWriteLock(WriteLockDSL):
 
         system_id = str(ObjectId())
 
-        self.mock_write_lock(system_id, SYSTEM_IN_DATA_NO_PARENT_A)
+        self.mock_write_lock(system_id, SYSTEM_IN_DATA_STORAGE_NO_PARENT_A)
         self.call_write_lock(system_id)
         self.check_write_lock_success()

--- a/test/unit/repositories/test_usage_status.py
+++ b/test/unit/repositories/test_usage_status.py
@@ -5,7 +5,7 @@ Unit tests for the `UsageStatusRepo` repository.
 # Expect some duplicate code inside tests as the tests for the different entities can be very similar
 # pylint: disable=duplicate-code
 
-from test.mock_data import ITEM_DATA_REQUIRED_VALUES_ONLY, USAGE_STATUS_IN_DATA_NEW, USAGE_STATUS_IN_DATA_USED
+from test.mock_data import ITEM_DATA_NEW_REQUIRED_VALUES_ONLY, USAGE_STATUS_IN_DATA_NEW, USAGE_STATUS_IN_DATA_USED
 from test.unit.repositories.conftest import RepositoryTestHelpers
 from typing import Optional
 from unittest.mock import MagicMock, Mock, call
@@ -438,7 +438,7 @@ class TestDelete(DeleteDSL):
         self.mock_delete(
             deleted_count=1,
             item_data={
-                **ITEM_DATA_REQUIRED_VALUES_ONLY,
+                **ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
                 "catalogue_item_id": str(ObjectId()),
                 "system_id": str(ObjectId()),
                 "usage_status_id": usage_status_id,

--- a/test/unit/services/conftest.py
+++ b/test/unit/services/conftest.py
@@ -217,6 +217,7 @@ def fixture_item_service(
     catalogue_item_repository_mock: Mock,
     system_repository_mock: Mock,
     usage_status_repository_mock: Mock,
+    rule_repository_mock: Mock,
     setting_repository_mock: Mock,
 ) -> ItemService:
     """
@@ -228,6 +229,7 @@ def fixture_item_service(
     :param catalogue_item_repository_mock: Mocked `CatalogueItemRepo` instance.
     :param system_repository_mock: Mocked `SystemRepo` instance.
     :param usage_status_repository_mock: Mocked `UsageStatusRepo` instance.
+    :param rule_repository_mock: Mocked `RuleRepo` instance.
     :param setting_repository_mock: Mocked `SettingRepo` instance.
     :return: `ItemService` instance with the mocked dependencies.
     """
@@ -237,6 +239,7 @@ def fixture_item_service(
         catalogue_item_repository_mock,
         system_repository_mock,
         usage_status_repository_mock,
+        rule_repository_mock,
         setting_repository_mock,
     )
 

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -20,7 +20,6 @@ from test.mock_data import (
     SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
     USAGE_STATUS_GET_DATA_IN_USE,
-    USAGE_STATUS_GET_DATA_NEW,
     USAGE_STATUS_IN_DATA_IN_USE,
     USAGE_STATUS_IN_DATA_NEW,
 )
@@ -1203,12 +1202,12 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
+            item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]},
             stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             stored_rule_exists=True,
-            new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
+            new_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_system_in_data={
                 **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
@@ -1225,12 +1224,12 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
+            item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]},
             stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             stored_rule_exists=False,
-            new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
+            new_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_system_in_data={
                 **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
@@ -1253,7 +1252,7 @@ class TestUpdate(UpdateDSL):
             stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
-            new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
+            new_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
         )
         self.call_update_expecting_error(item_id, InvalidActionError)

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -1147,7 +1147,6 @@ class TestUpdate(UpdateDSL):
             stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
             stored_rule_exists=True,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
-            # TODO: Rename systems to mention what type???
             new_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
         )
         self.call_update(item_id)
@@ -1167,7 +1166,6 @@ class TestUpdate(UpdateDSL):
             stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
             stored_rule_exists=False,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
-            # TODO: Rename systems to mention what type???
             new_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
         )
         self.call_update_expecting_error(item_id, InvalidActionError)
@@ -1176,7 +1174,8 @@ class TestUpdate(UpdateDSL):
         )
 
     def test_update_system_and_usage_status_ids_when_systems_have_same_type(self):
-        """Test updating an item's `system_id` and `usage_status_id` when the systems have the same type."""
+        """Test updating an item's `system_id` and `usage_status_id` when the current and new systems have the same
+        type."""
 
         item_id = str(ObjectId())
 

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -11,14 +11,15 @@ from test.mock_data import (
     BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES,
     CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
     CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_DATA_ALL_VALUES_NO_PROPERTIES,
-    ITEM_DATA_REQUIRED_VALUES_ONLY,
-    ITEM_DATA_WITH_ALL_PROPERTIES,
-    ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY,
+    ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
+    ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
+    ITEM_DATA_NEW_WITH_ALL_PROPERTIES,
+    ITEM_DATA_NEW_WITH_MANDATORY_PROPERTIES_ONLY,
     SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
-    SYSTEM_IN_DATA_NO_PARENT_A,
-    SYSTEM_IN_DATA_NO_PARENT_B,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
+    USAGE_STATUS_GET_DATA_IN_USE,
     USAGE_STATUS_GET_DATA_NEW,
     USAGE_STATUS_IN_DATA_IN_USE,
     USAGE_STATUS_IN_DATA_NEW,
@@ -451,7 +452,7 @@ class TestCreate(CreateDSL):
         """Test creating an item without any properties in the catalogue item or item."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
             catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -463,7 +464,7 @@ class TestCreate(CreateDSL):
         """Test creating an item when none of the properties present in the catalogue item are defined in the item."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES,
             catalogue_category_in_data=BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES_MM,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -475,7 +476,7 @@ class TestCreate(CreateDSL):
         """Test creating an item when all properties present in the catalogue item are defined in the item."""
 
         self.mock_create(
-            ITEM_DATA_WITH_ALL_PROPERTIES,
+            ITEM_DATA_NEW_WITH_ALL_PROPERTIES,
             catalogue_item_data=BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES,
             catalogue_category_in_data=BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES_MM,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -487,7 +488,7 @@ class TestCreate(CreateDSL):
         """Test creating an item when there is a spares definition defined."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
             catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -500,7 +501,7 @@ class TestCreate(CreateDSL):
         """Test creating an item when there is a spares definition defined and a write conflict occurs."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
             catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -514,7 +515,7 @@ class TestCreate(CreateDSL):
         """Test creating an item with a non-existent catalogue item ID."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=None,
             catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -526,7 +527,7 @@ class TestCreate(CreateDSL):
         """Test creating an item with a catalogue item that has a non-existent catalogue category ID."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
             catalogue_category_in_data=None,
             usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
@@ -540,7 +541,7 @@ class TestCreate(CreateDSL):
         """Test creating an item with a non-existent usage status ID."""
 
         self.mock_create(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             catalogue_item_data=CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
             catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
             usage_status_in_data=None,
@@ -1071,8 +1072,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data=ITEM_DATA_ALL_VALUES_NO_PROPERTIES,
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            item_update_data=ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
         )
         self.call_update(item_id)
@@ -1085,11 +1086,11 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data=ITEM_DATA_ALL_VALUES_NO_PROPERTIES,
+            item_update_data=ITEM_DATA_NEW_ALL_VALUES_NO_PROPERTIES,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             # Strictly speaking we wouldn't allow this in the first place - the stored data is missing a mandatory
             # property but it is irrelevant for this test and saves creating a new version
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_catalogue_item_data=BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES,
             stored_catalogue_category_in_data=BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES_MM,
         )
@@ -1103,11 +1104,11 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data=ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY,
+            item_update_data=ITEM_DATA_NEW_WITH_MANDATORY_PROPERTIES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             # Strictly speaking we wouldn't allow this in the first place - the stored data is missing a mandatory
             # property but it is irrelevant for this test and saves creating a new version
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_catalogue_item_data=BASE_CATALOGUE_ITEM_DATA_WITH_PROPERTIES,
             stored_catalogue_category_in_data=BASE_CATALOGUE_CATEGORY_IN_DATA_WITH_PROPERTIES_MM,
         )
@@ -1122,7 +1123,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"catalogue_item_id": str(ObjectId())},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
         )
         self.call_update_expecting_error(item_id, InvalidActionError)
@@ -1136,10 +1137,10 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": str(ObjectId())},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
-            new_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+            new_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
         )
         self.call_update(item_id)
         self.check_update_success()
@@ -1152,11 +1153,11 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": str(ObjectId())},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
-            new_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            new_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
         )
         self.call_update(item_id)
         self.check_update_success()
@@ -1169,11 +1170,11 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": str(ObjectId())},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
-            new_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            new_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             raise_write_conflict_once=True,
         )
         self.call_update(item_id)
@@ -1188,7 +1189,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": system_id},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_system_in_data=None,
         )
@@ -1203,12 +1204,15 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             stored_rule_exists=True,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
-            new_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
+            new_system_in_data={
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+                "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+            },
         )
         self.call_update(item_id)
         self.check_update_success()
@@ -1222,12 +1226,15 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             stored_rule_exists=False,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
-            new_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
+            new_system_in_data={
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+                "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+            },
         )
         self.call_update_expecting_error(item_id, InvalidActionError)
         self.check_update_failed_with_exception(
@@ -1242,12 +1249,12 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            item_update_data={"system_id": str(ObjectId()), "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]},
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
-            stored_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
-            new_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            new_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
         )
         self.call_update_expecting_error(item_id, InvalidActionError)
         self.check_update_failed_with_exception(
@@ -1264,7 +1271,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             item_id,
             item_update_data={"system_id": str(ObjectId()), "usage_status_id": usage_status_id},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_usage_status_in_data=None,
         )
@@ -1278,8 +1285,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data={"usage_status_id": USAGE_STATUS_GET_DATA_NEW["id"]},
-            stored_item_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            item_update_data={"usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]},
+            stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
         )
@@ -1295,7 +1302,7 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             item_id,
-            item_update_data=ITEM_DATA_REQUIRED_VALUES_ONLY,
+            item_update_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_item_data=None,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
         )
@@ -1402,7 +1409,7 @@ class TestDelete(DeleteDSL):
     def test_delete(self):
         """Test deleting an item."""
 
-        self.mock_delete(ITEM_DATA_REQUIRED_VALUES_ONLY)
+        self.mock_delete(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         self.call_delete(str(ObjectId()))
         self.check_delete_success()
 
@@ -1410,7 +1417,8 @@ class TestDelete(DeleteDSL):
         """Test deleting an item when there is a spares definition defined."""
 
         self.mock_delete(
-            ITEM_DATA_REQUIRED_VALUES_ONLY, stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
+            stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
         )
         self.call_delete(str(ObjectId()))
         self.check_delete_success()
@@ -1419,7 +1427,7 @@ class TestDelete(DeleteDSL):
         """Test deleting an item when there is a spares definition defined and a write conflict occurs."""
 
         self.mock_delete(
-            ITEM_DATA_REQUIRED_VALUES_ONLY,
+            ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
             raise_write_conflict_once=True,
         )

--- a/test/unit/services/test_system.py
+++ b/test/unit/services/test_system.py
@@ -7,13 +7,14 @@ Unit tests for the `SystemService` service.
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-lines
 
 from test.mock_data import (
     SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
-    SYSTEM_IN_DATA_NO_PARENT_A,
-    SYSTEM_IN_DATA_NO_PARENT_B,
-    SYSTEM_POST_DATA_NO_PARENT_A,
-    SYSTEM_POST_DATA_NO_PARENT_B,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
+    SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+    SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
+    SYSTEM_POST_DATA_STORAGE_NO_PARENT_B,
     SYSTEM_TYPE_GET_DATA_OPERATIONAL,
     SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
     SYSTEM_TYPE_OUT_DATA_STORAGE,
@@ -252,7 +253,7 @@ class TestCreate(CreateDSL):
     def test_create(self):
         """Test creating a system."""
 
-        self.mock_create(SYSTEM_POST_DATA_NO_PARENT_A, system_type_out_data=SYSTEM_TYPE_OUT_DATA_STORAGE)
+        self.mock_create(SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, system_type_out_data=SYSTEM_TYPE_OUT_DATA_STORAGE)
         self.call_create()
         self.check_create_success()
 
@@ -260,9 +261,9 @@ class TestCreate(CreateDSL):
         """Test creating a system with a `parent_id`."""
 
         self.mock_create(
-            {**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
+            {**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
             system_type_out_data=SYSTEM_TYPE_OUT_DATA_STORAGE,
-            parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
         )
         self.call_create()
         self.check_create_success()
@@ -273,7 +274,7 @@ class TestCreate(CreateDSL):
         parent_id = str(ObjectId())
 
         self.mock_create(
-            {**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": parent_id},
+            {**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": parent_id},
             system_type_out_data=SYSTEM_TYPE_OUT_DATA_STORAGE,
             parent_system_in_data=None,
         )
@@ -285,12 +286,12 @@ class TestCreate(CreateDSL):
 
         self.mock_create(
             {
-                **SYSTEM_POST_DATA_NO_PARENT_A,
+                **SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
                 "parent_id": str(ObjectId()),
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
             },
             system_type_out_data=SYSTEM_TYPE_OUT_DATA_STORAGE,
-            parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_A,
+            parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
         )
         self.call_create_expecting_error(InvalidActionError)
         self.check_create_failed_with_exception("Cannot use a different type_id to the parent system")
@@ -301,7 +302,7 @@ class TestCreate(CreateDSL):
         type_id = str(ObjectId())
 
         self.mock_create(
-            {**SYSTEM_POST_DATA_NO_PARENT_A, "type_id": type_id},
+            {**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "type_id": type_id},
             system_type_out_data=None,
         )
         self.call_create_expecting_error(MissingRecordError)
@@ -646,8 +647,8 @@ class TestUpdate(UpdateDSL):
 
         self.mock_update(
             system_id,
-            system_patch_data=SYSTEM_POST_DATA_NO_PARENT_B,
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            system_patch_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_B,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
         )
         self.call_update(system_id)
         self.check_update_success()
@@ -660,7 +661,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
         )
         self.call_update(system_id)
@@ -675,7 +676,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
         )
@@ -690,9 +691,9 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data={**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_system_post_data={**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
             stored_parent_system_in_data={
-                **SYSTEM_IN_DATA_NO_PARENT_B,
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
             },
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
@@ -708,9 +709,9 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data={**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_system_post_data={**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
             stored_parent_system_in_data={
-                **SYSTEM_IN_DATA_NO_PARENT_B,
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
             },
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
@@ -728,7 +729,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"type_id": new_type_id},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             new_system_type_out_data=None,
         )
         self.call_update_expecting_error(system_id, MissingRecordError)
@@ -742,8 +743,8 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": str(ObjectId())},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
-            new_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
+            new_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
         )
         self.call_update(system_id)
         self.check_update_success()
@@ -756,8 +757,11 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": str(ObjectId())},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
-            new_parent_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
+            new_parent_system_in_data={
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+                "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+            },
         )
         self.call_update_expecting_error(system_id, InvalidActionError)
         self.check_update_failed_with_exception("Cannot move a system into one with a different type")
@@ -771,9 +775,12 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": str(ObjectId()), "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
-            new_parent_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
+            new_parent_system_in_data={
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+                "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+            },
         )
         self.call_update(system_id)
         self.check_update_success()
@@ -787,10 +794,13 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": str(ObjectId()), "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
-            new_parent_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
+            new_parent_system_in_data={
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+                "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+            },
         )
         self.call_update(system_id)
         self.check_update_success()
@@ -804,9 +814,12 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": str(ObjectId()), "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
-            new_parent_system_in_data={**SYSTEM_IN_DATA_NO_PARENT_B, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
+            new_parent_system_in_data={
+                **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
+                "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
+            },
             has_child_elements=True,
         )
         self.call_update_expecting_error(system_id, InvalidActionError)
@@ -820,8 +833,8 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": None},
-            stored_system_post_data={**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            stored_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            stored_system_post_data={**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             new_parent_system_in_data=None,
         )
         self.call_update(system_id)
@@ -835,8 +848,8 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": None},
-            stored_system_post_data={**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            stored_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            stored_system_post_data={**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             stored_spares_definition_out_data=SETTING_SPARES_DEFINITION_OUT_DATA_STORAGE,
             new_parent_system_in_data=None,
         )
@@ -851,8 +864,8 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": None, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data={**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            stored_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            stored_system_post_data={**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             new_system_type_out_data=SYSTEM_TYPE_OUT_DATA_OPERATIONAL,
             new_parent_system_in_data=None,
         )
@@ -867,8 +880,8 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": None, "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"]},
-            stored_system_post_data={**SYSTEM_POST_DATA_NO_PARENT_A, "parent_id": str(ObjectId())},
-            stored_parent_system_in_data=SYSTEM_IN_DATA_NO_PARENT_B,
+            stored_system_post_data={**SYSTEM_POST_DATA_STORAGE_NO_PARENT_A, "parent_id": str(ObjectId())},
+            stored_parent_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
             new_parent_system_in_data=None,
             has_child_elements=True,
         )
@@ -884,7 +897,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"parent_id": new_parent_id},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
             new_parent_system_in_data=None,
         )
         self.call_update_expecting_error(system_id, MissingRecordError)
@@ -898,7 +911,7 @@ class TestUpdate(UpdateDSL):
         self.mock_update(
             system_id,
             system_patch_data={"description": "A new description"},
-            stored_system_post_data=SYSTEM_POST_DATA_NO_PARENT_A,
+            stored_system_post_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_A,
         )
         self.call_update(system_id)
         self.check_update_success()
@@ -908,7 +921,9 @@ class TestUpdate(UpdateDSL):
 
         system_id = str(ObjectId())
 
-        self.mock_update(system_id, system_patch_data=SYSTEM_POST_DATA_NO_PARENT_B, stored_system_post_data=None)
+        self.mock_update(
+            system_id, system_patch_data=SYSTEM_POST_DATA_STORAGE_NO_PARENT_B, stored_system_post_data=None
+        )
         self.call_update_expecting_error(system_id, MissingRecordError)
         self.check_update_failed_with_exception(f"No system found with ID: {system_id}")
 


### PR DESCRIPTION
## Description

This PR implements moving rules and modifies the item update behaviour so that a user:
- Cannot change usage status on its own
- Cannot change usage status when moving between systems of the same type
- Can only move the item between systems or change the usage status when satisfying a rule i.e. moving between systems of the same src and dst types and setting the usage status to be the same as in that rule

This functionality also technically works with multiple rules of the same src and dst system type's but different usage statuses, allowing the usage status to be chosen by the user (but the front end wont be implementing this, so its on the configuration/sysadmin to avoid duplicating them).

## Other notes
- I split up the system and usage status id update up into a new function much like systems has `_validate_type_and_parent_update` now as the function was getting very long. I did the same for the properties as well.
- The ItemService was missing raises in the docstrings for the update method, same for CatalogueItemService so I added them.
- I modified the mock data so that the items are new instead of in use since the systems were all storage and updated the names to include the type/usage status so its clear in tests. I also decided to remove `_NO_PARENT` becuase it was redundant and just making them needlessly long as they never have parents unless added during the tests themselves.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #541
