### PR TITLE
Implement authorisation logic for item rules #551

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This microservice requires a MongoDB instance to run against.
 
 - Docker and Docker Compose installed (if you want to run the microservice inside Docker)
 - Python 3.12 and MongoDB 7.0 installed on your machine (if you are not using Docker)
-- Public key (must be OpenSSH encoded) to decode JWT access tokens (if JWT authentication/authorization is enabled)
+- Public key (must be OpenSSH encoded) to decode JWT access tokens (if JWT authentication/authorisation is enabled)
 - [MongoDB Compass](https://www.mongodb.com/products/compass) installed (if you want to interact with the database using
   a GUI)
 - This repository cloned
@@ -373,11 +373,11 @@ Listed below are the environment variables supported by the application.
 | `OBJECT_STORAGE__API_REQUEST_TIMEOUT_SECONDS` | The maximum number of seconds that the request should wait for a response from the Object Storage API before timing out.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | If Object Storage enabled |                                                       |
 | `OBJECT_STORAGE__API_URL`                     | The URL of the Object Storage API.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | If Object Storage enabled |                                                       |
 
-### JWT Authentication/Authorization
+### JWT Authentication/Authorisation
 
-This microservice supports JWT authentication/authorization and this can be enabled or disabled by setting
+This microservice supports JWT authentication/authorisation and this can be enabled or disabled by setting
 the `AUTHENTICATION__ENABLED` environment variable to `True` or `False`. When enabled, all the endpoints require a JWT
-access token to be supplied. This ensures that only authenticated and authorized users can access the resources. To
+access token to be supplied. This ensures that only authenticated and authorised users can access the resources. To
 decode the JWT access token, the application needs the public key that corresponding to the private key used for
 encoding the token. Once the JWT access token is decoded successfully, it checks that it has a `username` in the
 payload, and it has not expired. This means that any microservice can be used to generate JWT access tokens so long as

--- a/inventory_management_system_api/auth/jwt_bearer.py
+++ b/inventory_management_system_api/auth/jwt_bearer.py
@@ -17,7 +17,7 @@ logger = logging.getLogger()
 
 class JWTBearer(HTTPBearer):
     """
-    Extends the FastAPI `HTTPBearer` class to provide JSON Web Token (JWT) based authentication/authorization.
+    Extends the FastAPI `HTTPBearer` class to provide JSON Web Token (JWT) based authentication/authorisation.
     """
 
     def __init__(self, auto_error: bool = True) -> None:
@@ -31,10 +31,10 @@ class JWTBearer(HTTPBearer):
 
     async def __call__(self, request: Request) -> str:
         """
-        Callable method for JWT access token authentication/authorization.
+        Callable method for JWT access token authentication/authorisation.
 
         This method is called when `JWTBearer` is used as a dependency in a FastAPI route. It performs authentication/
-        authorization by calling the parent class method and then verifying the JWT access token.
+        authorisation by calling the parent class method and then verifying the JWT access token.
         :param request: The FastAPI `Request` object.
         :return: The JWT access token if authentication is successful.
         :raises HTTPException: If the supplied JWT access token is invalid or has expired.

--- a/inventory_management_system_api/core/config.py
+++ b/inventory_management_system_api/core/config.py
@@ -24,7 +24,7 @@ class APIConfig(BaseModel):
 
 class AuthenticationConfig(BaseModel):
     """
-    Configuration model for the JWT access token authentication/authorization.
+    Configuration model for the JWT access token authentication/authorisation.
     """
 
     enabled: bool

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -124,7 +124,7 @@ def partial_update_item(
     item: ItemPatchSchema,
     item_id: Annotated[str, Path(description="The ID of the item to update")],
     item_service: ItemServiceDep,
-    request: Request
+    request: Request,
 ) -> ItemSchema:
     logger.info("Partially updating item with ID: %s", item_id)
     logger.debug("Item data: %s", item)

--- a/inventory_management_system_api/services/item.py
+++ b/inventory_management_system_api/services/item.py
@@ -247,7 +247,7 @@ class ItemService:
                 raise MissingRecordError(f"No system found with ID: {item.system_id}")
 
             current_system = self._system_repository.get(stored_item.system_id)
-            
+
             # bypass rule check if authorised
             if current_system.type_id != system.type_id and not is_authorised:
                 # System type is changing - Ensure the moving operation is allowed by a rule

--- a/test/e2e/test_item.py
+++ b/test/e2e/test_item.py
@@ -804,7 +804,11 @@ class UpdateDSL(ListDSL):
             item_update_data, self.property_name_id_dict
         )
 
-        self._patch_response_item = self.test_client.patch(f"/v1/items/{item_id}", json=item_update_data, headers={"Authorization": f"Bearer {VALID_ACCESS_TOKEN_NO_ROLE if token is None else token}"})
+        self._patch_response_item = self.test_client.patch(
+            f"/v1/items/{item_id}",
+            json=item_update_data,
+            headers={"Authorization": f"Bearer {VALID_ACCESS_TOKEN_NO_ROLE if token is None else token}"},
+        )
 
     def check_patch_item_success(self, expected_item_get_data: dict) -> None:
         """
@@ -901,7 +905,9 @@ class TestUpdate(UpdateDSL):
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]}, None)
+        self.patch_item(
+            item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]}, None
+        )
         self.check_patch_item_success(
             {
                 **ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
@@ -917,18 +923,24 @@ class TestUpdate(UpdateDSL):
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]}, None)
+        self.patch_item(
+            item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]}, None
+        )
         self.check_patch_item_failed_with_detail(
             422, "No rule found for moving between the given system's types with the same final usage status"
         )
-    
+
     def test_partial_update_system_and_usage_status_ids_with_non_existent_rule_when_authorised(self):
         """Test updating the `system_id` and `usage_status_id` of an item when the user is authorised."""
 
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]}, VALID_ACCESS_TOKEN_ADMIN_ROLE)
+        self.patch_item(
+            item_id,
+            {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]},
+            VALID_ACCESS_TOKEN_ADMIN_ROLE,
+        )
         self.check_patch_item_success(
             {
                 **ITEM_GET_DATA_NEW_REQUIRED_VALUES_ONLY,
@@ -944,7 +956,9 @@ class TestUpdate(UpdateDSL):
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(SYSTEM_POST_DATA_OPERATIONAL_REQUIRED_VALUES_ONLY)
 
-        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]}, None)
+        self.patch_item(
+            item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_SCRAPPED["id"]}, None
+        )
         self.check_patch_item_failed_with_detail(
             422, "No rule found for moving between the given system's types with the same final usage status"
         )
@@ -956,7 +970,9 @@ class TestUpdate(UpdateDSL):
         item_id = self.post_item_and_prerequisites_no_properties(ITEM_DATA_NEW_REQUIRED_VALUES_ONLY)
         new_system_id = self.post_system(SYSTEM_POST_DATA_STORAGE_ALL_VALUES_NO_PARENT)
 
-        self.patch_item(item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]}, None)
+        self.patch_item(
+            item_id, {"system_id": new_system_id, "usage_status_id": USAGE_STATUS_GET_DATA_IN_USE["id"]}, None
+        )
         self.check_patch_item_failed_with_detail(
             422, "Cannot change usage status of an item when moving between two systems of the same type"
         )
@@ -988,7 +1004,7 @@ class TestUpdate(UpdateDSL):
         self.check_patch_item_failed_with_detail(
             422, "Cannot change usage status without moving between systems according to a defined rule"
         )
-        
+
     def test_partial_update_usage_status_id_when_authorised(self):
         """Test updating the `usage_status_id` of an item when user is authorised"""
 
@@ -1056,7 +1072,9 @@ class TestUpdate(UpdateDSL):
 
         item_id = self.post_item_and_prerequisites_with_properties(ITEM_DATA_NEW_WITH_ALL_PROPERTIES)
 
-        self.patch_item(item_id, {"properties": [{**PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": None}]}, None)
+        self.patch_item(
+            item_id, {"properties": [{**PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": None}]}, None
+        )
         self.check_patch_item_success(
             {
                 **ITEM_GET_DATA_NEW_WITH_ALL_PROPERTIES,
@@ -1091,7 +1109,9 @@ class TestUpdate(UpdateDSL):
             item_properties_data=[],
         )
 
-        self.patch_item(item_id, {"properties": [{**PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": "42"}]}, None)
+        self.patch_item(
+            item_id, {"properties": [{**PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_1, "value": "42"}]}, None
+        )
 
         self.check_patch_item_failed_with_detail(
             422,
@@ -1140,7 +1160,7 @@ class TestUpdate(UpdateDSL):
                     PROPERTY_DATA_STRING_NON_MANDATORY_WITH_ALLOWED_VALUES_LIST_VALUE2,
                 ]
             },
-            None
+            None,
         )
         self.check_patch_item_success(
             {

--- a/test/e2e/test_setting.py
+++ b/test/e2e/test_setting.py
@@ -138,7 +138,7 @@ class SparesDefinitionDSL(ItemDeleteDSL, CatalogueItemGetDSL):
         system_id = self._system_type_map.get(system_type_id)
         if not system_id:
             system_id = self.post_system_with_type_id(system_type_id)
-        self.patch_item(item_id, {"system_id": system_id, "usage_status_id": usage_status_id})
+        self.patch_item(item_id, {"system_id": system_id, "usage_status_id": usage_status_id}, None)
 
     def check_catalogue_item_spares(self, expected_number_of_spares_list: list[Optional[int]]) -> None:
         """

--- a/test/unit/auth/test_jwt_bearer.py
+++ b/test/unit/auth/test_jwt_bearer.py
@@ -115,7 +115,7 @@ async def test_jwt_bearer_authorization_request_unauthorised_roles_in_bearer_tok
 
 async def test_jwt_bearer_authorization_request_missing_authorization_header(request_mock):
     """
-    Test `JWTBearer` with missing authorization header.
+    Test `JWTBearer` with missing authorisation header.
     """
     jwt_bearer = JWTBearer()
 
@@ -126,7 +126,7 @@ async def test_jwt_bearer_authorization_request_missing_authorization_header(req
 
 async def test_jwt_bearer_authorization_request_empty_authorization_header(request_mock):
     """
-    Test `JWTBearer` with empty authorization header.
+    Test `JWTBearer` with empty authorisation header.
     """
     request_mock.headers = {"Authorization": ""}
 
@@ -152,7 +152,7 @@ async def test_jwt_bearer_authorization_request_missing_bearer_token(request_moc
 
 async def test_jwt_bearer_authorization_request_invalid_authorization_scheme(request_mock):
     """
-    Test `JWTBearer` with invalid authorization scheme.
+    Test `JWTBearer` with invalid authorisation scheme.
     """
     request_mock.headers = {"Authorization": f"Invalid-Bearer {VALID_ACCESS_TOKEN_ADMIN_ROLE}"}
 

--- a/test/unit/services/test_item.py
+++ b/test/unit/services/test_item.py
@@ -653,7 +653,7 @@ class UpdateDSL(ItemServiceDSL):
     _updated_item_id: str
     _updated_item: MagicMock
     _update_exception: pytest.ExceptionInfo
-    
+
     _user_authorised: bool
     _moving_system: bool
     _updating_usage_status: bool
@@ -677,7 +677,7 @@ class UpdateDSL(ItemServiceDSL):
         new_usage_status_in_data: Optional[dict] = None,
         new_system_in_data: Optional[dict] = None,
         raise_write_conflict_once: bool = False,
-        user_is_authorised = False
+        user_is_authorised=False,
     ) -> None:
         """
         Mocks repository methods appropriately to test the `update` service method.
@@ -710,7 +710,7 @@ class UpdateDSL(ItemServiceDSL):
                                           test the retrying functionality.
         :param user_is_authorised: Whether the request is authorised to bypass functionality such as checking rules.
         """
-        
+
         self._user_authorised = user_is_authorised
 
         # Add property ids to the stored catalogue item and item if needed
@@ -1241,11 +1241,11 @@ class TestUpdate(UpdateDSL):
                 **SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
                 "type_id": SYSTEM_TYPE_GET_DATA_OPERATIONAL["id"],
             },
-            user_is_authorised=True
+            user_is_authorised=True,
         )
         self.call_update(item_id)
         self.check_update_success()
-    
+
     def test_update_system_and_usage_status_ids_with_non_existent_rule(self):
         """Test updating an item's `system_id` and `usage_status_id` when there isn't a rule defined for the change
         of system types."""
@@ -1289,7 +1289,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_failed_with_exception(
             "Cannot change usage status of an item when moving between two systems of the same type"
         )
-        
+
     def test_update_system_and_usage_status_ids_when_systems_have_same_type_when_authorised(self):
         """Test updating an item's `system_id` and `usage_status_id` when the current and new systems have the same
         type, and when the user is authorised."""
@@ -1304,7 +1304,7 @@ class TestUpdate(UpdateDSL):
             stored_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_A,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_system_in_data=SYSTEM_IN_DATA_STORAGE_NO_PARENT_B,
-            user_is_authorised=True
+            user_is_authorised=True,
         )
         self.call_update(item_id)
         self.check_update_success()
@@ -1342,6 +1342,7 @@ class TestUpdate(UpdateDSL):
         self.check_update_failed_with_exception(
             "Cannot change usage status without moving between systems according to a defined rule"
         )
+
     def test_update_usage_status_id_when_authorised(self):
         """Test updating an item's `usage_status_id` when the user is authorised"""
         item_id = str(ObjectId())
@@ -1352,9 +1353,9 @@ class TestUpdate(UpdateDSL):
             stored_item_data=ITEM_DATA_NEW_REQUIRED_VALUES_ONLY,
             stored_usage_status_in_data=USAGE_STATUS_IN_DATA_IN_USE,
             new_usage_status_in_data=USAGE_STATUS_IN_DATA_NEW,
-            user_is_authorised=True
+            user_is_authorised=True,
         )
-        
+
         self.call_update(item_id)
         self.check_update_success()
 


### PR DESCRIPTION
## Description

This PR implements authorisation logic in the `JWTBearer` class, which is then utilised in the item `PATCH` endpoint to verify if the user is authorised to then bypass moving item rule checks, and/or allowed to update the usage status.
The configuration and setup of the new authorisation logic is in #602, which this PR is based on.

**Note**
This PR is dependent on [this pull request](https://github.com/ral-facilities/ldap-jwt-auth/pull/271) in ldap-jwt-auth, and should be merged in conjunction with it, to avoid breaking changes.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking

connect to #551 
