### PR TITLE
Add sysadmin CLI with command to set spares definition #595

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,9 @@ of spares you have for each catalogue item. To configure the spares definition a
 ims configure spares-definition
 ```
 
-and follow its instructions. This will calculate and update the `number_of_spares` field on all catalogue items.
+and follow its instructions. This will calculate and update the `number_of_spares` field on all catalogue items and may also be used to change the spares definition once already setup.
+
+NOTE: Please ensure that no one is using ims-api when executing this. Otherwise it is possible to miscount the number of spares. If using a reverse proxy to provide access, we recommend first shutting it down before doing this.
 
 Subsequently, whenever a new item is added, moved or deleted and would effect the number of spares, the number of spares
 inside the effected catalogue item will be recalculated.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,39 @@ payload, and it has not expired. This means that any microservice can be used to
 it meets the above criteria. The [LDAP-JWT Authentication Service](https://github.com/ral-facilities/ldap-jwt-auth) is
 a microservice that provides user authentication against an LDAP server and returns a JWT access token.
 
+### IMS System Administrator CLI
+
+IMS includes a command line interface intended to help a system administrator manage the system. This can be accessed
+using the command `ims` e.g.
+
+```bash
+ims --help
+```
+
+or in Docker
+
+```bash
+docker exec -it inventory-management-system-api ims --help
+```
+
+#### Setting the spares definition
+
+The spares definition is a list of system types that define what systems contain spares. E.g. If you have system type
+of `Storage`, and define the spares definition as `Storage`. Then a spare of a given catalogue item will be defined
+as any item that is within a system of with a type of `Storage`.
+
+When first setup IMS does not have a spares definition assigned and so will not attempt to calculate the number
+of spares you have for each catalogue item. To configure the spares definition and enable this functionality use
+
+```bash
+ims configure spares-definition
+```
+
+and follow its instructions. This will calculate and update the `number_of_spares` field on all catalogue items.
+
+Subsequently, whenever a new item is added, moved or deleted and would effect the number of spares, the number of spares
+inside the effected catalogue item will be recalculated.
+
 ### Migrations
 
 #### Adding a migration

--- a/README.md
+++ b/README.md
@@ -401,20 +401,21 @@ docker exec -it inventory-management-system-api ims --help
 
 #### Setting the spares definition
 
-The spares definition is a list of system types that define what systems contain spares. E.g. If you have system type
-of `Storage`, and define the spares definition as `Storage`. Then a spare of a given catalogue item will be defined
-as any item that is within a system of with a type of `Storage`.
-
-When first setup IMS does not have a spares definition assigned and so will not attempt to calculate the number
-of spares you have for each catalogue item. To configure the spares definition and enable this functionality use
+The spares definition is a list of system types that define what systems contain spares. E.g. If you have system type of
+`Storage`, and define the spares definition as `Storage`. Then a spare of a given catalogue item will be defined as any
+item that is within a system of with a type of `Storage`.
+When first setup, IMS does not have a spares definition assigned and so will not attempt to calculate the number of
+spares you have for each catalogue item. To configure the spares definition and enable this functionality use
 
 ```bash
 ims configure spares-definition
 ```
 
-and follow its instructions. This will calculate and update the `number_of_spares` field on all catalogue items and may also be used to change the spares definition once already setup.
+and follow its instructions. This will calculate and update the `number_of_spares` field on all catalogue items and may
+also be used to change the spares definition once already setup.
 
-NOTE: Please ensure that no one is using ims-api when executing this. Otherwise it is possible to miscount the number of spares. If using a reverse proxy to provide access, we recommend first shutting it down before doing this.
+NOTE: Please ensure that no one is using ims-api when executing this. Otherwise it is possible to miscount the number of
+spares. If using a reverse proxy to provide access, we recommend first shutting it down before doing this.
 
 Subsequently, whenever a new item is added, moved or deleted and would effect the number of spares, the number of spares
 inside the effected catalogue item will be recalculated.

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,4 @@ ignore:
   - "test/"
   - "inventory_management_system_api/migrations/scripts/*" # ignore migration scripts
   - "inventory_management_system_api/routers/v1/*" # ignore routers as they are tested in the e2e tests
+  - "inventory_management_system_api/cli" # ignore cli as its not easy to test and is instead manually checked

--- a/inventory_management_system_api/cli/configure.py
+++ b/inventory_management_system_api/cli/configure.py
@@ -108,6 +108,7 @@ def spares_definition():
     console.print(
         "[red bold] This operation will recalculate the 'number_of_spares' field of all existing catalogue items![/]"
     )
+    console.print("[red bold] Please ensure no one else is using ims-api to avoid any miscalculations.[/]")
     console.print("[red bold] Should an error occur at any point during this process no changes will be made.[/]")
     console.print()
     console.print(f"[red bold]{":warning: " * 48}[/]")

--- a/inventory_management_system_api/cli/configure.py
+++ b/inventory_management_system_api/cli/configure.py
@@ -1,12 +1,17 @@
 """Module for providing a subcommand for configuring IMS."""
 
+from typing import Optional, Tuple, TypeVar
+
 import typer
 from rich.console import Console
+from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn, TimeElapsedColumn, TimeRemainingColumn
 from rich.prompt import Prompt
 from rich.table import Table
 
 from inventory_management_system_api.core.database import get_database
+from inventory_management_system_api.models.custom_object_id_data_types import StringObjectIdField
 from inventory_management_system_api.models.setting import SparesDefinitionIn, SparesDefinitionOut
+from inventory_management_system_api.models.system_type import SystemTypeOut
 from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
 from inventory_management_system_api.repositories.item import ItemRepo
 from inventory_management_system_api.repositories.setting import SettingRepo
@@ -16,6 +21,53 @@ from inventory_management_system_api.services.system_type import SystemTypeServi
 
 app = typer.Typer()
 console = Console()
+
+
+def display_indexed_system_types(system_types: list[SystemTypeOut]):
+    """Displays a list of system types in an indexed table."""
+
+    table = Table("Index", "Value")
+    for i, system_type in enumerate(system_types, start=1):
+        table.add_row(str(i), system_type.value)
+
+    console.print(table)
+    console.print()
+
+
+def display_indices_selection(message: str, indices: list[int], values: list[str]):
+    """Displays a list of indices and their corresponding values after a message."""
+
+    console.print(f"{message}: [green]{",".join(str(index) for index in indices)}[/] [orange1]({",".join(values)})")
+    console.print()
+
+
+def display_current_spares_definition(
+    definition: Optional[SparesDefinitionOut], system_type_ids: list[StringObjectIdField]
+):
+    """Displays the current spares definition."""
+
+    if definition is None:
+        console.print("There is no spares definition currently")
+    else:
+        current_type_values = [system_type.value for system_type in definition.system_types]
+        current_type_indices = []
+        for system_type in definition.system_types:
+            current_type_indices.append(str(system_type_ids.index(system_type.id) + 1))
+
+        display_indices_selection("The current spares definition is", current_type_indices, current_type_values)
+
+
+T = TypeVar("T")
+
+
+def ask_user_for_indices_selection(message: str, options: list[T]) -> Tuple[list[str], list[T]]:
+    """Asks the user for a selection of indices and returns the resulting selected indices and the options they
+    represent."""
+
+    selected_indices = [int(index) for index in Prompt.ask(message).split(",")]
+    selected_options = [options[selected_index - 1] for selected_index in selected_indices]
+
+    return selected_indices, selected_options
 
 
 @app.command()
@@ -33,65 +85,58 @@ def spares_definition():
     system_types = system_type_service.list()
 
     console.print("Below is a list of the current system types available:")
-
-    table = Table("Index", "Value")
-    for i, system_type in enumerate(system_types, start=1):
-        table.add_row(str(i), system_type.value)
-
-    console.print(table)
-    console.print()
+    display_indexed_system_types(system_types)
 
     # Obtain and output the current spares definition
     # pylint:disable=fixme
-    # TODO: Obtain from the setting service directly rather than via the repo
+    # TODO: Obtain from the setting service directly rather than via the repo once implemented in #549
     # pylint:disable=protected-access
     current_spares_definition = setting_service._setting_repository.get(SparesDefinitionOut)
 
     system_type_ids = [system_type.id for system_type in system_types]
-    current_type_values = [system_type.value for system_type in current_spares_definition.system_types]
-    current_type_indices = []
-    for system_type in current_spares_definition.system_types:
-        current_type_indices.append(str(system_type_ids.index(system_type.id) + 1))
-
-    console.print(
-        f"The current spares definition is: [green]{",".join(current_type_indices)}[/green]"
-        f" [orange1]({",".join(current_type_values)})[/orange1]"
-    )
+    display_current_spares_definition(current_spares_definition, system_type_ids)
 
     # Obtain new requested spares definition
-    selected_type_indices = Prompt.ask(
-        "Please enter a new list of system types separated by commas e.g. [green]1,2,3[/green]"
+    selected_type_indices, selected_types = ask_user_for_indices_selection(
+        "Please enter a new list of system types separated by commas e.g. [green]1,2,3[/]", system_types
     )
-    selected_type_indices = selected_type_indices.split(",")
-    selected_types = [system_types[int(selected_type_index) - 1] for selected_type_index in selected_type_indices]
-    selected_type_values = [system_type.value for system_type in selected_types]
 
     # Display a warning message explaining the consequences of continuing
     console.print()
-    console.print(f"[red]{":warning: " * 48}[/red]")
+    console.print(f"[red bold]{":warning: " * 48}[/]")
     console.print()
     console.print(
-        "[red] This operation will recalculate the 'number_of_spares' field of all existing catalogue items![/red]"
+        "[red bold] This operation will recalculate the 'number_of_spares' field of all existing catalogue items![/]"
     )
-    console.print("[red] Should an error occur at any point during this process no changes will be made.[/red]")
+    console.print("[red bold] Should an error occur at any point during this process no changes will be made.[/]")
     console.print()
-    console.print(f"[red]{":warning: " * 48}[/red]")
+    console.print(f"[red bold]{":warning: " * 48}[/]")
     console.print()
 
     # Output the new selected spares definition and request confirmation before setting it
-    console.print("")
-    console.print(
-        f"You have selected [green]{",".join(selected_type_indices)}[/green]"
-        f" [orange1]({",".join(selected_type_values)})[/orange1]"
+    display_indices_selection(
+        "You have selected", selected_type_indices, [system_type.value for system_type in selected_types]
     )
 
     cont = typer.confirm("Are you sure you want to select this as your new spares definition?")
 
     if cont:
-        # Now set the spares definition
-        setting_service.set_spares_definition(
-            SparesDefinitionIn(system_type_ids=[selected_type.id for selected_type in selected_types])
+        # Now set the spares definition with a progress bar
+        console.print("Updating catalogue items...")
+        progress_bar = Progress(
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("•"),
+            TimeElapsedColumn(),
+            TextColumn("•"),
+            TimeRemainingColumn(),
         )
+        with progress_bar as p:
+            setting_service.set_spares_definition(
+                SparesDefinitionIn(system_type_ids=[selected_type.id for selected_type in selected_types]),
+                tracker=p.track,
+            )
 
         console.print("Success! :party_popper:")
     else:

--- a/inventory_management_system_api/cli/configure.py
+++ b/inventory_management_system_api/cli/configure.py
@@ -52,7 +52,7 @@ def display_current_spares_definition(
         current_type_values = [system_type.value for system_type in definition.system_types]
         current_type_indices = []
         for system_type in definition.system_types:
-            current_type_indices.append(str(system_type_ids.index(system_type.id) + 1))
+            current_type_indices.append(system_type_ids.index(system_type.id) + 1)
 
         display_indices_selection("The current spares definition is", current_type_indices, current_type_values)
 

--- a/inventory_management_system_api/cli/configure.py
+++ b/inventory_management_system_api/cli/configure.py
@@ -1,0 +1,98 @@
+"""Module for providing a subcommand for configuring IMS."""
+
+import typer
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.table import Table
+
+from inventory_management_system_api.core.database import get_database
+from inventory_management_system_api.models.setting import SparesDefinitionIn, SparesDefinitionOut
+from inventory_management_system_api.repositories.catalogue_item import CatalogueItemRepo
+from inventory_management_system_api.repositories.item import ItemRepo
+from inventory_management_system_api.repositories.setting import SettingRepo
+from inventory_management_system_api.repositories.system_type import SystemTypeRepo
+from inventory_management_system_api.services.setting import SettingService
+from inventory_management_system_api.services.system_type import SystemTypeService
+
+app = typer.Typer()
+console = Console()
+
+
+@app.command()
+def spares_definition():
+    """Configures the spares definition used by IMS."""
+
+    # Acquire the required services
+    database = get_database()
+    system_type_service = SystemTypeService(SystemTypeRepo(database))
+    setting_service = SettingService(
+        SettingRepo(database), SystemTypeRepo(database), CatalogueItemRepo(database), ItemRepo(database)
+    )
+
+    # Output a table of existing system types
+    system_types = system_type_service.list()
+
+    console.print("Below is a list of the current system types available:")
+
+    table = Table("Index", "Value")
+    for i, system_type in enumerate(system_types, start=1):
+        table.add_row(str(i), system_type.value)
+
+    console.print(table)
+    console.print()
+
+    # Obtain and output the current spares definition
+    # pylint:disable=fixme
+    # TODO: Obtain from the setting service directly rather than via the repo
+    # pylint:disable=protected-access
+    current_spares_definition = setting_service._setting_repository.get(SparesDefinitionOut)
+
+    system_type_ids = [system_type.id for system_type in system_types]
+    current_type_values = [system_type.value for system_type in current_spares_definition.system_types]
+    current_type_indices = []
+    for system_type in current_spares_definition.system_types:
+        current_type_indices.append(str(system_type_ids.index(system_type.id) + 1))
+
+    console.print(
+        f"The current spares definition is: [green]{",".join(current_type_indices)}[/green]"
+        f" [orange1]({",".join(current_type_values)})[/orange1]"
+    )
+
+    # Obtain new requested spares definition
+    selected_type_indices = Prompt.ask(
+        "Please enter a new list of system types separated by commas e.g. [green]1,2,3[/green]"
+    )
+    selected_type_indices = selected_type_indices.split(",")
+    selected_types = [system_types[int(selected_type_index) - 1] for selected_type_index in selected_type_indices]
+    selected_type_values = [system_type.value for system_type in selected_types]
+
+    # Display a warning message explaining the consequences of continuing
+    console.print()
+    console.print(f"[red]{":warning: " * 48}[/red]")
+    console.print()
+    console.print(
+        "[red] This operation will recalculate the 'number_of_spares' field of all existing catalogue items![/red]"
+    )
+    console.print("[red] Should an error occur at any point during this process no changes will be made.[/red]")
+    console.print()
+    console.print(f"[red]{":warning: " * 48}[/red]")
+    console.print()
+
+    # Output the new selected spares definition and request confirmation before setting it
+    console.print("")
+    console.print(
+        f"You have selected [green]{",".join(selected_type_indices)}[/green]"
+        f" [orange1]({",".join(selected_type_values)})[/orange1]"
+    )
+
+    cont = typer.confirm("Are you sure you want to select this as your new spares definition?")
+
+    if cont:
+        # Now set the spares definition
+        setting_service.set_spares_definition(
+            SparesDefinitionIn(system_type_ids=[selected_type.id for selected_type in selected_types])
+        )
+
+        console.print("Success! :party_popper:")
+    else:
+        console.print("Cancelled")

--- a/inventory_management_system_api/cli/configure.py
+++ b/inventory_management_system_api/cli/configure.py
@@ -60,7 +60,7 @@ def display_current_spares_definition(
 T = TypeVar("T")
 
 
-def ask_user_for_indices_selection(message: str, options: list[T]) -> Tuple[list[str], list[T]]:
+def ask_user_for_indices_selection(message: str, options: list[T]) -> Tuple[list[int], list[T]]:
     """Asks the user for a selection of indices and returns the resulting selected indices and the options they
     represent."""
 
@@ -119,6 +119,7 @@ def spares_definition():
     )
 
     cont = typer.confirm("Are you sure you want to select this as your new spares definition?")
+    console.print()
 
     if cont:
         # Now set the spares definition with a progress bar

--- a/inventory_management_system_api/cli/main.py
+++ b/inventory_management_system_api/cli/main.py
@@ -1,0 +1,13 @@
+"""Module for providing an admin CLI for managing IMS."""
+
+import typer
+
+from inventory_management_system_api.cli import configure
+
+app = typer.Typer()
+app.add_typer(configure.app, name="configure", help="Configure IMS.")
+
+
+def main():
+    """Entrypoint for the ims CLI."""
+    app()

--- a/inventory_management_system_api/services/setting.py
+++ b/inventory_management_system_api/services/setting.py
@@ -76,7 +76,7 @@ class SettingService:
 
             # Recalculate the number of spares for each catalogue item
             logger.info("Updating the number of spares for all catalogue items")
-            for catalogue_item_id in tracker(catalogue_item_ids) if tracker is not None else catalogue_item_ids:
+            for catalogue_item_id in catalogue_item_ids if tracker is None else tracker(catalogue_item_ids):
                 number_of_spares = self._item_repository.count_in_catalogue_item_with_system_type_one_of(
                     catalogue_item_id,
                     spares_definition.system_type_ids,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 
 [project.scripts]
 "ims-migrate" = "inventory_management_system_api.migrations.script:main"
+"ims" = "inventory_management_system_api.cli.main:main"
 
 [project.optional-dependencies]
 code-analysis = [


### PR DESCRIPTION
## Description

Adds a CLI `ims` for setting the spares definition. See updated readme for instructions on how to use.

<img width="705" height="458" alt="image" src="https://github.com/user-attachments/assets/debe419e-c4a6-4a57-b6b2-e77c1650eff5" />


### Notes
- No specific validation is done on the user inputs, if you enter something in the wrong format it will just give an error (in colour thanks to `rich`)
- This is an interactive command requiring user input - this seemed the easier option for our current use case. The alternative is using parameters in the command such as the codes/ids, but that seemed more complicated to use, likely requiring extensive usage of the `--help` and additional commands to look up what currently exists. It also misses out on having explanations and warning messages.
- I have told codecov to ignore coverage for the CLI as unit tests are difficult to implement for this case.
- You can use `ims --install-completion` to get tab completion from `typer` or use `typer inventory_management_system_api/cli/main.py run`

### Future
- I think it would be nice to change the existing ims-migrate to use this instead of a separate `ims-migrate` command, and have it `ims migrate`. Also the `dev_cli` can be updated to use Typer.
- E2E testing is possible (see https://typer.tiangolo.com/tutorial/testing/#testing-input) but tricky to do nicely due to the interactive input (`echo -e "1,2\ny" | ims configure spares-definition` can work for example).

## Testing instructions

You will likely need to use `pip install -e .[dev]` in your local venv/rebuild the docker container with `docker compose build --no-cache` for it to install.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Manually test `ims configure spares-definition`

## Agile board tracking

Closes #595
