### PR TITLE
Prevent creation of rule when same src & dst system type #654

### DIFF
--- a/inventory_management_system_api/cli/create.py
+++ b/inventory_management_system_api/cli/create.py
@@ -105,7 +105,7 @@ def get_user_constructed_rule(
             "Please enter the index of the [green]dst_system_type[/]", system_types
         )
 
-        if CustomObjectId(src_system_type.id) == CustomObjectId(dst_system_type.id):
+        if src_system_type.id == dst_system_type.id:
             exit_with_error("A rule cannot have the same source and destination system types!")
 
         # Output the existing usage statuses and obtain a user selected dst_usage_status


### PR DESCRIPTION
see #654 

## Description

CLI now shows error when attempting to use same system type

<img width="1231" height="471" alt="image" src="https://github.com/user-attachments/assets/5fc800aa-be7b-4595-a1be-7fce8417b66d" />



## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

closes #654
