### PR TITLE
Ignore preceding and trailing whitespace when checking for duplicate allowed values

### DIFF
--- a/inventory_management_system_api/schemas/catalogue_category.py
+++ b/inventory_management_system_api/schemas/catalogue_category.py
@@ -96,9 +96,9 @@ class CatalogueCategoryPostPropertySchema(BaseModel):
         cls, allowed_values: Optional[AllowedValuesSchema], property_data: dict[str, Any]
     ) -> None:
         """
-        Checks `allowed_values` against its parent property raising an error if its invalid
+        Checks `allowed_values` against its parent property raising an error if its invalid.
 
-        :param `allowed_values`: The value of the `allowed_values` field.
+        :param allowed_values: The value of the `allowed_values` field.
         :param property_data: Property data to validate the allowed values against.
         :raises ValueError:
             - If the `allowed_values` has been given a value and the property type is a `boolean`.
@@ -129,7 +129,7 @@ class CatalogueCategoryPostPropertySchema(BaseModel):
                     seen_value = (
                         allowed_value
                         if property_data["type"] != CatalogueCategoryPropertyType.STRING
-                        else allowed_value.lower()
+                        else allowed_value.lower().strip()
                     )
                     if seen_value in seen_values:
                         raise ValueError(f"allowed_values of type 'list' contains a duplicate value: {allowed_value}")

--- a/test/e2e/test_catalogue_category.py
+++ b/test/e2e/test_catalogue_category.py
@@ -318,11 +318,11 @@ class TestCreate(CreateDSL):
 
         # Capitalisation is different as it shouldn't matter for this test
         self.post_leaf_catalogue_category_with_allowed_values(
-            "string", {"type": "list", "values": ["value1", "value2", "Value1", "value3"]}
+            "string", {"type": "list", "values": ["value1", "value2", " Value1 ", "value3"]}
         )
         self.check_post_catalogue_category_failed_with_validation_message(
             422,
-            "Value error, allowed_values of type 'list' contains a duplicate value: Value1",
+            "Value error, allowed_values of type 'list' contains a duplicate value:  Value1 ",
         )
 
     def test_create_leaf_with_number_property_with_allowed_values_list_invalid_value(self):


### PR DESCRIPTION
## Description
Updates the check for duplicate allowed value strings to remove the leading and trailing whitespaces.

## Testing instructions
- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
closes #626 