### PR TITLE
Prevent same rule creation regardless of usage status #661

### DIFF
--- a/inventory_management_system_api/cli/create.py
+++ b/inventory_management_system_api/cli/create.py
@@ -176,7 +176,7 @@ def rule(rule_type: Annotated[RuleType, typer.Argument()]):
         "dst_system_type_id": CustomObjectId(dst_system_type.id) if dst_system_type else None,
     }
     if rules_collection.find_one(rule_data):
-        exit_with_error("The selected rule already exists!")
+        exit_with_error("A rule with the same source and destination system type already exists!")
 
     # Output the user selected rule and request confirmation before adding it
     display_user_constructed_rule(rule_type, src_system_type, dst_system_type, dst_usage_status)


### PR DESCRIPTION
## Description

Changed logic to use only `src_system_type` and `dst_system_type` when checking if rule exists.

Tested for creation of `creation` , `moving` and `deletion` rules

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

closes #661
