### PR TITLE
Make `HTTPException` message consistent everywhere when it returns `500`

### DIFF
--- a/inventory_management_system_api/core/consts.py
+++ b/inventory_management_system_api/core/consts.py
@@ -11,6 +11,9 @@ from inventory_management_system_api.core.config import config
 # parents
 BREADCRUMBS_TRAIL_MAX_LENGTH: int = 5
 
+# Detail to return in the 500 (Internal Server Error) responses
+HTTP_500_INTERNAL_SERVER_ERROR_DETAIL = "Something went wrong"
+
 if config.authentication.enabled:
     # Read the content of the public key file into a constant. This is used for decoding of JWT access tokens.
     try:

--- a/inventory_management_system_api/main.py
+++ b/inventory_management_system_api/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from inventory_management_system_api.core.config import config
+from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
 from inventory_management_system_api.core.logger_setup import setup_logger
 from inventory_management_system_api.routers.v1 import (
     catalogue_category,
@@ -43,7 +44,9 @@ async def custom_general_exception_handler(_: Request, exc: Exception) -> JSONRe
     :return: A JSON response indicating that something went wrong.
     """
     logger.exception(exc)
-    return JSONResponse(content={"detail": "Something went wrong"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    return JSONResponse(
+        content={"detail": HTTP_500_INTERNAL_SERVER_ERROR_DETAIL}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+    )
 
 
 @app.exception_handler(RequestValidationError)

--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -13,6 +13,7 @@ from typing import Annotated, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 
+from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     DatabaseIntegrityError,
@@ -143,11 +144,9 @@ def get_catalogue_category_breadcrumbs(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except DatabaseIntegrityError as exc:
-        message = "Unable to obtain breadcrumbs"
-        logger.exception(message)
+        logger.exception("Unable to obtain breadcrumbs")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=message,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
         ) from exc
 
 

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -14,6 +14,7 @@ from typing import Annotated, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 
 from inventory_management_system_api.core.config import config
+from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     InvalidActionError,
@@ -205,10 +206,11 @@ def delete_catalogue_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
     except (ObjectStorageAPIAuthError, ObjectStorageAPIServerError) as exc:
-        message = "Unable to delete attachments and/or images"
-        logger.exception(message)
+        logger.exception("Unable to delete attachments and/or images")
 
         if exc.args[0] == "Invalid token or expired token":
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=exc.args[0]) from exc
 
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+        ) from exc

--- a/inventory_management_system_api/routers/v1/item.py
+++ b/inventory_management_system_api/routers/v1/item.py
@@ -13,6 +13,7 @@ from typing import Annotated, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 
 from inventory_management_system_api.core.config import config
+from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
 from inventory_management_system_api.core.exceptions import (
     DatabaseIntegrityError,
     InvalidActionError,
@@ -63,9 +64,10 @@ def create_item(item: ItemPostSchema, item_service: ItemServiceDep) -> ItemSchem
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
     except DatabaseIntegrityError as exc:
-        message = "Unable to create item"
-        logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+        logger.exception("Unable to create item")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+        ) from exc
     except InvalidActionError as exc:
         message = str(exc)
         logger.exception(message)
@@ -149,9 +151,10 @@ def partial_update_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except DatabaseIntegrityError as exc:
-        message = "Unable to update item"
-        logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+        logger.exception("Unable to update item")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+        ) from exc
     except InvalidActionError as exc:
         message = str(exc)
         logger.exception(message)
@@ -181,13 +184,14 @@ def delete_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except (ObjectStorageAPIAuthError, ObjectStorageAPIServerError) as exc:
-        message = "Unable to delete attachments and/or images"
-        logger.exception(message)
+        logger.exception("Unable to delete attachments and/or images")
 
         if exc.args[0] == "Invalid token or expired token":
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=exc.args[0]) from exc
 
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+        ) from exc
     except WriteConflictError as exc:
         message = str(exc)
         logger.exception(message)
@@ -197,6 +201,7 @@ def delete_item(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
     except DatabaseIntegrityError as exc:
-        message = "Unable to delete item"
-        logger.exception(message)
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+        logger.exception("Unable to delete item")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+        ) from exc

--- a/inventory_management_system_api/routers/v1/system.py
+++ b/inventory_management_system_api/routers/v1/system.py
@@ -13,6 +13,7 @@ from typing import Annotated, Optional
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 
 from inventory_management_system_api.core.config import config
+from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     DatabaseIntegrityError,
@@ -113,11 +114,9 @@ def get_system_breadcrumbs(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
     except DatabaseIntegrityError as exc:
-        message = "Unable to obtain breadcrumbs"
-        logger.exception(message)
+        logger.exception("Unable to obtain breadcrumbs")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=message,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
         ) from exc
 
 
@@ -179,10 +178,11 @@ def delete_system(
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
     except (ObjectStorageAPIAuthError, ObjectStorageAPIServerError) as exc:
-        message = "Unable to delete attachments and/or images"
-        logger.exception(message)
+        logger.exception("Unable to delete attachments and/or images")
 
         if exc.args[0] == "Invalid token or expired token":
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=exc.args[0]) from exc
 
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+        ) from exc


### PR DESCRIPTION
## Description
This response returned to the client when 500 is returned is now `{"detail": "Something went wrong"}`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #623 