### PR TITLE
Add description field to system type migration script #656

### DIFF
--- a/inventory_management_system_api/migrations/scripts/20250703083422_system_types_migration.py
+++ b/inventory_management_system_api/migrations/scripts/20250703083422_system_types_migration.py
@@ -85,7 +85,7 @@ class Migration(BaseMigration):
 
         # Create and obtain the system types
         system_type_ids = self._system_types_collection.insert_many(
-            [{"value": value} for value in SYSTEM_TYPE_VALUES], session=session
+            [{"value": value, "description": None} for value in SYSTEM_TYPE_VALUES], session=session
         ).inserted_ids
         assert len(system_type_ids) == len(SYSTEM_TYPE_VALUES)
         system_types = self._system_types_collection.find(session=session)


### PR DESCRIPTION
## Description

See title. Was missing before. Using a default of `None`, as the field is optional and can be changed anytime in the future. (We dont display it currently nor do we know what CLF want).

## Testing instructions

To test undo previous migration with:
```bash
docker exec -it inventory-management-system-api ims migrate backward 20250703083422_system_types_migration
```

Then redo the system types one e.g.
```bash
docker exec -it inventory-management-system-api ims migrate forward latest
```

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #656 
