### PR TITLE
Add db-dump and db-restore commands to dev_cli #688

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Database dumps (ignore all but the mock_data one used for db-import)
+# Database dumps (ignore all but the mock_data one we keep for general testing)
 data/*
 !data/mock_data.dump

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The simplest way to populate the database with mock data is to use the already c
 for development you may use
 
 ```bash
-python ./scripts/dev_cli.py db-import
+python ./scripts/dev_cli.py db-restore mock_data.dump
 ```
 
 to populate the database with mock data.

--- a/scripts/dev_cli.py
+++ b/scripts/dev_cli.py
@@ -120,7 +120,7 @@ def dump_database(
     console.print("Dumping database contents...")
 
     mongodb_auth_args = get_mongodb_auth_args(db_username, db_password)
-    with open(Path(f"./data/{file_name}.dump"), "w", encoding="utf-8") as file:
+    with open(Path(f"./data/{file_name}"), "w", encoding="utf-8") as file:
         run_mongodb_command(
             [
                 "mongodump",
@@ -144,7 +144,7 @@ def restore_database(
     console.print("Restoring database contents...")
 
     mongodb_auth_args = get_mongodb_auth_args(db_username, db_password)
-    with open(Path(f"./data/{file_name}.dump"), "r", encoding="utf-8") as file:
+    with open(Path(f"./data/{file_name}"), "r", encoding="utf-8") as file:
         run_mongodb_command(
             [
                 "mongorestore",
@@ -170,14 +170,6 @@ def db_restore(db_username: DatabaseUsernameOption, db_password: DatabasePasswor
     """Restores data in the database from a database dump file."""
 
     restore_database(db_username, db_password, file_name)
-    console.print("Success! :party_popper:")
-
-@app.command()
-def db_import(db_username: DatabaseUsernameOption, db_password: DatabasePasswordOption):
-    """Imports mock data into the database."""
-
-    # Populate database with generated test data
-    restore_database(db_username, db_password, "mock_data")
     console.print("Success! :party_popper:")
 
 


### PR DESCRIPTION
## Description

Adds two new commands one to dump the database contents to a named file, and another to restore the database from a named file. I have removed the old db-import command as it does essentially the same thing as restore which is closer to the command used for mongodb. I have excluded the other files in the data directory, as I dont think it necessarily makes sense to try and commit other dumps we may have e.g. in this case I made one with 57K items. It takes a long time to generate and I want it locally for testing, but maintaining it will be nasty due to the length of time to generate after any changes.

E.g.

```bash
python ./scripts/dev_cli.py db-dump large.dump
python ./scripts/dev_cli.py db-restore large.dump
```

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #688
