### PR TITLE
Add bulk creation of catalogue items #764

### DIFF
--- a/inventory_management_system_api/core/consts.py
+++ b/inventory_management_system_api/core/consts.py
@@ -15,6 +15,13 @@ PUBLIC_KEY = None
 # Detail to return in the 500 (Internal Server Error) responses
 HTTP_500_INTERNAL_SERVER_ERROR_DETAIL = "Something went wrong"
 
+# Error types to be used within custom pydantic errors
+ERROR_TYPE_INVALID_PROPERTY_TYPE = "invalid_property_type"
+ERROR_TYPE_MISSING_MANDATORY_PROPERTY = "missing_mandatory_property"
+ERROR_TYPE_MISSING_RECORD = "missing_record"
+ERROR_TYPE_NON_LEAF_CATALOGUE_CATEGORY = "non_leaf_catalogue_category"
+ERROR_TYPE_DUPLICATE_RECORD = "duplicate_record"
+
 if config.authentication.enabled:
     # Read the content of the public key file into a constant. This is used for decoding of JWT access tokens.
     try:

--- a/inventory_management_system_api/core/consts.py
+++ b/inventory_management_system_api/core/consts.py
@@ -3,6 +3,7 @@ Contains constants used in multiple places so they are easier to change
 """
 
 import sys
+from typing import LiteralString
 
 from inventory_management_system_api.core.config import config
 
@@ -16,11 +17,11 @@ PUBLIC_KEY = None
 HTTP_500_INTERNAL_SERVER_ERROR_DETAIL = "Something went wrong"
 
 # Error types to be used within custom pydantic errors
-ERROR_TYPE_INVALID_PROPERTY_TYPE = "invalid_property_type"
-ERROR_TYPE_MISSING_MANDATORY_PROPERTY = "missing_mandatory_property"
-ERROR_TYPE_MISSING_RECORD = "missing_record"
-ERROR_TYPE_NON_LEAF_CATALOGUE_CATEGORY = "non_leaf_catalogue_category"
-ERROR_TYPE_DUPLICATE_RECORD = "duplicate_record"
+ERROR_TYPE_INVALID_PROPERTY_TYPE: LiteralString = "invalid_property_type"
+ERROR_TYPE_MISSING_MANDATORY_PROPERTY: LiteralString = "missing_mandatory_property"
+ERROR_TYPE_MISSING_RECORD: LiteralString = "missing_record"
+ERROR_TYPE_NON_LEAF_CATALOGUE_CATEGORY: LiteralString = "non_leaf_catalogue_category"
+ERROR_TYPE_DUPLICATE_RECORD: LiteralString = "duplicate_record"
 
 if config.authentication.enabled:
     # Read the content of the public key file into a constant. This is used for decoding of JWT access tokens.

--- a/inventory_management_system_api/repositories/rule.py
+++ b/inventory_management_system_api/repositories/rule.py
@@ -2,7 +2,7 @@
 Module for providing a repository for managing rules in a MongoDB database.
 """
 
-from typing import Optional
+from typing import List, Optional
 
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -66,7 +66,7 @@ class RuleRepo:
         src_system_type_id: Optional[str],
         dst_system_type_id: Optional[str],
         session: Optional[ClientSession] = None,
-    ) -> list[RuleOut]:
+    ) -> List[RuleOut]:
         """
         Retrieve rules from a MongoDB database based on the provided filters.
 

--- a/inventory_management_system_api/repositories/system.py
+++ b/inventory_management_system_api/repositories/system.py
@@ -3,7 +3,7 @@ Module for providing a repository for managing systems in a MongoDB database.
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -94,7 +94,7 @@ class SystemRepo:
             collection_name="systems",
         )
 
-    def list(self, parent_id: Optional[str], session: Optional[ClientSession] = None) -> list[SystemOut]:
+    def list(self, parent_id: Optional[str], session: Optional[ClientSession] = None) -> List[SystemOut]:
         """
         Retrieve systems from a MongoDB database based on the provided filters.
 

--- a/inventory_management_system_api/repositories/system_type.py
+++ b/inventory_management_system_api/repositories/system_type.py
@@ -3,7 +3,7 @@ Module for providing a repository for managing system types in a MongoDB databas
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -47,7 +47,7 @@ class SystemTypeRepo:
             return SystemTypeOut(**system_type)
         return None
 
-    def list(self, session: Optional[ClientSession] = None) -> list[SystemTypeOut]:
+    def list(self, session: Optional[ClientSession] = None) -> List[SystemTypeOut]:
         """
         Retrieve system types from a MongoDB database.
 

--- a/inventory_management_system_api/repositories/unit.py
+++ b/inventory_management_system_api/repositories/unit.py
@@ -3,7 +3,7 @@ Module for providing a repository for managing Units in a MongoDB database
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -52,7 +52,7 @@ class UnitRepo:
 
         return self.get(str(result.inserted_id), session=session)
 
-    def list(self, session: Optional[ClientSession] = None) -> list[UnitOut]:
+    def list(self, session: Optional[ClientSession] = None) -> List[UnitOut]:
         """
         Retrieve Units from a MongoDB database
 

--- a/inventory_management_system_api/repositories/usage_status.py
+++ b/inventory_management_system_api/repositories/usage_status.py
@@ -3,7 +3,7 @@ Module for providing a repository for managing Usage statuses in a MongoDB datab
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection
@@ -55,7 +55,7 @@ class UsageStatusRepo:
 
         return self.get(str(result.inserted_id), session=session)
 
-    def list(self, session: Optional[ClientSession] = None) -> list[UsageStatusOut]:
+    def list(self, session: Optional[ClientSession] = None) -> List[UsageStatusOut]:
         """
         Retrieve Usage statuses from a MongoDB database
 

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -89,7 +89,10 @@ def bulk_create_catalogue_item(
 ) -> list[CatalogueItemSchema]:
     logger.info("Bulk creating catalogue items")
     try:
-        return catalogue_item_service.bulk_create(catalogue_items)
+        return [
+            CatalogueItemSchema(**catalogue_item.model_dump())
+            for catalogue_item in catalogue_item_service.bulk_create(catalogue_items)
+        ]
     except (InvalidPropertyTypeError, MissingMandatoryProperty) as exc:
         logger.exception(str(exc))
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -86,24 +86,15 @@ def create_catalogue_item(
 )
 def bulk_create_catalogue_item(
     catalogue_items: list[CatalogueItemPostSchema], catalogue_item_service: CatalogueItemServiceDep
-):
+) -> list[CatalogueItemSchema]:
     logger.info("Bulk creating catalogue items")
     try:
-        catalogue_item_service.bulk_create(catalogue_items)
+        return catalogue_item_service.bulk_create(catalogue_items)
     except (InvalidPropertyTypeError, MissingMandatoryProperty) as exc:
         logger.exception(str(exc))
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
     except (MissingRecordError, InvalidObjectIdError) as exc:
-        if "catalogue category" in str(exc).lower():
-            message = "A specified catalogue category does not exist"
-            logger.exception(message)
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
-        if "manufacturer" in str(exc).lower():
-            message = "A specified manufacturer does not exist"
-            logger.exception(message)
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
-
-        message = "A specified replacement catalogue item does not exist"
+        message = "A specified entity does not exist"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
     except NonLeafCatalogueCategoryError as exc:
@@ -122,7 +113,7 @@ def bulk_validate_create_catalogue_item(
         list[dict[str, Any]],
         Body(
             description="List of catalogue items data to validate",
-            example=[{"name": "Catalogue Item 1"}, {"name": "Catalogue Item 2"}],
+            examples=[[{"name": "Catalogue Item 1"}, {"name": "Catalogue Item 2"}]],
         ),
     ],
     catalogue_item_service: CatalogueItemServiceDep,

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -113,17 +113,31 @@ def bulk_create_catalogue_item(
 
 
 @router.post(
-    path="/bulk-validate",
-    summary="Bulk validate a catalogue items",
+    path="/bulk-validate-create",
+    summary="Bulk validate catalogue items for creation",
     response_description="Any errors found in the data",
 )
-def validate_catalogue_item(
-    catalogue_items: Annotated[list[dict[str, Any]], Body(description="List of catalogue items data to validate")],
+def bulk_validate_create_catalogue_item(
+    catalogue_items: Annotated[
+        list[dict[str, Any]],
+        Body(
+            description="List of catalogue items data to validate",
+            example=[{"name": "Catalogue Item 1"}, {"name": "Catalogue Item 2"}],
+        ),
+    ],
     catalogue_item_service: CatalogueItemServiceDep,
 ) -> BulkValidationResultSchema:
-    logger.info("Bulk validating catalogue items")
+    """
+    Validate a list of catalogue item data to determine whether it is suitable for creating them as catalogue items
+    either via the single `POST /v1/catalogue-items` or the bulk `POST /v1/catalogue-items/bulk` endpoints.
 
-    return catalogue_item_service.bulk_validate(catalogue_items)
+    This includes the same validation of schema, field constraints and business rules, as these creation endpoints
+    without creating or modifying any resources. This also collects and returns any validation errors instead of failing
+    fast.
+    """
+    logger.info("Bulk validating catalogue items for creation")
+
+    return catalogue_item_service.bulk_validate_create(catalogue_items)
 
 
 @router.get(path="", summary="Get catalogue items", response_description="List of catalogue items")

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -11,10 +11,21 @@ service.
 import logging
 from typing import Annotated, Any, List, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, status
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    status,
+)
 
 from inventory_management_system_api.core.config import config
-from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
+from inventory_management_system_api.core.consts import (
+    HTTP_500_INTERNAL_SERVER_ERROR_DETAIL,
+)
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     InvalidActionError,
@@ -71,6 +82,39 @@ def create_catalogue_item(
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
 
         message = "The specified replacement catalogue item does not exist"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
+    except NonLeafCatalogueCategoryError as exc:
+        message = "Adding a catalogue item to a non-leaf catalogue category is not allowed"
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+
+
+@router.post(
+    path="/bulk",
+    summary="Bulk create new catalogue items",
+    status_code=status.HTTP_201_CREATED,
+)
+def bulk_create_catalogue_item(
+    catalogue_items: list[CatalogueItemPostSchema], catalogue_item_service: CatalogueItemServiceDep
+):
+    logger.info("Bulk creating catalogue items")
+    try:
+        catalogue_item_service.bulk_create(catalogue_items)
+    except (InvalidPropertyTypeError, MissingMandatoryProperty) as exc:
+        logger.exception(str(exc))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc)) from exc
+    except (MissingRecordError, InvalidObjectIdError) as exc:
+        if "catalogue category" in str(exc).lower():
+            message = "A specified catalogue category does not exist"
+            logger.exception(message)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
+        if "manufacturer" in str(exc).lower():
+            message = "A specified manufacturer does not exist"
+            logger.exception(message)
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
+
+        message = "A specified replacement catalogue item does not exist"
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
     except NonLeafCatalogueCategoryError as exc:

--- a/inventory_management_system_api/routers/v1/catalogue_item.py
+++ b/inventory_management_system_api/routers/v1/catalogue_item.py
@@ -11,21 +11,10 @@ service.
 import logging
 from typing import Annotated, Any, List, Optional
 
-from fastapi import (
-    APIRouter,
-    Body,
-    Depends,
-    HTTPException,
-    Path,
-    Query,
-    Request,
-    status,
-)
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, status
 
 from inventory_management_system_api.core.config import config
-from inventory_management_system_api.core.consts import (
-    HTTP_500_INTERNAL_SERVER_ERROR_DETAIL,
-)
+from inventory_management_system_api.core.consts import HTTP_500_INTERNAL_SERVER_ERROR_DETAIL
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     InvalidActionError,
@@ -44,7 +33,7 @@ from inventory_management_system_api.schemas.catalogue_item import (
     CatalogueItemPostSchema,
     CatalogueItemSchema,
 )
-from inventory_management_system_api.schemas.validation import ValidationResponseSchema
+from inventory_management_system_api.schemas.validation import BulkValidationResultSchema
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService
 
 logger = logging.getLogger()
@@ -124,17 +113,17 @@ def bulk_create_catalogue_item(
 
 
 @router.post(
-    path="/validate",
-    summary="Validate a catalogue item",
+    path="/bulk-validate",
+    summary="Bulk validate a catalogue items",
     response_description="Any errors found in the data",
 )
 def validate_catalogue_item(
-    catalogue_item: Annotated[dict[str, Any], Body(description="Catalogue item data to validate")],
+    catalogue_items: Annotated[list[dict[str, Any]], Body(description="List of catalogue items data to validate")],
     catalogue_item_service: CatalogueItemServiceDep,
-) -> ValidationResponseSchema:
-    logger.info("Validating a catalogue item")
+) -> BulkValidationResultSchema:
+    logger.info("Bulk validating catalogue items")
 
-    return catalogue_item_service.validate(catalogue_item)
+    return catalogue_item_service.bulk_validate(catalogue_items)
 
 
 @router.get(path="", summary="Get catalogue items", response_description="List of catalogue items")

--- a/inventory_management_system_api/schemas/validation.py
+++ b/inventory_management_system_api/schemas/validation.py
@@ -20,8 +20,15 @@ class ValidationErrorSchema(BaseModel):
     input: Any = Field(description="Specific input the error was caused by")
 
 
-class ValidationResponseSchema(BaseModel):
-    """Schema model for a validation response."""
+class ValidationResultSchema(BaseModel):
+    """Schema model for a single result in a bulk validation response."""
 
-    warnings: list[ValidationErrorSchema] = Field(description="List of validation warnings.")
-    errors: list[ValidationErrorSchema] = Field(description="List of validation errors.")
+    index: int = Field(description="Index of the result, corresponding to the inputted list data.")
+    warnings: list[ValidationErrorSchema] = Field(description="List of validation warnings for the specific entity.")
+    errors: list[ValidationErrorSchema] = Field(description="List of validation errors for the specific entity.")
+
+
+class BulkValidationResultSchema(BaseModel):
+    """Schema model for the result of a bulk validation request."""
+
+    results: list[ValidationResultSchema] = Field(description="List of validation results for the entities.")

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -32,7 +32,7 @@ from inventory_management_system_api.schemas.catalogue_item import (
     CatalogueItemPostSchema,
     PropertyPostSchema,
 )
-from inventory_management_system_api.schemas.validation import ValidationResponseSchema
+from inventory_management_system_api.schemas.validation import BulkValidationResultSchema, ValidationResultSchema
 from inventory_management_system_api.services import utils
 
 
@@ -73,7 +73,7 @@ class CatalogueItemService:
         is. It then processes the properties.
 
         :param catalogue_item: The catalogue item to be created.
-        :param session: PyMongo ClientSession to use for database operations
+        :param session: PyMongo ClientSession to use for the creation operation itself.
         :return: The created catalogue item.
         :raises MissingRecordError: If the catalogue category does not exist, and/or the manufacturer does not exist
         :raises NonLeafCatalogueCategoryError: If the catalogue category is not a leaf category.
@@ -282,14 +282,14 @@ class CatalogueItemService:
         self._catalogue_item_repository.delete(catalogue_item_id)
 
     # pylint:disable=too-many-statements
-    def validate(self, catalogue_item_data: dict[str, Any]) -> ValidationResponseSchema:
+    def _validate(self, index: int, catalogue_item_data: dict[str, Any]) -> ValidationResultSchema:
         """
-        Performs validation of catalogue item creation data returning any errors.
+        Performs validation of a single set of catalogue item creation data returning any errors.
 
+        :param index: Index of the catalogue item being validated.
         :param catalogue_item_data: Catalogue item data to verify.
-        :return: Schema containing the validation warnings/errors that have occurred.
+        :return: Schema containing the validation warnings/errors that been found within the data.
         """
-
         warnings = []
         errors = []
         # This records any errors from basic schema validation including the properties
@@ -407,6 +407,20 @@ class CatalogueItemService:
                 title="Catalogue item validation error",
                 line_errors=errors,
             ).errors()
-        return ValidationResponseSchema(warnings=warnings, errors=errors)
+        return ValidationResultSchema(index=index, warnings=warnings, errors=errors)
 
     # pylint:enable=too-many-statements
+
+    def bulk_validate(self, catalogue_items_data: dict[str, Any]) -> BulkValidationResultSchema:
+        """
+        Performs validation of bulk catalogue item creation data returning any errors.
+
+        :param catalogue_items_data: Catalogue items data to verify.
+        :return: Schema containing the validation warnings/errors that been found within the data.
+        """
+        return BulkValidationResultSchema(
+            results=[
+                self._validate(index, catalogue_item_data)
+                for index, catalogue_item_data in enumerate(catalogue_items_data)
+            ]
+        )

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -10,6 +10,11 @@ from pydantic import ValidationError
 from pymongo.client_session import ClientSession
 
 from inventory_management_system_api.core.config import config
+from inventory_management_system_api.core.consts import (
+    ERROR_TYPE_DUPLICATE_RECORD,
+    ERROR_TYPE_MISSING_RECORD,
+    ERROR_TYPE_NON_LEAF_CATALOGUE_CATEGORY,
+)
 from inventory_management_system_api.core.database import start_session_transaction
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
@@ -307,6 +312,7 @@ class CatalogueItemService:
         # Check the catalogue category exists (if defined)
         catalogue_category_id = catalogue_item_data.get("catalogue_category_id")
         if catalogue_category_id:
+            catalogue_category = None
             try:
                 catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
             except InvalidObjectIdError:
@@ -315,7 +321,7 @@ class CatalogueItemService:
             if catalogue_category is None:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        error_type="missing_record",
+                        error_type=ERROR_TYPE_MISSING_RECORD,
                         error_message=f"No catalogue category found with ID '{catalogue_category_id}'",
                         error_location=("catalogue_category_id",),
                         error_input=catalogue_category_id,
@@ -325,7 +331,7 @@ class CatalogueItemService:
             elif not catalogue_category.is_leaf:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        error_type="non_leaf_catalogue_category",
+                        error_type=ERROR_TYPE_NON_LEAF_CATALOGUE_CATEGORY,
                         error_message="Cannot add catalogue item to a non-leaf catalogue category",
                         error_location=("catalogue_category_id",),
                         error_input=catalogue_category_id,
@@ -346,7 +352,7 @@ class CatalogueItemService:
             if obsolete_replacement_catalogue_item is None:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        error_type="missing_record",
+                        error_type=ERROR_TYPE_MISSING_RECORD,
                         error_message=f"No catalogue item found with ID '{obsolete_replacement_catalogue_item_id}'",
                         error_location=("obsolete_replacement_catalogue_item_id",),
                         error_input=obsolete_replacement_catalogue_item_id,
@@ -365,7 +371,7 @@ class CatalogueItemService:
             if not manufacturer:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        error_type="missing_record",
+                        error_type=ERROR_TYPE_MISSING_RECORD,
                         error_message=f"No manufacturer found with ID '{manufacturer_id}'",
                         error_location=("manufacturer_id",),
                         error_input=manufacturer_id,
@@ -377,7 +383,7 @@ class CatalogueItemService:
             if self._catalogue_item_repository.is_duplicate_name(catalogue_item_data["name"]):
                 warnings.append(
                     utils.create_custom_validation_error_details(
-                        error_type="duplicate_record",
+                        error_type=ERROR_TYPE_DUPLICATE_RECORD,
                         error_message=f"Duplicate record found with the same name '{catalogue_item_data["name"]}'",
                         error_location=("name",),
                         error_input=catalogue_item_data["name"],

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -121,7 +121,7 @@ class CatalogueItemService:
             session=session,
         )
 
-    def bulk_create(self, catalogue_items: list[CatalogueItemPostSchema]) -> list[CatalogueItemOut]:
+    def bulk_create(self, catalogue_items: List[CatalogueItemPostSchema]) -> List[CatalogueItemOut]:
         """
         Creates catalogue items in bulk.
 

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -118,7 +118,7 @@ class CatalogueItemService:
 
     def bulk_create(self, catalogue_items: list[CatalogueItemPostSchema]) -> None:
         """
-        Create a catalogue items in bulk.
+        Creates catalogue items in bulk.
 
         Uses the single create method, but wrapped within a transaction so either all succeed or none do. Will
         fail fast the moment it encounters an error, so for detailed information on what went wrong and where
@@ -282,9 +282,12 @@ class CatalogueItemService:
         self._catalogue_item_repository.delete(catalogue_item_id)
 
     # pylint:disable=too-many-statements
-    def _validate(self, index: int, catalogue_item_data: dict[str, Any]) -> ValidationResultSchema:
+    def _validate_create(self, index: int, catalogue_item_data: dict[str, Any]) -> ValidationResultSchema:
         """
         Performs validation of a single set of catalogue item creation data returning any errors.
+
+        This includes the same validation, as the `create` function without creating or modifying any resources. This
+        also collects and returns any validation errors instead of failing fast.
 
         :param index: Index of the catalogue item being validated.
         :param catalogue_item_data: Catalogue item data to verify.
@@ -316,7 +319,7 @@ class CatalogueItemService:
                         input=catalogue_category_id,
                     )
                 )
-            # If defined, ensure the category can take new catalogue items (i.e. is a leaf category)
+            # If exists, ensure the category can take new catalogue items (i.e. is a leaf category)
             elif not catalogue_category.is_leaf:
                 errors.append(
                     utils.create_custom_validation_error_details(
@@ -411,7 +414,7 @@ class CatalogueItemService:
 
     # pylint:enable=too-many-statements
 
-    def bulk_validate(self, catalogue_items_data: dict[str, Any]) -> BulkValidationResultSchema:
+    def bulk_validate_create(self, catalogue_items_data: dict[str, Any]) -> BulkValidationResultSchema:
         """
         Performs validation of bulk catalogue item creation data returning any errors.
 
@@ -420,7 +423,7 @@ class CatalogueItemService:
         """
         return BulkValidationResultSchema(
             results=[
-                self._validate(index, catalogue_item_data)
+                self._validate_create(index, catalogue_item_data)
                 for index, catalogue_item_data in enumerate(catalogue_items_data)
             ]
         )

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -391,22 +391,23 @@ class CatalogueItemService:
                 )
 
         # Now validate any properties
-        if "properties" in catalogue_item_data:
-            # NOTE: Basic schema validation of properties has already occurred at this point from using
-            #       CatalogueItemPostSchema above, we dont want to capture those errors again.
-            #       While we cant validate those properties that dont pass the basic checks, we can
-            #       at least attempt to perform additional validation on those that do.
-            property_schemas = []
+        supplied_properties = catalogue_item_data["properties"] if "properties" in catalogue_item_data else []
+        # NOTE: Basic schema validation of properties has already occurred at this point from using
+        #       CatalogueItemPostSchema above, we dont want to capture those errors again.
+        #       While we cant validate those properties that dont pass the basic checks, we can
+        #       at least attempt to perform additional validation on those that do.
+        property_schemas = []
 
-            for property_data in catalogue_item_data["properties"]:
-                try:
-                    property_schemas.append(PropertyPostSchema(**property_data))
-                except ValidationError:
-                    pass
+        for supplied_property in supplied_properties:
+            try:
+                property_schemas.append(PropertyPostSchema(**supplied_property))
+            except ValidationError:
+                pass
 
-            # Perform validation of the properties - can only be done assuming a valid catalogue category has been found
-            if catalogue_category:
-                utils.process_properties(catalogue_category.properties, property_schemas, errors)
+        # Perform validation of the properties - can only be done assuming a valid catalogue category has been found
+        if catalogue_category:
+            utils.process_properties(catalogue_category.properties, property_schemas, errors)
+
         if warnings:
             warnings = ValidationError.from_exception_data(
                 title="Catalogue item validation error",

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -305,15 +305,14 @@ class CatalogueItemService:
             errors.extend(exc.errors())
 
         # Check the catalogue category exists (if defined)
-        catalogue_category = None
-        if "catalogue_category_id" in catalogue_item_data:
-            catalogue_category_id = catalogue_item_data["catalogue_category_id"]
+        catalogue_category_id = catalogue_item_data.get("catalogue_category_id")
+        if catalogue_category_id:
             try:
                 catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
             except InvalidObjectIdError:
                 # Ignore invalid object ID, treat as missing
                 pass
-            if not catalogue_category:
+            if catalogue_category is None:
                 errors.append(
                     utils.create_custom_validation_error_details(
                         error_type="missing_record",
@@ -334,30 +333,29 @@ class CatalogueItemService:
                 )
 
         # If defined, check obsolete replacement item exists
-        if "obsolete_replacement_catalogue_item_id" in catalogue_item_data:
-            obsolete_replacement_catalogue_item_id = catalogue_item_data["obsolete_replacement_catalogue_item_id"]
-            if obsolete_replacement_catalogue_item_id is not None:
-                obsolete_replacement_catalogue_item = None
-                try:
-                    obsolete_replacement_catalogue_item = self._catalogue_item_repository.get(
-                        obsolete_replacement_catalogue_item_id
+        obsolete_replacement_catalogue_item_id = catalogue_item_data.get("obsolete_replacement_catalogue_item_id")
+        if obsolete_replacement_catalogue_item_id is not None:
+            obsolete_replacement_catalogue_item = None
+            try:
+                obsolete_replacement_catalogue_item = self._catalogue_item_repository.get(
+                    obsolete_replacement_catalogue_item_id
+                )
+            except InvalidObjectIdError:
+                # Ignore invalid object ID, treat as missing
+                pass
+            if obsolete_replacement_catalogue_item is None:
+                errors.append(
+                    utils.create_custom_validation_error_details(
+                        error_type="missing_record",
+                        error_message=f"No catalogue item found with ID '{obsolete_replacement_catalogue_item_id}'",
+                        error_location=("obsolete_replacement_catalogue_item_id",),
+                        error_input=obsolete_replacement_catalogue_item_id,
                     )
-                except InvalidObjectIdError:
-                    # Ignore invalid object ID, treat as missing
-                    pass
-                if obsolete_replacement_catalogue_item is None:
-                    errors.append(
-                        utils.create_custom_validation_error_details(
-                            error_type="missing_record",
-                            error_message=f"No catalogue item found with ID '{obsolete_replacement_catalogue_item_id}'",
-                            error_location=("obsolete_replacement_catalogue_item_id",),
-                            error_input=obsolete_replacement_catalogue_item_id,
-                        )
-                    )
+                )
 
         # Check the manufacturer exists (if defined)
-        if "manufacturer_id" in catalogue_item_data:
-            manufacturer_id = catalogue_item_data["manufacturer_id"]
+        manufacturer_id = catalogue_item_data.get("manufacturer_id")
+        if manufacturer_id:
             manufacturer = None
             try:
                 manufacturer = self._manufacturer_repository.get(manufacturer_id)

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -311,8 +311,8 @@ class CatalogueItemService:
 
         # Check the catalogue category exists (if defined)
         catalogue_category_id = catalogue_item_data.get("catalogue_category_id")
+        catalogue_category = None
         if catalogue_category_id:
-            catalogue_category = None
             try:
                 catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
             except InvalidObjectIdError:
@@ -421,7 +421,7 @@ class CatalogueItemService:
 
     # pylint:enable=too-many-statements
 
-    def bulk_validate_create(self, catalogue_items_data: dict[str, Any]) -> BulkValidationResultSchema:
+    def bulk_validate_create(self, catalogue_items_data: List[dict[str, Any]]) -> BulkValidationResultSchema:
         """
         Performs validation of bulk catalogue item creation data returning any errors.
 

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -312,7 +312,7 @@ class CatalogueItemService:
         # Check the catalogue category exists (if defined)
         catalogue_category_id = catalogue_item_data.get("catalogue_category_id")
         catalogue_category = None
-        if catalogue_category_id:
+        if catalogue_category_id is not None:
             try:
                 catalogue_category = self._catalogue_category_repository.get(catalogue_category_id)
             except InvalidObjectIdError:
@@ -361,7 +361,7 @@ class CatalogueItemService:
 
         # Check the manufacturer exists (if defined)
         manufacturer_id = catalogue_item_data.get("manufacturer_id")
-        if manufacturer_id:
+        if manufacturer_id is not None:
             manufacturer = None
             try:
                 manufacturer = self._manufacturer_repository.get(manufacturer_id)

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -7,8 +7,10 @@ from typing import Annotated, Any, List, Optional
 
 from fastapi import Depends
 from pydantic import ValidationError
+from pymongo.client_session import ClientSession
 
 from inventory_management_system_api.core.config import config
+from inventory_management_system_api.core.database import start_session_transaction
 from inventory_management_system_api.core.exceptions import (
     ChildElementsExistError,
     InvalidActionError,
@@ -60,7 +62,9 @@ class CatalogueItemService:
         self._manufacturer_repository = manufacturer_repository
         self._setting_repository = setting_repository
 
-    def create(self, catalogue_item: CatalogueItemPostSchema) -> CatalogueItemOut:
+    def create(
+        self, catalogue_item: CatalogueItemPostSchema, session: Optional[ClientSession] = None
+    ) -> CatalogueItemOut:
         """
         Create a new catalogue item.
 
@@ -69,6 +73,7 @@ class CatalogueItemService:
         is. It then processes the properties.
 
         :param catalogue_item: The catalogue item to be created.
+        :param session: PyMongo ClientSession to use for database operations
         :return: The created catalogue item.
         :raises MissingRecordError: If the catalogue category does not exist, and/or the manufacturer does not exist
         :raises NonLeafCatalogueCategoryError: If the catalogue category is not a leaf category.
@@ -107,8 +112,23 @@ class CatalogueItemService:
                     "properties": supplied_properties,
                 },
                 number_of_spares=0 if spares_definition else None,
-            )
+            ),
+            session=session,
         )
+
+    def bulk_create(self, catalogue_items: list[CatalogueItemPostSchema]) -> None:
+        """
+        Create a catalogue items in bulk.
+
+        Uses the single create method, but wrapped within a transaction so either all succeed or none do. Will
+        fail fast the moment it encounters an error, so for detailed information on what went wrong and where
+        `verify` should be used instead.
+
+        :param catalogue_items: The catalogue items to be created.
+        """
+        with start_session_transaction("creating bulk catalogue items") as session:
+            for catalogue_item in catalogue_items:
+                self.create(catalogue_item, session)
 
     def get(self, catalogue_item_id: str) -> Optional[CatalogueItemOut]:
         """

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -313,20 +313,20 @@ class CatalogueItemService:
             if not catalogue_category:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        type="missing_record",
-                        message=f"No catalogue category found with ID '{catalogue_category_id}'",
-                        location=("catalogue_category_id",),
-                        input=catalogue_category_id,
+                        error_type="missing_record",
+                        error_message=f"No catalogue category found with ID '{catalogue_category_id}'",
+                        error_location=("catalogue_category_id",),
+                        error_input=catalogue_category_id,
                     )
                 )
             # If exists, ensure the category can take new catalogue items (i.e. is a leaf category)
             elif not catalogue_category.is_leaf:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        type="non_leaf_catalogue_category",
-                        message="Cannot add catalogue item to a non-leaf catalogue category",
-                        location=("catalogue_category_id",),
-                        input=catalogue_category_id,
+                        error_type="non_leaf_catalogue_category",
+                        error_message="Cannot add catalogue item to a non-leaf catalogue category",
+                        error_location=("catalogue_category_id",),
+                        error_input=catalogue_category_id,
                     )
                 )
 
@@ -345,10 +345,10 @@ class CatalogueItemService:
                 if obsolete_replacement_catalogue_item is None:
                     errors.append(
                         utils.create_custom_validation_error_details(
-                            type="missing_record",
-                            message=f"No catalogue item found with ID '{obsolete_replacement_catalogue_item_id}'",
-                            location=("obsolete_replacement_catalogue_item_id",),
-                            input=obsolete_replacement_catalogue_item_id,
+                            error_type="missing_record",
+                            error_message=f"No catalogue item found with ID '{obsolete_replacement_catalogue_item_id}'",
+                            error_location=("obsolete_replacement_catalogue_item_id",),
+                            error_input=obsolete_replacement_catalogue_item_id,
                         )
                     )
 
@@ -364,10 +364,10 @@ class CatalogueItemService:
             if not manufacturer:
                 errors.append(
                     utils.create_custom_validation_error_details(
-                        type="missing_record",
-                        message=f"No manufacturer found with ID '{manufacturer_id}'",
-                        location=("manufacturer_id",),
-                        input=manufacturer_id,
+                        error_type="missing_record",
+                        error_message=f"No manufacturer found with ID '{manufacturer_id}'",
+                        error_location=("manufacturer_id",),
+                        error_input=manufacturer_id,
                     )
                 )
 
@@ -376,10 +376,10 @@ class CatalogueItemService:
             if self._catalogue_item_repository.is_duplicate_name(catalogue_item_data["name"]):
                 warnings.append(
                     utils.create_custom_validation_error_details(
-                        type="duplicate_record",
-                        message=f"Duplicate record found with the same name '{catalogue_item_data["name"]}'",
-                        location=("name",),
-                        input=catalogue_item_data["name"],
+                        error_type="duplicate_record",
+                        error_message=f"Duplicate record found with the same name '{catalogue_item_data["name"]}'",
+                        error_location=("name",),
+                        error_input=catalogue_item_data["name"],
                     )
                 )
 
@@ -399,7 +399,7 @@ class CatalogueItemService:
 
             # Perform validation of the properties - can only be done assuming a valid catalogue category has been found
             if catalogue_category:
-                utils.validate_properties(catalogue_category.properties, property_schemas, errors)
+                utils.process_properties(catalogue_category.properties, property_schemas, errors)
         if warnings:
             warnings = ValidationError.from_exception_data(
                 title="Catalogue item validation error",

--- a/inventory_management_system_api/services/catalogue_item.py
+++ b/inventory_management_system_api/services/catalogue_item.py
@@ -116,7 +116,7 @@ class CatalogueItemService:
             session=session,
         )
 
-    def bulk_create(self, catalogue_items: list[CatalogueItemPostSchema]) -> None:
+    def bulk_create(self, catalogue_items: list[CatalogueItemPostSchema]) -> list[CatalogueItemOut]:
         """
         Creates catalogue items in bulk.
 
@@ -125,10 +125,13 @@ class CatalogueItemService:
         `verify` should be used instead.
 
         :param catalogue_items: The catalogue items to be created.
+        :return: List of created catalogue items.
         """
+        created_catalogue_items = []
         with start_session_transaction("creating bulk catalogue items") as session:
             for catalogue_item in catalogue_items:
-                self.create(catalogue_item, session)
+                created_catalogue_items.append(self.create(catalogue_item, session=session))
+        return created_catalogue_items
 
     def get(self, catalogue_item_id: str) -> Optional[CatalogueItemOut]:
         """

--- a/inventory_management_system_api/services/rule.py
+++ b/inventory_management_system_api/services/rule.py
@@ -2,7 +2,7 @@
 Module for providing a service for managing rules using the `RuleRepo` repository.
 """
 
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional
 
 from fastapi import Depends
 
@@ -23,7 +23,7 @@ class RuleService:
         """
         self._rule_repository = rule_repository
 
-    def list(self, src_system_type_id: Optional[str], dst_system_type_id: Optional[str]) -> list[RuleOut]:
+    def list(self, src_system_type_id: Optional[str], dst_system_type_id: Optional[str]) -> List[RuleOut]:
         """
         Retrieve rules based on the provided filters.
 

--- a/inventory_management_system_api/services/system.py
+++ b/inventory_management_system_api/services/system.py
@@ -3,7 +3,7 @@ Module for providing a service for managing systems using the `SystemRepo` repos
 """
 
 from contextlib import contextmanager
-from typing import Annotated, Generator, Optional
+from typing import Annotated, Generator, List, Optional
 
 from fastapi import Depends
 from pymongo.client_session import ClientSession
@@ -92,7 +92,7 @@ class SystemService:
         """
         return self._system_repository.get_breadcrumbs(system_id)
 
-    def list(self, parent_id: Optional[str]) -> list[SystemOut]:
+    def list(self, parent_id: Optional[str]) -> List[SystemOut]:
         """
         Retrieve systems based on the provided filters.
 

--- a/inventory_management_system_api/services/system_type.py
+++ b/inventory_management_system_api/services/system_type.py
@@ -2,7 +2,7 @@
 Module for providing a service for managing systems using the `SystemRepo` repository.
 """
 
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional
 
 from fastapi import Depends
 
@@ -23,7 +23,7 @@ class SystemTypeService:
         """
         self._system_type_repository = system_type_repository
 
-    def list(self) -> list[SystemTypeOut]:
+    def list(self) -> List[SystemTypeOut]:
         """
         Retrieve system types.
 

--- a/inventory_management_system_api/services/unit.py
+++ b/inventory_management_system_api/services/unit.py
@@ -2,12 +2,13 @@
 Module for providing a service for managing Units using the `UnitRepo` repository
 """
 
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional
+
 from fastapi import Depends
+
 from inventory_management_system_api.models.unit import UnitIn, UnitOut
 from inventory_management_system_api.repositories.unit import UnitRepo
 from inventory_management_system_api.schemas.unit import UnitPostSchema
-
 from inventory_management_system_api.services import utils
 
 
@@ -43,7 +44,7 @@ class UnitService:
         """
         return self._unit_repository.get(unit_id)
 
-    def list(self) -> list[UnitOut]:
+    def list(self) -> List[UnitOut]:
         """
         Retrieve a list of all Units
 

--- a/inventory_management_system_api/services/usage_status.py
+++ b/inventory_management_system_api/services/usage_status.py
@@ -2,7 +2,7 @@
 Module for providing a service for managing Usage statuses using the `UsageStatusRepo` repository
 """
 
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional
 
 from fastapi import Depends
 
@@ -44,7 +44,7 @@ class UsageStatusService:
         """
         return self._usage_status_repository.get(usage_status_id)
 
-    def list(self) -> list[UsageStatusOut]:
+    def list(self) -> List[UsageStatusOut]:
         """
         Retrieve a list of all Usage statuses
 

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -5,7 +5,7 @@ Collection of some utility functions used by services
 import logging
 import re
 from copy import deepcopy
-from typing import Any, Dict, List, LiteralString, Union
+from typing import Any, Callable, Dict, List, LiteralString, Optional, Type, Union
 
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
@@ -19,6 +19,40 @@ from inventory_management_system_api.schemas.catalogue_category import Catalogue
 from inventory_management_system_api.schemas.catalogue_item import PropertyPostSchema
 
 logger = logging.getLogger()
+
+ProcessErrorFunctionType = Callable[[str, str, tuple, Any], None]
+
+
+ERROR_MAP: dict[str, Type[BaseException]] = {
+    "invalid_property_type": InvalidPropertyTypeError,
+    "missing_mandatory_property": MissingMandatoryProperty,
+}
+
+
+def process_and_raise_error(
+    error_type: LiteralString, error_message: LiteralString, error_location: tuple, error_input: Any
+):
+    """Processes an error by raising it."""
+    raise ERROR_MAP[error_type](error_message)
+
+
+def make_process_and_add_error(errors: list[InitErrorDetails]):
+    """Creates a function that processes errors by adding them to a given list."""
+
+    def process_and_add_error(
+        error_type: LiteralString, error_message: LiteralString, error_location: tuple, error_input: Any
+    ):
+        """Processes an error by adding it to a list."""
+        errors.append(
+            create_custom_validation_error_details(
+                error_type=error_type,
+                error_message=error_message,
+                error_location=error_location,
+                error_input=error_input,
+            )
+        )
+
+    return process_and_add_error
 
 
 def generate_code(name: str, entity_type: str) -> str:
@@ -60,6 +94,7 @@ def check_duplicate_property_names(
 def process_properties(
     defined_properties: List[CatalogueCategoryPropertyOut],
     supplied_properties: List[PropertyPostSchema],
+    errors: Optional[list[InitErrorDetails]] = None,
 ) -> List[Dict]:
     """
     Process and validate supplied properties based on the defined properties.
@@ -69,49 +104,24 @@ def process_properties(
 
     :param defined_properties: The list of defined property objects.
     :param supplied_properties: The list of supplied property objects.
+    :param errors: List to collect errors within. When defined errors are collected within it, when not errors are
+                   raised instead to fail fast.
     :return: A list of processed and validated supplied properties.
     """
+
+    if errors is None:
+        process_error = process_and_raise_error
+    else:
+        process_error = make_process_and_add_error(errors)
+
     # Convert properties to dictionaries for easier lookups
     defined_properties_dict = _create_properties_dict(defined_properties)
     supplied_properties_dict = _create_properties_dict(supplied_properties)
 
     # Some mandatory properties may not have been supplied
-    _check_missing_mandatory_properties(defined_properties_dict, supplied_properties_dict)
-    # Some non-mandatory properties may not have been supplied
-    supplied_properties_dict = _merge_non_mandatory_properties(defined_properties_dict, supplied_properties_dict)
-    # Supplied properties do not have names as we can't trust they would be correct
-    _add_property_names(defined_properties_dict, supplied_properties_dict)
-    # Supplied properties do not have units as we can't trust they would be correct
-    _add_property_units(defined_properties_dict, supplied_properties_dict)
-    # The values of the supplied properties may not be of the expected types
-    _check_property_values(defined_properties_dict, supplied_properties_dict)
-
-    return list(supplied_properties_dict.values())
-
-
-def validate_properties(
-    defined_properties: list[CatalogueCategoryPropertyOut],
-    supplied_properties: list[PropertyPostSchema],
-    errors: list[InitErrorDetails],
-) -> None:
-    """
-    Validate supplied properties based on the defined properties.
-
-    Checks for missing mandatory, filters the matching properties, adds the property units, and finally validates the
-    property values.
-
-    :param defined_properties: The list of defined property objects.
-    :param supplied_properties: The list of supplied property objects.
-    :param errors: List to append any found errors to (its mutable).
-    """
-    # Convert properties to dictionaries for easier lookups
-    defined_properties_dict = _create_properties_dict(defined_properties)
-    supplied_properties_dict = _create_properties_dict(supplied_properties)
-
-    # Some mandatory properties may not have been supplied
-    _validate_missing_mandatory_properties(defined_properties_dict, supplied_properties_dict, errors)
+    _validate_missing_mandatory_properties(defined_properties_dict, supplied_properties_dict, process_error)
     # Some non-mandatory properties may not have been supplied. Deep copy to prevent past errors from containing
-    # anything not added yet.
+    # anything not added yet when collecting errors.
     supplied_properties_dict = deepcopy(
         _merge_non_mandatory_properties(defined_properties_dict, supplied_properties_dict)
     )
@@ -120,7 +130,9 @@ def validate_properties(
     # Supplied properties do not have units as we can't trust they would be correct
     _add_property_units(defined_properties_dict, supplied_properties_dict)
     # The values of the supplied properties may not be of the expected types
-    _validate_property_values(defined_properties_dict, supplied_properties_dict, errors)
+    _validate_property_values(defined_properties_dict, supplied_properties_dict, process_error)
+
+    return list(supplied_properties_dict.values())
 
 
 def _create_properties_dict(
@@ -176,53 +188,8 @@ def _add_property_units(
         supplied_property["unit"] = defined_properties[supplied_property_name]["unit"]
 
 
-def _check_property_value(defined_property: Dict, supplied_property: Dict) -> None:
-    """
-    Checks that a given property value has a valid type and is within the defined allowed_values (if specified).
-
-    Raises errors to fail fast compared to _validate_property_value.
-
-    :param defined_property: Definition of the property from the catalogue category
-    :param supplied_property: Supplied property dictionary
-    :raises InvalidPropertyTypeError: If the supplied property value is found to either be an
-                                      invalid type, or not an allowed value
-    """
-
-    defined_property_type = defined_property["type"]
-    defined_property_allowed_values = defined_property["allowed_values"]
-    defined_property_mandatory = defined_property["mandatory"]
-
-    supplied_property_id = supplied_property["id"]
-    supplied_property_value = supplied_property["value"]
-
-    # Do not type check a value of None
-    if supplied_property_value is None:
-        if defined_property_mandatory:
-            raise InvalidPropertyTypeError(f"Mandatory property with ID '{supplied_property_id}' cannot be None.")
-    else:
-        if not CatalogueCategoryPostPropertySchema.is_valid_property_type(
-            defined_property_type, supplied_property_value
-        ):
-            raise InvalidPropertyTypeError(
-                f"Invalid value type for property with ID '{supplied_property_id}'. Expected type: "
-                f"{defined_property_type}."
-            )
-
-        # Verify the given property is one of the allowed based on the type of allowed_values defined
-        if defined_property_allowed_values is not None and defined_property_allowed_values["type"] == "list":
-            values = defined_property_allowed_values["values"]
-            if supplied_property_value not in values:
-                raise InvalidPropertyTypeError(
-                    f"Invalid value for property with ID '{supplied_property_id}'. Expected one of "
-                    f"{', '.join([str(value) for value in values])}."
-                )
-
-
 def _validate_property_value(
-    defined_property: dict,
-    supplied_property: dict,
-    index: int,
-    errors: list[InitErrorDetails],
+    defined_property: dict, supplied_property: dict, index: int, process_error: ProcessErrorFunctionType
 ) -> None:
     """
     Validates a given property value has a valid type and is within the defined allowed_values (if specified).
@@ -232,7 +199,7 @@ def _validate_property_value(
     :param defined_property: Definition of the property from the catalogue category.
     :param supplied_property: Supplied property dictionary.
     :param index: Index of the supplied property (For the location of any validation errors).
-    :param errors: List to append any found errors to (its mutable).
+    :param process_error: Function to process any errors that occur.
     """
     defined_property_type = defined_property["type"]
     defined_property_allowed_values = defined_property["allowed_values"]
@@ -244,26 +211,22 @@ def _validate_property_value(
     # Do not type check a value of None
     if supplied_property_value is None:
         if defined_property_mandatory:
-            errors.append(
-                create_custom_validation_error_details(
-                    type="invalid_property_type",
-                    message=f"Mandatory property with ID '{supplied_property_id}' cannot be None.",
-                    location=("properties", index, "value"),
-                    input=supplied_property_value,
-                )
+            process_error(
+                error_type="invalid_property_type",
+                error_message=f"Mandatory property with ID '{supplied_property_id}' cannot be None.",
+                error_location=("properties", index, "value"),
+                error_input=supplied_property_value,
             )
     else:
         if not CatalogueCategoryPostPropertySchema.is_valid_property_type(
             defined_property_type, supplied_property_value
         ):
-            errors.append(
-                create_custom_validation_error_details(
-                    type="invalid_property_type",
-                    message=f"Invalid value type for property with ID '{supplied_property_id}'. Expected type: "
-                    f"{defined_property_type}.",
-                    location=("properties", index, "value"),
-                    input=supplied_property_value,
-                )
+            process_error(
+                error_type="invalid_property_type",
+                error_message=f"Invalid value type for property with ID '{supplied_property_id}'. Expected type: "
+                f"{defined_property_type}.",
+                error_location=("properties", index, "value"),
+                error_input=supplied_property_value,
             )
 
     # Verify the given property is one of the allowed based on the type of allowed_values defined
@@ -275,41 +238,17 @@ def _validate_property_value(
         if supplied_property_value not in values and (
             defined_property["mandatory"] or supplied_property_value is not None
         ):
-            errors.append(
-                create_custom_validation_error_details(
-                    type="invalid_property_type",
-                    message=f"Invalid value for property with ID '{supplied_property_id}'. Expected one of "
-                    f"{', '.join([str(value) for value in values])}.",
-                    location=("properties", index, "value"),
-                    input=supplied_property_value,
-                )
+            process_error(
+                error_type="invalid_property_type",
+                error_message=f"Invalid value for property with ID '{supplied_property_id}'. Expected one of "
+                f"{', '.join([str(value) for value in values])}.",
+                error_location=("properties", index, "value"),
+                error_input=supplied_property_value,
             )
 
 
-def _check_property_values(
-    defined_properties: Dict[str, Dict],
-    supplied_properties: Dict[str, Dict],
-) -> None:
-    """
-    Checks the values of the supplied properties against the expected property types.
-
-    Raises an error if the type of any supplied property does not match the expected type.
-
-    :param defined_properties: The defined properties stored as part of the catalogue category in the
-                               database.
-    :param supplied_properties: The supplied properties.
-    :raises InvalidPropertyTypeError: If the any of the types of the supplied values does not match the
-                                      expected type.
-    """
-    logger.info("Checking the values of the supplied properties against the expected property types")
-    for supplied_property_id, supplied_property in supplied_properties.items():
-        _check_property_value(defined_properties[supplied_property_id], supplied_property)
-
-
 def _validate_property_values(
-    defined_properties: dict[str, dict],
-    supplied_properties: dict[str, dict],
-    errors: list[InitErrorDetails],
+    defined_properties: dict[str, dict], supplied_properties: dict[str, dict], process_error: ProcessErrorFunctionType
 ) -> None:
     """
     Validates the values of the supplied properties against the expected property types.
@@ -319,36 +258,15 @@ def _validate_property_values(
     :param defined_properties: The defined properties stored as part of the catalogue category in the
                                database.
     :param supplied_properties: The supplied properties.
-    :param errors: List to append any found errors to (its mutable).
+    :param process_error: Function to process any errors that occur.
     """
     logger.info("Validating the values of the supplied properties against the expected property types")
     for i, (supplied_property_id, supplied_property) in enumerate(supplied_properties.items()):
-        _validate_property_value(defined_properties[supplied_property_id], supplied_property, i, errors)
-
-
-def _check_missing_mandatory_properties(
-    defined_properties: Dict[str, Dict],
-    supplied_properties: Dict[str, Dict],
-) -> None:
-    """
-    Check for mandatory properties that are missing/have not been supplied. Raise an error as soon
-    as a mandatory property is found to be missing.
-
-    :param defined_properties: The defined properties stored as part of the catalogue category in the
-        database.
-    :param supplied_properties: The supplied properties.
-    :raises MissingMandatoryProperty: If a mandatory property is missing/not supplied.
-    """
-    logger.info("Checking for missing mandatory property")
-    for defined_property_id, defined_property in defined_properties.items():
-        if defined_property["mandatory"] and defined_property_id not in supplied_properties:
-            raise MissingMandatoryProperty(f"Missing mandatory property with ID '{defined_property_id}'")
+        _validate_property_value(defined_properties[supplied_property_id], supplied_property, i, process_error)
 
 
 def _validate_missing_mandatory_properties(
-    defined_properties: dict[str, dict],
-    supplied_properties: dict[str, dict],
-    errors: list[InitErrorDetails],
+    defined_properties: dict[str, dict], supplied_properties: dict[str, dict], process_error: ProcessErrorFunctionType
 ) -> None:
     """
     Validate that all mandatory properties have been supplied.
@@ -356,18 +274,16 @@ def _validate_missing_mandatory_properties(
     :param defined_properties: The defined properties stored as part of the catalogue category in the
                                database.
     :param supplied_properties: The supplied properties.
-    :param errors: List to append any found errors to (its mutable).
+    :param process_error: Function to process any errors that occur.
     """
     logger.info("Validating there are no missing mandatory properties")
     for defined_property_id, defined_property in defined_properties.items():
         if defined_property["mandatory"] and defined_property_id not in supplied_properties:
-            errors.append(
-                create_custom_validation_error_details(
-                    type="missing_mandatory_property",
-                    message=f"Missing mandatory property with ID '{defined_property_id}'",
-                    location=("properties",),
-                    input=supplied_properties,
-                )
+            process_error(
+                error_type="missing_mandatory_property",
+                error_message=f"Missing mandatory property with ID '{defined_property_id}'",
+                error_location=("properties",),
+                error_input=supplied_properties,
             )
 
 
@@ -397,18 +313,15 @@ def _merge_non_mandatory_properties(
 
 
 def create_custom_validation_error_details(
-    type: LiteralString,  # pylint:disable=redefined-builtin
-    message: LiteralString,
-    location: tuple,
-    input: Any,  # pylint:disable=redefined-builtin
+    error_type: LiteralString, error_message: LiteralString, error_location: tuple, error_input: Any
 ) -> InitErrorDetails:
     """
     Creates a Pydantic ValidationError with a custom message and returns its details.
 
-    :param type: String type identifier of the custom error.
-    :param message: Message to display in the error.
-    :param location: Location of the error expressed as a tuple.
-    :param input: Input that led to the error.
+    :param error_type: String type identifier of the custom error.
+    :param error_message: Message to display in the error.
+    :param error_location: Location of the error expressed as a tuple.
+    :param error_input: Input that led to the error.
     :return: Created ValidationError.
     """
-    return InitErrorDetails(type=PydanticCustomError(type, message), loc=location, input=input)
+    return InitErrorDetails(type=PydanticCustomError(error_type, error_message), loc=error_location, input=error_input)

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -39,7 +39,7 @@ def process_and_raise_error(
     raise ERROR_MAP[error_type](error_message)
 
 
-def make_process_and_add_error(errors: list[InitErrorDetails]) -> ProcessErrorFunctionType:
+def make_process_and_add_error(errors: List[InitErrorDetails]) -> ProcessErrorFunctionType:
     """Creates a function that processes errors by adding them to a given list."""
 
     def process_and_add_error(error_type: LiteralString, error_message: str, error_location: tuple, error_input: Any):
@@ -74,7 +74,7 @@ def generate_code(name: str, entity_type: str) -> str:
 
 
 def check_duplicate_property_names(
-    properties: list[CatalogueCategoryPostPropertySchema | CatalogueCategoryPropertyOut],
+    properties: List[CatalogueCategoryPostPropertySchema | CatalogueCategoryPropertyOut],
 ) -> None:
     """
     Go through a list of properties to check for any duplicate names during creation of a catalogue
@@ -95,7 +95,7 @@ def check_duplicate_property_names(
 def process_properties(
     defined_properties: List[CatalogueCategoryPropertyOut],
     supplied_properties: List[PropertyPostSchema],
-    errors: Optional[list[InitErrorDetails]] = None,
+    errors: Optional[List[InitErrorDetails]] = None,
 ) -> List[Dict]:
     """
     Process and validate supplied properties based on the defined properties.

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -5,7 +5,7 @@ Collection of some utility functions used by services
 import logging
 import re
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, LiteralString, Optional, Type, Union
+from typing import Any, Callable, Dict, List, LiteralString, Optional, Type, Union, cast
 
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
@@ -24,7 +24,7 @@ from inventory_management_system_api.schemas.catalogue_item import PropertyPostS
 
 logger = logging.getLogger()
 
-ProcessErrorFunctionType = Callable[[str, str, tuple, Any], None]
+ProcessErrorFunctionType = Callable[[LiteralString, str, tuple, Any], None]
 
 ERROR_MAP: dict[str, Type[BaseException]] = {
     ERROR_TYPE_INVALID_PROPERTY_TYPE: InvalidPropertyTypeError,
@@ -33,18 +33,16 @@ ERROR_MAP: dict[str, Type[BaseException]] = {
 
 
 def process_and_raise_error(
-    error_type: LiteralString, error_message: LiteralString, error_location: tuple, error_input: Any
-):
+    error_type: LiteralString, error_message: str, error_location: tuple, error_input: Any
+) -> None:
     """Processes an error by raising it."""
     raise ERROR_MAP[error_type](error_message)
 
 
-def make_process_and_add_error(errors: list[InitErrorDetails]):
+def make_process_and_add_error(errors: list[InitErrorDetails]) -> ProcessErrorFunctionType:
     """Creates a function that processes errors by adding them to a given list."""
 
-    def process_and_add_error(
-        error_type: LiteralString, error_message: LiteralString, error_location: tuple, error_input: Any
-    ):
+    def process_and_add_error(error_type: LiteralString, error_message: str, error_location: tuple, error_input: Any):
         """Processes an error by adding it to a list."""
         errors.append(
             create_custom_validation_error_details(
@@ -316,7 +314,7 @@ def _merge_non_mandatory_properties(
 
 
 def create_custom_validation_error_details(
-    error_type: LiteralString, error_message: LiteralString, error_location: tuple, error_input: Any
+    error_type: LiteralString, error_message: str, error_location: tuple, error_input: Any
 ) -> InitErrorDetails:
     """
     Creates a Pydantic ValidationError with a custom message and returns its details.
@@ -327,4 +325,8 @@ def create_custom_validation_error_details(
     :param error_input: Input that led to the error.
     :return: Created ValidationError.
     """
-    return InitErrorDetails(type=PydanticCustomError(error_type, error_message), loc=error_location, input=error_input)
+    # Cast message to literal string as this avoids type errors and matches pydantic's type, but most error messages
+    # are fstrings which we want to be able to use
+    return InitErrorDetails(
+        type=PydanticCustomError(error_type, cast(LiteralString, error_message)), loc=error_location, input=error_input
+    )

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -109,7 +109,6 @@ def process_properties(
                    raised instead to fail fast.
     :return: A list of processed and validated supplied properties.
     """
-
     if errors is None:
         process_error = process_and_raise_error
     else:

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -9,6 +9,10 @@ from typing import Any, Callable, Dict, List, LiteralString, Optional, Type, Uni
 
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
+from inventory_management_system_api.core.consts import (
+    ERROR_TYPE_INVALID_PROPERTY_TYPE,
+    ERROR_TYPE_MISSING_MANDATORY_PROPERTY,
+)
 from inventory_management_system_api.core.exceptions import (
     DuplicateCatalogueCategoryPropertyNameError,
     InvalidPropertyTypeError,
@@ -22,10 +26,9 @@ logger = logging.getLogger()
 
 ProcessErrorFunctionType = Callable[[str, str, tuple, Any], None]
 
-
 ERROR_MAP: dict[str, Type[BaseException]] = {
-    "invalid_property_type": InvalidPropertyTypeError,
-    "missing_mandatory_property": MissingMandatoryProperty,
+    ERROR_TYPE_INVALID_PROPERTY_TYPE: InvalidPropertyTypeError,
+    ERROR_TYPE_MISSING_MANDATORY_PROPERTY: MissingMandatoryProperty,
 }
 
 
@@ -212,7 +215,7 @@ def _validate_property_value(
     if supplied_property_value is None:
         if defined_property_mandatory:
             process_error(
-                error_type="invalid_property_type",
+                error_type=ERROR_TYPE_INVALID_PROPERTY_TYPE,
                 error_message=f"Mandatory property with ID '{supplied_property_id}' cannot be None.",
                 error_location=("properties", index, "value"),
                 error_input=supplied_property_value,
@@ -222,7 +225,7 @@ def _validate_property_value(
             defined_property_type, supplied_property_value
         ):
             process_error(
-                error_type="invalid_property_type",
+                error_type=ERROR_TYPE_INVALID_PROPERTY_TYPE,
                 error_message=f"Invalid value type for property with ID '{supplied_property_id}'. Expected type: "
                 f"{defined_property_type}.",
                 error_location=("properties", index, "value"),
@@ -239,7 +242,7 @@ def _validate_property_value(
             defined_property["mandatory"] or supplied_property_value is not None
         ):
             process_error(
-                error_type="invalid_property_type",
+                error_type=ERROR_TYPE_INVALID_PROPERTY_TYPE,
                 error_message=f"Invalid value for property with ID '{supplied_property_id}'. Expected one of "
                 f"{', '.join([str(value) for value in values])}.",
                 error_location=("properties", index, "value"),
@@ -280,7 +283,7 @@ def _validate_missing_mandatory_properties(
     for defined_property_id, defined_property in defined_properties.items():
         if defined_property["mandatory"] and defined_property_id not in supplied_properties:
             process_error(
-                error_type="missing_mandatory_property",
+                error_type=ERROR_TYPE_MISSING_MANDATORY_PROPERTY,
                 error_message=f"Missing mandatory property with ID '{defined_property_id}'",
                 error_location=("properties",),
                 error_input=supplied_properties,

--- a/inventory_management_system_api/services/utils.py
+++ b/inventory_management_system_api/services/utils.py
@@ -5,7 +5,7 @@ Collection of some utility functions used by services
 import logging
 import re
 from copy import deepcopy
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, LiteralString, Union
 
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
@@ -14,12 +14,8 @@ from inventory_management_system_api.core.exceptions import (
     InvalidPropertyTypeError,
     MissingMandatoryProperty,
 )
-from inventory_management_system_api.models.catalogue_category import (
-    CatalogueCategoryPropertyOut,
-)
-from inventory_management_system_api.schemas.catalogue_category import (
-    CatalogueCategoryPostPropertySchema,
-)
+from inventory_management_system_api.models.catalogue_category import CatalogueCategoryPropertyOut
+from inventory_management_system_api.schemas.catalogue_category import CatalogueCategoryPostPropertySchema
 from inventory_management_system_api.schemas.catalogue_item import PropertyPostSchema
 
 logger = logging.getLogger()
@@ -250,7 +246,7 @@ def _validate_property_value(
         if defined_property_mandatory:
             errors.append(
                 create_custom_validation_error_details(
-                    "invalid_property_type",
+                    type="invalid_property_type",
                     message=f"Mandatory property with ID '{supplied_property_id}' cannot be None.",
                     location=("properties", index, "value"),
                     input=supplied_property_value,
@@ -401,8 +397,8 @@ def _merge_non_mandatory_properties(
 
 
 def create_custom_validation_error_details(
-    type: str,  # pylint:disable=redefined-builtin
-    message: str,
+    type: LiteralString,  # pylint:disable=redefined-builtin
+    message: LiteralString,
     location: tuple,
     input: Any,  # pylint:disable=redefined-builtin
 ) -> InitErrorDetails:

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1680,21 +1680,33 @@ class TestDelete(DeleteDSL):
         self.check_delete_catalogue_item_failed_with_detail(404, "Catalogue item not found")
 
 
-class ValidateDSL(CreateDSL):
+class BulkValidateDSL(CreateDSL):
     """Base class for validate tests."""
 
-    _validate_response_catalogue_item: Response
+    _bulk_validate_response_catalogue_items: Response
 
     def validate_catalogue_item(self, catalogue_item_data: dict) -> None:
         """
-        Validates catalogue item data.
+        Validates a single catalogue item's data.
 
         :param catalogue_item_data: Dictionary containing the data to validate. Does not automatically add IDs so
                                     they can be omitted as required.
         """
 
-        self._validate_response_catalogue_item = self.test_client.post(
-            "/v1/catalogue-items/validate/", json=catalogue_item_data
+        self._bulk_validate_response_catalogue_items = self.test_client.post(
+            "/v1/catalogue-items/bulk-validate/", json=[catalogue_item_data]
+        )
+
+    def bulk_validate_catalogue_items(self, catalogue_items_data: list[dict]) -> None:
+        """
+        Validates bulk catalogue item data.
+
+        :param catalogue_items_data: List of dictionaries containing the data to validate. Does not automatically add
+                                     IDs so they can be omitted as required.
+        """
+
+        self._bulk_validate_response_catalogue_items = self.test_client.post(
+            "/v1/catalogue-items/bulk-validate/", json=catalogue_items_data
         )
 
     def check_validate_catalogue_item_success(self, expected_warnings: list[dict], expected_errors: list[dict]) -> None:
@@ -1706,15 +1718,31 @@ class ValidateDSL(CreateDSL):
         :param expected_errors: List of dictionaries containing the expected validation errors.
         """
 
-        assert self._validate_response_catalogue_item.status_code == 200
-        assert self._validate_response_catalogue_item.json() == {
-            "warnings": expected_warnings,
-            "errors": expected_errors,
+        assert self._bulk_validate_response_catalogue_items.status_code == 200
+        assert self._bulk_validate_response_catalogue_items.json() == {
+            "results": [
+                {
+                    "index": 0,
+                    "warnings": expected_warnings,
+                    "errors": expected_errors,
+                }
+            ]
         }
 
+    def check_bulk_validate_catalogue_items_success(self, expected_result: dict) -> None:
+        """
+        Checks that a prior call to `bulk_validate_catalogue_items` gave a successful response with the expected data
+        returned.
 
-class TestValidate(ValidateDSL):
-    """Tests for updating a catalogue item."""
+        :param expected_result: Dictionary of the expected result.
+        """
+
+        assert self._bulk_validate_response_catalogue_items.status_code == 200
+        assert self._bulk_validate_response_catalogue_items.json() == expected_result
+
+
+class TestBulkValidate(BulkValidateDSL):
+    """Tests for bulk validating catalogue items."""
 
     def test_validate_with_only_required_values_provided(self):
         """Test validating a catalogue item with only required values provided."""
@@ -2535,4 +2563,61 @@ class TestValidate(ValidateDSL):
                     "type": "missing_record",
                 },
             ],
+        )
+
+    def test_bulk_validate(self):
+        """
+        Test bulk validating catalogue items.
+
+        Comprehensive testing is done above on single items, this tests it works more more than one.
+        """
+
+        self.post_catalogue_item_prerequisites_no_properties()
+        self.bulk_validate_catalogue_items(
+            [
+                {
+                    **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+                    "catalogue_category_id": self.catalogue_category_id,
+                    "manufacturer_id": self.manufacturer_id,
+                },
+                {
+                    **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+                },
+                {
+                    **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+                    "catalogue_category_id": self.catalogue_category_id,
+                    "manufacturer_id": self.manufacturer_id,
+                },
+            ]
+        )
+
+        self.check_bulk_validate_catalogue_items_success(
+            expected_result={
+                "results": [
+                    {"index": 0, "warnings": [], "errors": []},
+                    {
+                        "index": 1,
+                        "warnings": [],
+                        "errors": [
+                            {
+                                "input": CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+                                "location": [
+                                    "catalogue_category_id",
+                                ],
+                                "message": "Field required",
+                                "type": "missing",
+                            },
+                            {
+                                "input": CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
+                                "location": [
+                                    "manufacturer_id",
+                                ],
+                                "message": "Field required",
+                                "type": "missing",
+                            },
+                        ],
+                    },
+                    {"index": 2, "warnings": [], "errors": []},
+                ]
+            }
         )

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -1680,12 +1680,12 @@ class TestDelete(DeleteDSL):
         self.check_delete_catalogue_item_failed_with_detail(404, "Catalogue item not found")
 
 
-class BulkValidateDSL(CreateDSL):
-    """Base class for validate tests."""
+class BulkValidateCreateDSL(CreateDSL):
+    """Base class for validate creation tests."""
 
-    _bulk_validate_response_catalogue_items: Response
+    _bulk_validate_create_response_catalogue_items: Response
 
-    def validate_catalogue_item(self, catalogue_item_data: dict) -> None:
+    def validate_create_catalogue_item(self, catalogue_item_data: dict) -> None:
         """
         Validates a single catalogue item's data.
 
@@ -1693,11 +1693,11 @@ class BulkValidateDSL(CreateDSL):
                                     they can be omitted as required.
         """
 
-        self._bulk_validate_response_catalogue_items = self.test_client.post(
-            "/v1/catalogue-items/bulk-validate/", json=[catalogue_item_data]
+        self._bulk_validate_create_response_catalogue_items = self.test_client.post(
+            "/v1/catalogue-items/bulk-validate-create/", json=[catalogue_item_data]
         )
 
-    def bulk_validate_catalogue_items(self, catalogue_items_data: list[dict]) -> None:
+    def bulk_validate_create_catalogue_items(self, catalogue_items_data: list[dict]) -> None:
         """
         Validates bulk catalogue item data.
 
@@ -1705,21 +1705,23 @@ class BulkValidateDSL(CreateDSL):
                                      IDs so they can be omitted as required.
         """
 
-        self._bulk_validate_response_catalogue_items = self.test_client.post(
-            "/v1/catalogue-items/bulk-validate/", json=catalogue_items_data
+        self._bulk_validate_create_response_catalogue_items = self.test_client.post(
+            "/v1/catalogue-items/bulk-validate-create/", json=catalogue_items_data
         )
 
-    def check_validate_catalogue_item_success(self, expected_warnings: list[dict], expected_errors: list[dict]) -> None:
+    def check_validate_create_catalogue_item_success(
+        self, expected_warnings: list[dict], expected_errors: list[dict]
+    ) -> None:
         """
-        Checks that a prior call to `validate_catalogue_item` gave a successful response with the expected data
+        Checks that a prior call to `validate_create_catalogue_item` gave a successful response with the expected data
         returned.
 
         :param expected_warnings: List of dictionaries containing the expected validation warnings.
         :param expected_errors: List of dictionaries containing the expected validation errors.
         """
 
-        assert self._bulk_validate_response_catalogue_items.status_code == 200
-        assert self._bulk_validate_response_catalogue_items.json() == {
+        assert self._bulk_validate_create_response_catalogue_items.status_code == 200
+        assert self._bulk_validate_create_response_catalogue_items.json() == {
             "results": [
                 {
                     "index": 0,
@@ -1729,27 +1731,27 @@ class BulkValidateDSL(CreateDSL):
             ]
         }
 
-    def check_bulk_validate_catalogue_items_success(self, expected_result: dict) -> None:
+    def check_bulk_validate_create_catalogue_items_success(self, expected_result: dict) -> None:
         """
-        Checks that a prior call to `bulk_validate_catalogue_items` gave a successful response with the expected data
-        returned.
+        Checks that a prior call to `bulk_validate_create_catalogue_items` gave a successful response with the expected
+        data returned.
 
         :param expected_result: Dictionary of the expected result.
         """
 
-        assert self._bulk_validate_response_catalogue_items.status_code == 200
-        assert self._bulk_validate_response_catalogue_items.json() == expected_result
+        assert self._bulk_validate_create_response_catalogue_items.status_code == 200
+        assert self._bulk_validate_create_response_catalogue_items.json() == expected_result
 
 
-class TestBulkValidate(BulkValidateDSL):
+class TestBulkValidateCreate(BulkValidateCreateDSL):
     """Tests for bulk validating catalogue items."""
 
-    def test_validate_with_only_required_values_provided(self):
-        """Test validating a catalogue item with only required values provided."""
+    def test_validate_create_with_only_required_values_provided(self):
+        """Test validating catalogue item data for creation with only required values provided."""
 
         self.post_catalogue_item_prerequisites_no_properties()
 
-        self.validate_catalogue_item(
+        self.validate_create_catalogue_item(
             {
                 **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
                 "catalogue_category_id": self.catalogue_category_id,
@@ -1757,14 +1759,15 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_with_duplicate_name(self):
-        """Test validating a catalogue item with only required values provided but the name is a duplicate."""
+    def test_validate_create_with_duplicate_name(self):
+        """Test validating catalogue item data for creation with only required values provided but the name is a
+        duplicate."""
 
         self.post_catalogue_item_and_prerequisites_no_properties(CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY)
 
-        self.validate_catalogue_item(
+        self.validate_create_catalogue_item(
             {
                 **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
                 "catalogue_category_id": self.catalogue_category_id,
@@ -1772,7 +1775,7 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[
                 {
                     "input": "Catalogue Item Required Values Only",
@@ -1787,8 +1790,8 @@ class TestBulkValidate(BulkValidateDSL):
             expected_errors=[],
         )
 
-    def test_validate_with_invalid_schema(self):
-        """Test validating a catalogue item when the schema itself is invalid."""
+    def test_validate_create_with_invalid_schema(self):
+        """Test validating catalogue item data for creation when the schema itself is invalid."""
 
         self.post_catalogue_item_prerequisites_no_properties()
 
@@ -1799,9 +1802,9 @@ class TestBulkValidate(BulkValidateDSL):
             # Optional property, invalid type
             "notes": 12,
         }
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -1863,13 +1866,13 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_non_obsolete_with_all_values_except_properties(self):
-        """Test validating a non obsolete catalogue item with all values provided except `properties` and
-        those related to being obsolete."""
+    def test_validate_create_non_obsolete_with_all_values_except_properties(self):
+        """Test validating non obsolete catalogue item data for creation with all values provided except `properties`
+        and those related to being obsolete."""
 
         self.post_catalogue_item_prerequisites_no_properties()
 
-        self.validate_catalogue_item(
+        self.validate_create_catalogue_item(
             {
                 **CATALOGUE_ITEM_DATA_NOT_OBSOLETE_NO_PROPERTIES,
                 "catalogue_category_id": self.catalogue_category_id,
@@ -1877,16 +1880,16 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_obsolete_with_all_values_except_properties(self):
-        """Test validating an obsolete catalogue item with all values provided except `properties`."""
+    def test_validate_create_obsolete_with_all_values_except_properties(self):
+        """Test validating obsolete catalogue item data for creation with all values provided except `properties`."""
 
         self.post_catalogue_item_prerequisites_no_properties()
         obsolete_replacement_catalogue_item_id = self.post_catalogue_item(
             CATALOGUE_ITEM_DATA_NOT_OBSOLETE_NO_PROPERTIES
         )
-        self.validate_catalogue_item(
+        self.validate_create_catalogue_item(
             {
                 **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
                 "catalogue_category_id": self.catalogue_category_id,
@@ -1895,14 +1898,15 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_obsolete_with_non_existent_obsolete_replacement_catalogue_item_id(self):
-        """Test validating an obsolete catalogue item with a non-existent `obsolete_replacement_catalogue_item_id`."""
+    def test_validate_create_obsolete_with_non_existent_obsolete_replacement_catalogue_item_id(self):
+        """Test validating obsolete catalogue item data for creation with a non-existent
+        `obsolete_replacement_catalogue_item_id`."""
 
         obsolete_replacement_catalogue_item_id = str(ObjectId())
         self.post_catalogue_item_prerequisites_no_properties()
-        self.validate_catalogue_item(
+        self.validate_create_catalogue_item(
             {
                 **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
                 "catalogue_category_id": self.catalogue_category_id,
@@ -1911,7 +1915,7 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -1925,12 +1929,13 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_obsolete_with_invalid_obsolete_replacement_catalogue_item_id(self):
-        """Test validating an obsolete catalogue item an invalid `obsolete_replacement_catalogue_item_id`."""
+    def test_validate_create_obsolete_with_invalid_obsolete_replacement_catalogue_item_id(self):
+        """Test validating obsolete catalogue item data for creation with an invalid
+        `obsolete_replacement_catalogue_item_id`."""
 
         obsolete_replacement_catalogue_item_id = "invalid"
         self.post_catalogue_item_prerequisites_no_properties()
-        self.validate_catalogue_item(
+        self.validate_create_catalogue_item(
             {
                 **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
                 "catalogue_category_id": self.catalogue_category_id,
@@ -1939,7 +1944,7 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -1953,8 +1958,9 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_all_properties_provided(self):
-        """Test validating a catalogue item with all properties within the catalogue category being defined."""
+    def test_validate_create_with_all_properties_provided(self):
+        """Test validating catalogue item data for creation with all properties within the catalogue category being
+        defined."""
 
         self.post_catalogue_item_prerequisites_with_properties()
 
@@ -1966,14 +1972,14 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_with_properties_invalid_schema(self):
+    def test_validate_create_with_properties_invalid_schema(self):
         """
-        Test validating a catalogue item with properties within the catalogue category being defined but with an
-        invalid schema.
+        Test validating catalogue item data for creation with properties within the catalogue category being defined but
+        with an invalid schema.
         """
 
         self.post_catalogue_item_prerequisites_with_properties()
@@ -1985,9 +1991,9 @@ class TestBulkValidate(BulkValidateDSL):
             "manufacturer_id": self.manufacturer_id,
         }
 
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2032,8 +2038,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_mandatory_properties_only(self):
-        """Test validating a catalogue item with only mandatory properties defined."""
+    def test_validate_create_with_mandatory_properties_only(self):
+        """Test validating catalogue item data for creation with only mandatory properties defined."""
 
         self.post_catalogue_item_prerequisites_with_properties()
 
@@ -2049,12 +2055,12 @@ class TestBulkValidate(BulkValidateDSL):
             catalogue_item_data, self.property_name_id_dict
         )
 
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_with_mandatory_properties_given_none(self):
-        """Test validating a catalogue item when mandatory properties are given a value of `None`."""
+    def test_validate_create_with_mandatory_properties_given_none(self):
+        """Test validating catalogue item data for creation when mandatory properties are given a value of `None`."""
 
         self.post_catalogue_item_prerequisites_with_properties()
 
@@ -2067,9 +2073,9 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2086,8 +2092,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_missing_mandatory_properties(self):
-        """Test validating a catalogue item when missing mandatory properties."""
+    def test_validate_create_with_missing_mandatory_properties(self):
+        """Test validating catalogue item data for creation when missing mandatory properties."""
 
         self.post_catalogue_item_prerequisites_with_properties()
 
@@ -2100,9 +2106,9 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2117,8 +2123,9 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_non_mandatory_properties_given_none(self):
-        """Test validating a catalogue item when non-mandatory properties are given a value of `None`."""
+    def test_validate_create_with_non_mandatory_properties_given_none(self):
+        """Test validating catalogue item data for creation when non-mandatory properties are given a value of
+        `None`."""
 
         self.post_catalogue_item_prerequisites_with_properties()
 
@@ -2134,12 +2141,12 @@ class TestBulkValidate(BulkValidateDSL):
                 ],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validating_with_string_property_with_invalid_value_type(self):
-        """Test validating a catalogue item with an invalid value type for a string property."""
+    def test_validate_create_with_string_property_with_invalid_value_type(self):
+        """Test validating catalogue item data for creation with an invalid value type for a string property."""
 
         self.post_catalogue_item_prerequisites_with_given_properties(
             catalogue_category_properties_data=[CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_MANDATORY],
@@ -2152,9 +2159,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "properties": [{"name": CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_MANDATORY["name"], "value": 42}],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2172,8 +2179,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_number_property_with_invalid_value_type(self):
-        """Test validate a catalogue item with an invalid value type for a number property."""
+    def test_validate_create_with_number_property_with_invalid_value_type(self):
+        """Test validate catalogue item data or creation with an invalid value type for a number property."""
 
         self.post_catalogue_item_prerequisites_with_given_properties(
             catalogue_category_properties_data=[CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT],
@@ -2188,9 +2195,9 @@ class TestBulkValidate(BulkValidateDSL):
                 ],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2210,8 +2217,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_boolean_property_with_invalid_value_type(self):
-        """Test validate a catalogue item with an invalid value type for a boolean property."""
+    def test_validate_create_with_boolean_property_with_invalid_value_type(self):
+        """Test validate catalogue item data for creation with an invalid value type for a boolean property."""
 
         self.post_catalogue_item_prerequisites_with_given_properties(
             catalogue_category_properties_data=[CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY],
@@ -2224,9 +2231,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "properties": [{"name": CATALOGUE_CATEGORY_PROPERTY_DATA_BOOLEAN_MANDATORY["name"], "value": 0}],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2244,8 +2251,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_allowed_values_list(self):
-        """Test validating a catalogue item with properties that have allowed values lists."""
+    def test_validate_create_with_allowed_values_list(self):
+        """Test validating catalogue item data for creation with properties that have allowed values lists."""
 
         self.post_catalogue_item_prerequisites_with_given_properties(
             catalogue_category_properties_data=[
@@ -2264,13 +2271,13 @@ class TestBulkValidate(BulkValidateDSL):
                 ],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(expected_warnings=[], expected_errors=[])
+        self.check_validate_create_catalogue_item_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_with_string_property_with_allowed_values_list_with_invalid_value(self):
-        """Test validate a catalogue item with a string property with an allowed values list while giving it a value not
-        in the list."""
+    def test_validate_create_with_string_property_with_allowed_values_list_with_invalid_value(self):
+        """Test validate catalogue item data for creation with a string property with an allowed values list while
+        giving it a value not in the list."""
 
         self.post_catalogue_item_prerequisites_with_allowed_values("string", {"type": "list", "values": ["value1"]})
         catalogue_item_data = self.get_catalogue_item_with_ids_in_properties(
@@ -2281,9 +2288,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "properties": [{"name": "property", "value": "value2"}],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2300,9 +2307,9 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_string_property_with_allowed_values_list_with_invalid_type(self):
-        """Test validating a catalogue item with a string property with an allowed values list while giving it a value
-        with an incorrect type."""
+    def test_validate_create_with_string_property_with_allowed_values_list_with_invalid_type(self):
+        """Test validating catalogue item data for creation with a string property with an allowed values list while
+        giving it a value with an incorrect type."""
 
         self.post_catalogue_item_prerequisites_with_allowed_values("string", {"type": "list", "values": ["value1"]})
         catalogue_item_data = self.get_catalogue_item_with_ids_in_properties(
@@ -2313,9 +2320,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "properties": [{"name": "property", "value": 42}],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2343,9 +2350,9 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_number_property_with_allowed_values_list_with_invalid_value(self):
-        """Test validating a catalogue item with a number property with an allowed values list while giving it a value
-        not in the list."""
+    def test_validate_create_with_number_property_with_allowed_values_list_with_invalid_value(self):
+        """Test validating catalogue item data for creation with a number property with an allowed values list while
+        giving it a value not in the list."""
 
         self.post_catalogue_item_prerequisites_with_allowed_values("number", {"type": "list", "values": [1]})
         catalogue_item_data = self.get_catalogue_item_with_ids_in_properties(
@@ -2356,9 +2363,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "properties": [{"name": "property", "value": 2}],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2375,9 +2382,9 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_number_property_with_allowed_values_list_with_invalid_type(self):
-        """Test validate a catalogue item with a number property with an allowed values list while giving it a value
-        with an incorrect type."""
+    def test_validate_create_with_number_property_with_allowed_values_list_with_invalid_type(self):
+        """Test validate catalogue item data for creation with a number property with an allowed values list while
+        giving it a value with an incorrect type."""
 
         self.post_catalogue_item_prerequisites_with_allowed_values("number", {"type": "list", "values": [1]})
         catalogue_item_data = self.get_catalogue_item_with_ids_in_properties(
@@ -2388,9 +2395,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "properties": [{"name": "property", "value": "test"}],
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2418,8 +2425,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_in_non_leaf_catalogue_category(self):
-        """Test validating a catalogue item within a non-leaf catalogue category."""
+    def test_validate_create_in_non_leaf_catalogue_category(self):
+        """Test validating catalogue item data for creation within a non-leaf catalogue category."""
 
         self.post_catalogue_category(CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_REQUIRED_VALUES_ONLY)
         self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
@@ -2432,9 +2439,9 @@ class TestBulkValidate(BulkValidateDSL):
             }
         )
 
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2448,8 +2455,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_non_existent_catalogue_category_id(self):
-        """Test validating a catalogue item with a non-existent catalogue category ID."""
+    def test_validate_create_with_non_existent_catalogue_category_id(self):
+        """Test validating catalogue item data for creation with a non-existent catalogue category ID."""
 
         self.catalogue_category_id = str(ObjectId())
         self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
@@ -2461,9 +2468,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "manufacturer_id": self.manufacturer_id,
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2477,8 +2484,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_invalid_catalogue_category_id(self):
-        """Test validating a catalogue item with an invalid catalogue category ID."""
+    def test_validate_create_with_invalid_catalogue_category_id(self):
+        """Test validating catalogue item data for creation with an invalid catalogue category ID."""
 
         self.catalogue_category_id = "invalid-id"
         self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
@@ -2490,10 +2497,10 @@ class TestBulkValidate(BulkValidateDSL):
                 "manufacturer_id": self.manufacturer_id,
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
         self.post_catalogue_item(CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2507,8 +2514,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_non_existent_manufacturer_id(self):
-        """Test validating a catalogue item with a non-existent manufacturer ID."""
+    def test_validate_create_with_non_existent_manufacturer_id(self):
+        """Test validating catalogue item data for creation with a non-existent manufacturer ID."""
 
         self.post_catalogue_category(CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES)
         self.manufacturer_id = str(ObjectId())
@@ -2520,9 +2527,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "manufacturer_id": self.manufacturer_id,
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2536,8 +2543,8 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_validate_with_invalid_manufacturer_id(self):
-        """Test validating a catalogue item with an invalid manufacturer ID."""
+    def test_validate_create_with_invalid_manufacturer_id(self):
+        """Test validating catalogue item data for creation with an invalid manufacturer ID."""
 
         self.post_catalogue_category(CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES)
         self.manufacturer_id = "invalid-id"
@@ -2549,9 +2556,9 @@ class TestBulkValidate(BulkValidateDSL):
                 "manufacturer_id": self.manufacturer_id,
             }
         )
-        self.validate_catalogue_item(catalogue_item_data)
+        self.validate_create_catalogue_item(catalogue_item_data)
 
-        self.check_validate_catalogue_item_success(
+        self.check_validate_create_catalogue_item_success(
             expected_warnings=[],
             expected_errors=[
                 {
@@ -2565,15 +2572,15 @@ class TestBulkValidate(BulkValidateDSL):
             ],
         )
 
-    def test_bulk_validate(self):
+    def test_bulk_validate_create(self):
         """
-        Test bulk validating catalogue items.
+        Test bulk validating catalogue items for creation.
 
         Comprehensive testing is done above on single items, this tests it works more more than one.
         """
 
         self.post_catalogue_item_prerequisites_no_properties()
-        self.bulk_validate_catalogue_items(
+        self.bulk_validate_create_catalogue_items(
             [
                 {
                     **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
@@ -2591,7 +2598,7 @@ class TestBulkValidate(BulkValidateDSL):
             ]
         )
 
-        self.check_bulk_validate_catalogue_items_success(
+        self.check_bulk_validate_create_catalogue_items_success(
             expected_result={
                 "results": [
                     {"index": 0, "warnings": [], "errors": []},

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -662,6 +662,234 @@ class TestCreate(CreateDSL):
         self.check_post_catalogue_item_failed_with_detail(422, "The specified manufacturer does not exist")
 
 
+class BulkCreateDSL(CreateDSL):
+    """Base class for bulk create tests."""
+
+    _post_bulk_response_catalogue_item: Response
+
+    def post_bulk_catalogue_items(self, catalogue_items_data: list[dict]) -> Optional[list[str]]:
+        """
+        Posts bulk catalogue items with the given data.l.
+
+        :param catalogue_items_data: List of Dictionaries containing the basic catalogue item data as would be required
+                                      for a `CatalogueItemPostSchema` but with mandatory IDs missing and any `id`'s
+                                      replaced by the `name` value in its properties as the IDs will be added
+                                      automatically.
+        :return: IDs of the created catalogue items (or `None` if not successful).
+        """
+        full_catalogue_items_data = []
+        for catalogue_item_data in catalogue_items_data:
+            # Replace any unit values with unit IDs
+            full_catalogue_item_data = self.get_catalogue_item_with_ids_in_properties(catalogue_item_data)
+
+            # Insert mandatory IDs if they have been created
+            if self.catalogue_category_id:
+                full_catalogue_item_data["catalogue_category_id"] = self.catalogue_category_id
+            if self.manufacturer_id:
+                full_catalogue_item_data["manufacturer_id"] = self.manufacturer_id
+            full_catalogue_items_data.append(full_catalogue_item_data)
+
+        self._post_bulk_response_catalogue_item = self.test_client.post(
+            "/v1/catalogue-items/bulk", json=full_catalogue_items_data
+        )
+
+        return (
+            [catalogue_item["id"] for catalogue_item in self._post_bulk_response_catalogue_item.json()]
+            if self._post_bulk_response_catalogue_item.status_code == 201
+            else None
+        )
+
+    def check_post_bulk_catalogue_items_success(self, expected_catalogue_items_get_data: dict) -> None:
+        """
+        Checks that a prior call to `post_bulk_catalogue_items` gave a successful response with the expected data
+        returned.
+
+        :param expected_catalogue_items_get_data: Dictionary containing the expected catalogue items data returned as
+                                would be required for a `CatalogueItemSchema`. Does not need mandatory IDs (e.g.
+                                `manufacturer_id`) as they will be added automatically to check they are as expected.
+        """
+
+        assert self._post_bulk_response_catalogue_item.status_code == 201
+        assert self._post_bulk_response_catalogue_item.json() == [
+            self.add_ids_to_expected_catalogue_item_get_data(expected_catalogue_item_get_data)
+            for expected_catalogue_item_get_data in expected_catalogue_items_get_data
+        ]
+
+    def check_post_bulk_catalogue_items_failed_with_detail(self, status_code: int, detail: str) -> None:
+        """
+        Checks that a prior call to `post_bulk_catalogue_item` gave a failed response with the expected code and
+        error message.
+
+        :param status_code: Expected status code of the response.
+        :param detail: Expected detail given in the response.
+        """
+
+        assert self._post_bulk_response_catalogue_item.status_code == status_code
+        assert self._post_bulk_response_catalogue_item.json()["detail"] == detail
+
+    def check_post_bulk_catalogue_items_failed_with_validation_message(self, status_code: int, message: str) -> None:
+        """
+        Checks that a prior call to `post_bulk_catalogue_item` gave a failed response with the expected code and
+        pydantic validation error message.
+
+        :param status_code: Expected status code of the response.
+        :param message: Expected validation error message given in the response.
+        """
+
+        assert self._post_bulk_response_catalogue_item.status_code == status_code
+        assert self._post_bulk_response_catalogue_item.json()["detail"][0]["msg"] == message
+
+
+class TestBulkCreate(BulkCreateDSL):
+    """Tests for bulk creating catalogue items (As logic is reused from create, only specific errors caught at the
+    router are tested)."""
+
+    def test_bulk_create(self):
+        """Test bulk creating catalogue items."""
+
+        self.post_catalogue_item_prerequisites_no_properties()
+        self.post_bulk_catalogue_items(
+            [CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY, CATALOGUE_ITEM_DATA_NOT_OBSOLETE_NO_PROPERTIES]
+        )
+
+        self.check_post_bulk_catalogue_items_success(
+            [CATALOGUE_ITEM_GET_DATA_REQUIRED_VALUES_ONLY, CATALOGUE_ITEM_GET_DATA_NOT_OBSOLETE_NO_PROPERTIES]
+        )
+
+    def test_bulk_create_obsolete_with_non_existent_obsolete_replacement_catalogue_item_id(self):
+        """Test bulk creating an obsolete catalogue item with a non-existent
+        `obsolete_replacement_catalogue_item_id`."""
+
+        self.post_catalogue_item_prerequisites_no_properties()
+        self.post_bulk_catalogue_items(
+            [
+                {
+                    **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
+                    "obsolete_replacement_catalogue_item_id": str(ObjectId()),
+                }
+            ]
+        )
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(422, "A specified entity does not exist")
+
+    def test_bulk_create_obsolete_with_invalid_obsolete_replacement_catalogue_item_id(self):
+        """Test bulk creating an obsolete catalogue item an invalid `obsolete_replacement_catalogue_item_id`."""
+
+        self.post_catalogue_item_prerequisites_no_properties()
+        self.post_bulk_catalogue_items(
+            [
+                {
+                    **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
+                    "obsolete_replacement_catalogue_item_id": "invalid-id",
+                }
+            ]
+        )
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(422, "A specified entity does not exist")
+
+    def test_bulk_create_with_mandatory_properties_given_none(self):
+        """Test bulk creating a catalogue item when mandatory properties are given a value of `None`."""
+
+        self.post_catalogue_item_prerequisites_with_properties()
+        self.post_bulk_catalogue_items(
+            [
+                {
+                    **CATALOGUE_ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY,
+                    "properties": [{**PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE, "value": None}],
+                }
+            ]
+        )
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(
+            422,
+            f"Mandatory property with ID '{self.property_name_id_dict[PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE['name']]}' "
+            "cannot be None.",
+        )
+
+    def test_bulk_create_with_missing_mandatory_properties(self):
+        """Test bulk creating a catalogue item when missing mandatory properties."""
+
+        self.post_catalogue_item_prerequisites_with_properties()
+        self.post_bulk_catalogue_items([{**CATALOGUE_ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY, "properties": []}])
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(
+            422,
+            "Missing mandatory property with ID "
+            f"'{self.property_name_id_dict[PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE['name']]}'",
+        )
+
+    def test_bulk_create_with_property_with_invalid_value_type(self):
+        """Test bulk creating a catalogue item with an invalid value type."""
+
+        self.post_catalogue_item_prerequisites_with_given_properties(
+            [CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_MANDATORY]
+        )
+        self.post_bulk_catalogue_items(
+            [
+                {
+                    **CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
+                    "properties": [
+                        {"name": CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_MANDATORY["name"], "value": 42},
+                    ],
+                }
+            ],
+        )
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(
+            422,
+            "Invalid value type for property with ID "
+            f"'{self.property_name_id_dict[CATALOGUE_CATEGORY_PROPERTY_DATA_STRING_MANDATORY['name']]}'. "
+            "Expected type: string.",
+        )
+
+    def test_bulk_create_in_non_leaf_catalogue_category(self):
+        """Test bulk creating a catalogue item within a non-leaf catalogue category."""
+
+        self.post_catalogue_category(CATALOGUE_CATEGORY_POST_DATA_NON_LEAF_REQUIRED_VALUES_ONLY)
+        self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_bulk_catalogue_items([CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY])
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(
+            409, "Adding a catalogue item to a non-leaf catalogue category is not allowed"
+        )
+
+    def test_bulk_create_with_non_existent_catalogue_category_id(self):
+        """Test bulk creating a catalogue item with a non-existent catalogue category ID."""
+
+        self.catalogue_category_id = str(ObjectId())
+        self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_bulk_catalogue_items([CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY])
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(422, "A specified entity does not exist")
+
+    def test_bulk_create_with_invalid_catalogue_category_id(self):
+        """Test bulk creating a catalogue item with an invalid catalogue category ID."""
+
+        self.catalogue_category_id = "invalid-id"
+        self.post_manufacturer(MANUFACTURER_POST_DATA_REQUIRED_VALUES_ONLY)
+        self.post_bulk_catalogue_items([CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY])
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(422, "A specified entity does not exist")
+
+    def test_bulk_create_with_non_existent_manufacturer_id(self):
+        """Test bulk creating a catalogue item with a non-existent manufacturer ID."""
+
+        self.post_catalogue_category(CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES)
+        self.manufacturer_id = str(ObjectId())
+        self.post_bulk_catalogue_items([CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY])
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(422, "A specified entity does not exist")
+
+    def test_bulk_create_with_invalid_manufacturer_id(self):
+        """Test bulk creating a catalogue item with an invalid manufacturer ID."""
+
+        self.post_catalogue_category(CATALOGUE_CATEGORY_POST_DATA_LEAF_NO_PARENT_NO_PROPERTIES)
+        self.manufacturer_id = "invalid-id"
+        self.post_bulk_catalogue_items([CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY])
+
+        self.check_post_bulk_catalogue_items_failed_with_detail(422, "A specified entity does not exist")
+
+
 class GetDSL(CreateDSL):
     """Base class for get tests."""
 

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -462,12 +462,26 @@ class TestCreate(CreateDSL):
             "cannot be None.",
         )
 
-    def test_create_with_missing_mandatory_properties(self):
-        """Test creating a catalogue item when missing mandatory properties."""
+    def test_create_with_missing_mandatory_properties_when_properties_field_defined(self):
+        """Test creating a catalogue item with missing mandatory properties when the properties field is defined."""
 
         self.post_catalogue_item_and_prerequisites_with_properties(
             {**CATALOGUE_ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY, "properties": []}
         )
+
+        self.check_post_catalogue_item_failed_with_detail(
+            422,
+            "Missing mandatory property with ID "
+            f"'{self.property_name_id_dict[PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE['name']]}'",
+        )
+
+    def test_create_with_missing_mandatory_properties_when_properties_field_undefined(self):
+        """Test creating a catalogue item when missing mandatory properties when the properties field
+        is not defined at all."""
+
+        catalogue_item_data = copy.deepcopy(CATALOGUE_ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY)
+        del catalogue_item_data["properties"]
+        self.post_catalogue_item_and_prerequisites_with_properties(catalogue_item_data)
 
         self.check_post_catalogue_item_failed_with_detail(
             422,
@@ -2029,6 +2043,8 @@ class TestBulkValidateCreate(BulkValidateCreateDSL):
             "cost_gpb": False,
             # Optional property, invalid type
             "notes": 12,
+            # Custom properties
+            "properties": [{}, {"id": 42, "value": "test"}],
         }
         self.validate_create_catalogue_item(catalogue_item_data)
 
@@ -2037,57 +2053,55 @@ class TestBulkValidateCreate(BulkValidateCreateDSL):
             expected_errors=[
                 {
                     "input": catalogue_item_data,
-                    "location": [
-                        "catalogue_category_id",
-                    ],
+                    "location": ["catalogue_category_id"],
                     "message": "Field required",
                     "type": "missing",
                 },
                 {
                     "input": catalogue_item_data,
-                    "location": [
-                        "manufacturer_id",
-                    ],
+                    "location": ["manufacturer_id"],
                     "message": "Field required",
                     "type": "missing",
                 },
                 {
                     "input": catalogue_item_data["name"],
-                    "location": [
-                        "name",
-                    ],
+                    "location": ["name"],
                     "message": "Input should be a valid string",
                     "type": "string_type",
                 },
                 {
                     "input": catalogue_item_data,
-                    "location": [
-                        "cost_gbp",
-                    ],
+                    "location": ["cost_gbp"],
                     "message": "Field required",
                     "type": "missing",
                 },
                 {
                     "input": catalogue_item_data,
-                    "location": [
-                        "days_to_replace",
-                    ],
+                    "location": ["days_to_replace"],
                     "message": "Field required",
                     "type": "missing",
                 },
                 {
                     "input": catalogue_item_data,
-                    "location": [
-                        "is_obsolete",
-                    ],
+                    "location": ["is_obsolete"],
                     "message": "Field required",
                     "type": "missing",
                 },
                 {
                     "input": catalogue_item_data["notes"],
-                    "location": [
-                        "notes",
-                    ],
+                    "location": ["notes"],
+                    "message": "Input should be a valid string",
+                    "type": "string_type",
+                },
+                {
+                    "input": {},
+                    "location": ["properties", 0, "id"],
+                    "message": "Field required",
+                    "type": "missing",
+                },
+                {
+                    "input": 42,
+                    "location": ["properties", 1, "id"],
                     "message": "Input should be a valid string",
                     "type": "string_type",
                 },
@@ -2320,8 +2334,9 @@ class TestBulkValidateCreate(BulkValidateCreateDSL):
             ],
         )
 
-    def test_validate_create_with_missing_mandatory_properties(self):
-        """Test validating catalogue item data for creation when missing mandatory properties."""
+    def test_validate_create_with_missing_mandatory_properties_when_properties_field_defined(self):
+        """Test validating catalogue item data for creation with missing mandatory properties when the properties field
+        is defined."""
 
         self.post_catalogue_item_prerequisites_with_properties()
 
@@ -2333,6 +2348,38 @@ class TestBulkValidateCreate(BulkValidateCreateDSL):
                 "properties": [],
             }
         )
+
+        self.validate_create_catalogue_item(catalogue_item_data)
+
+        self.check_validate_create_catalogue_item_success(
+            expected_warnings=[],
+            expected_errors=[
+                {
+                    "input": {},
+                    "location": [
+                        "properties",
+                    ],
+                    "message": f"Missing mandatory property with ID "
+                    f"'{self.property_name_id_dict[PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE['name']]}'",
+                    "type": "missing_mandatory_property",
+                },
+            ],
+        )
+
+    def test_validate_create_with_missing_mandatory_properties_when_properties_field_undefined(self):
+        """Test validating catalogue item data for creation with missing mandatory properties when the properties field
+        is not defined at all."""
+
+        self.post_catalogue_item_prerequisites_with_properties()
+
+        catalogue_item_data = self.get_catalogue_item_with_ids_in_properties(
+            {
+                **CATALOGUE_ITEM_DATA_WITH_MANDATORY_PROPERTIES_ONLY,
+                "catalogue_category_id": self.catalogue_category_id,
+                "manufacturer_id": self.manufacturer_id,
+            }
+        )
+        del catalogue_item_data["properties"]
 
         self.validate_create_catalogue_item(catalogue_item_data)
 

--- a/test/e2e/test_catalogue_item.py
+++ b/test/e2e/test_catalogue_item.py
@@ -699,7 +699,7 @@ class BulkCreateDSL(CreateDSL):
             else None
         )
 
-    def check_post_bulk_catalogue_items_success(self, expected_catalogue_items_get_data: dict) -> None:
+    def check_post_bulk_catalogue_items_success(self, expected_catalogue_items_get_data: list[dict]) -> None:
         """
         Checks that a prior call to `post_bulk_catalogue_items` gave a successful response with the expected data
         returned.

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -1262,9 +1262,9 @@ class ValidateDSL(CatalogueItemServiceDSL):
 
     _catalogue_category_out: Optional[CatalogueCategoryOut]
     _catalogue_item_data: dict
-    _validation_result: ValidationResultSchema
+    _validate_create_result: ValidationResultSchema
 
-    def mock_validate(
+    def mock_validate_create(
         self,
         catalogue_item_data: dict,
         catalogue_category_out_data: Optional[dict] = None,
@@ -1273,7 +1273,7 @@ class ValidateDSL(CatalogueItemServiceDSL):
         has_duplicate_name: bool = False,
     ) -> None:
         """
-        Mocks repo methods appropriately to test the `create` service method.
+        Mocks repo methods appropriately to test the `validate_create` service method.
 
         :param catalogue_item_data: Dictionary containing the catalogue item data to validate.
         :param catalogue_category_out_data: Either `None` or a dictionary containing the catalogue category data as
@@ -1321,20 +1321,20 @@ class ValidateDSL(CatalogueItemServiceDSL):
 
         self.mock_catalogue_item_repository.is_duplicate_name.return_value = has_duplicate_name
 
-    def call_validate(self) -> None:
-        """Calls the `CatalogueItemService` `validate` method with the appropriate data from a prior call to
-        `mock_validate`."""
+    def call_validate_create(self) -> None:
+        """Calls the `CatalogueItemService` `validate_create` method with the appropriate data from a prior call to
+        `mock_validate_create`."""
 
         # Easier to mock a single validation than a whole list, so do proper testing with single, then have a test
         # for multiple
-        self._validation_result = self.catalogue_item_service._validate(  # pylint:disable=protected-access
+        self._validate_create_result = self.catalogue_item_service._validate_create(  # pylint:disable=protected-access
             index=0, catalogue_item_data=self._catalogue_item_data
         )
 
-    def check_validate_success(
+    def check_validate_create_success(
         self, expected_warnings: list[ValidationErrorSchema], expected_errors: list[ValidationErrorSchema]
     ) -> None:
-        """Checks that a prior call to `call_validate` worked as expected.
+        """Checks that a prior call to `call_validate_create` worked as expected.
 
         :param expected_warnings: Expected validation warnings.
         :param expected_errors: Expected validation errors.
@@ -1375,19 +1375,19 @@ class ValidateDSL(CatalogueItemServiceDSL):
                     ANY,
                 )
 
-        assert self._validation_result == ValidationResultSchema(
+        assert self._validate_create_result == ValidationResultSchema(
             index=0, warnings=expected_warnings, errors=expected_errors
         )
 
 
-class TestValidate(ValidateDSL):
-    """Tests for validating a catalogue item."""
+class TestValidateCreate(ValidateDSL):
+    """Tests for validating catalogue item data for creation."""
 
-    def test_validate_with_all_properties(self):
-        """Test validating a catalogue item when all properties present in the catalogue category are defined in the
-        catalogue item."""
+    def test_validate_create_with_all_properties(self):
+        """Test validating catalogue item data for creation when all properties present in the catalogue category are
+        defined in the catalogue item."""
 
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
                 "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
@@ -1396,13 +1396,14 @@ class TestValidate(ValidateDSL):
             catalogue_category_out_data=BASE_CATALOGUE_CATEGORY_OUT_DATA_WITH_PROPERTIES_MM,
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
         )
-        self.call_validate()
-        self.check_validate_success(expected_warnings=[], expected_errors=[])
+        self.call_validate_create()
+        self.check_validate_create_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_with_duplicate_name(self):
-        """Test validating a catalogue item when it is using a duplicate name as an already existing catalogue item."""
+    def test_validate_create_with_duplicate_name(self):
+        """Test validating catalogue item data for creation when it is using a duplicate name as an already existing
+        catalogue item."""
 
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_WITH_ALL_PROPERTIES,
                 "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
@@ -1412,8 +1413,8 @@ class TestValidate(ValidateDSL):
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
             has_duplicate_name=True,
         )
-        self.call_validate()
-        self.check_validate_success(
+        self.call_validate_create()
+        self.check_validate_create_success(
             expected_warnings=[
                 ValidationErrorSchema(
                     type="duplicate_record",
@@ -1426,21 +1427,21 @@ class TestValidate(ValidateDSL):
             expected_errors=[],
         )
 
-    def test_validate_with_invalid_schema(self):
-        """Test validating a catalogue item when the schema itself is invalid."""
+    def test_validate_create_with_invalid_schema(self):
+        """Test validating catalogue item data for creation when the schema itself is invalid."""
 
         catalogue_item_data = {
             **{"name": 42, "days_to_replace": False},
             "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
             "manufacturer_id": str(MANUFACTURER_OUT_DATA_A["_id"]),
         }
-        self.mock_validate(
+        self.mock_validate_create(
             catalogue_item_data,
             catalogue_category_out_data=BASE_CATALOGUE_CATEGORY_OUT_DATA_WITH_PROPERTIES_MM,
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
         )
-        self.call_validate()
-        self.check_validate_success(
+        self.call_validate_create()
+        self.check_validate_create_success(
             expected_warnings=[],
             expected_errors=[
                 ValidationErrorSchema(type="string_type", loc=["name"], msg="Input should be a valid string", input=42),
@@ -1459,11 +1460,11 @@ class TestValidate(ValidateDSL):
             ],
         )
 
-    def test_validate_with_non_existent_catalogue_category_id(self):
-        """Test validating a catalogue item with a non-existent catalogue category ID."""
+    def test_validate_create_with_non_existent_catalogue_category_id(self):
+        """Test validating catalogue item data for creation with a non-existent catalogue category ID."""
 
         catalogue_category_id = str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"])
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
                 "catalogue_category_id": catalogue_category_id,
@@ -1472,8 +1473,8 @@ class TestValidate(ValidateDSL):
             catalogue_category_out_data=None,
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
         )
-        self.call_validate()
-        self.check_validate_success(
+        self.call_validate_create()
+        self.check_validate_create_success(
             expected_warnings=[],
             expected_errors=[
                 ValidationErrorSchema(
@@ -1485,11 +1486,11 @@ class TestValidate(ValidateDSL):
             ],
         )
 
-    def test_validate_with_non_leaf_catalogue_category(self):
-        """Test validating a catalogue item with a non-leaf catalogue category."""
+    def test_validate_create_with_non_leaf_catalogue_category(self):
+        """Test validating catalogue item data for creation with a non-leaf catalogue category."""
 
         catalogue_category_id = str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"])
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
                 "catalogue_category_id": catalogue_category_id,
@@ -1498,8 +1499,8 @@ class TestValidate(ValidateDSL):
             catalogue_category_out_data=CATALOGUE_CATEGORY_OUT_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
         )
-        self.call_validate()
-        self.check_validate_success(
+        self.call_validate_create()
+        self.check_validate_create_success(
             expected_warnings=[],
             expected_errors=[
                 ValidationErrorSchema(
@@ -1511,11 +1512,11 @@ class TestValidate(ValidateDSL):
             ],
         )
 
-    def test_validate_with_non_existent_manufacturer_id(self):
-        """Test validating a catalogue item with a non-existent manufacturer ID."""
+    def test_validate_create_with_non_existent_manufacturer_id(self):
+        """Test validating catalogue item data for creation with a non-existent manufacturer ID."""
 
         manufacturer_id = str(MANUFACTURER_OUT_DATA_A["_id"])
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_REQUIRED_VALUES_ONLY,
                 "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
@@ -1524,8 +1525,8 @@ class TestValidate(ValidateDSL):
             catalogue_category_out_data=CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES,
             manufacturer_out_data=None,
         )
-        self.call_validate()
-        self.check_validate_success(
+        self.call_validate_create()
+        self.check_validate_create_success(
             expected_warnings=[],
             expected_errors=[
                 ValidationErrorSchema(
@@ -1537,11 +1538,11 @@ class TestValidate(ValidateDSL):
             ],
         )
 
-    def test_validate_with_obsolete_replacement_catalogue_item(self):
-        """Test validating a catalogue item with an obsolete replacement catalogue item."""
+    def test_validate_create_with_obsolete_replacement_catalogue_item(self):
+        """Test validating catalogue item data for creation with an obsolete replacement catalogue item."""
 
         obsolete_replacement_catalogue_item_id = str(ObjectId())
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
                 "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
@@ -1552,14 +1553,15 @@ class TestValidate(ValidateDSL):
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
             obsolete_replacement_catalogue_item_out_data=CATALOGUE_ITEM_OUT_DATA_NOT_OBSOLETE_NO_PROPERTIES,
         )
-        self.call_validate()
-        self.check_validate_success(expected_warnings=[], expected_errors=[])
+        self.call_validate_create()
+        self.check_validate_create_success(expected_warnings=[], expected_errors=[])
 
-    def test_validate_with_non_existent_obsolete_replacement_catalogue_item_id(self):
-        """Test validating a catalogue item with a non-existent obsolete replacement catalogue item ID."""
+    def test_validate_create_with_non_existent_obsolete_replacement_catalogue_item_id(self):
+        """Test validating catalogue item data for creation with a non-existent obsolete replacement catalogue item
+        ID."""
 
         obsolete_replacement_catalogue_item_id = str(ObjectId())
-        self.mock_validate(
+        self.mock_validate_create(
             {
                 **CATALOGUE_ITEM_DATA_OBSOLETE_NO_PROPERTIES,
                 "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
@@ -1570,8 +1572,8 @@ class TestValidate(ValidateDSL):
             manufacturer_out_data=MANUFACTURER_OUT_DATA_A,
             obsolete_replacement_catalogue_item_out_data=None,
         )
-        self.call_validate()
-        self.check_validate_success(
+        self.call_validate_create()
+        self.check_validate_create_success(
             expected_warnings=[],
             expected_errors=[
                 ValidationErrorSchema(
@@ -1584,20 +1586,20 @@ class TestValidate(ValidateDSL):
         )
 
 
-class TestBulkValidate(CatalogueItemServiceDSL):
-    """Tests for bulk validating catalogue items."""
+class TestBulkValidateCreate(CatalogueItemServiceDSL):
+    """Tests for bulk validating catalogue items data for creation."""
 
-    def test_bulk_validate(self):
+    def test_bulk_validate_create(self):
         """Test bulk validate correctly returns a list of validation results for the individual catalogue items."""
         mock_catalogue_items = [{"name": "1"}, {"name": "2"}, {"name": "3"}]
         mock_results = [
             ValidationResultSchema(index=index, warnings=[], errors=[]) for index in range(0, len(mock_catalogue_items))
         ]
-        mock_validate = MagicMock(side_effect=mock_results)
+        mock_validate_create = MagicMock(side_effect=mock_results)
 
-        with patch.object(self.catalogue_item_service, "_validate", mock_validate):
-            result = self.catalogue_item_service.bulk_validate(mock_catalogue_items)
-        assert mock_validate.call_args_list == [
+        with patch.object(self.catalogue_item_service, "_validate_create", mock_validate_create):
+            result = self.catalogue_item_service.bulk_validate_create(mock_catalogue_items)
+        assert mock_validate_create.call_args_list == [
             call(index, mock_catalogue_item) for index, mock_catalogue_item in enumerate(mock_catalogue_items)
         ]
         assert result == BulkValidationResultSchema(results=mock_results)

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -53,7 +53,11 @@ from inventory_management_system_api.schemas.catalogue_item import (
     CatalogueItemPostSchema,
     PropertyPostSchema,
 )
-from inventory_management_system_api.schemas.validation import ValidationErrorSchema, ValidationResponseSchema
+from inventory_management_system_api.schemas.validation import (
+    BulkValidationResultSchema,
+    ValidationErrorSchema,
+    ValidationResultSchema,
+)
 from inventory_management_system_api.services import utils
 from inventory_management_system_api.services.catalogue_item import CatalogueItemService
 
@@ -68,6 +72,8 @@ class CatalogueItemServiceDSL(BaseCatalogueServiceDSL):
     mock_unit_repository: Mock
     mock_setting_repository: Mock
     catalogue_item_service: CatalogueItemService
+
+    mock_session = MagicMock()
 
     @pytest.fixture(autouse=True)
     def setup(
@@ -225,7 +231,9 @@ class CreateDSL(CatalogueItemServiceDSL):
         """Calls the `CatalogueItemService` `create` method with the appropriate data from a prior call to
         `mock_create`."""
 
-        self._created_catalogue_item = self.catalogue_item_service.create(self._catalogue_item_post)
+        self._created_catalogue_item = self.catalogue_item_service.create(
+            self._catalogue_item_post, session=self.mock_session
+        )
 
     def call_create_expecting_error(self, error_type: type[BaseException]) -> None:
         """
@@ -260,7 +268,9 @@ class CreateDSL(CatalogueItemServiceDSL):
             self._catalogue_category_out.properties, self._catalogue_item_post.properties
         )
 
-        self.mock_catalogue_item_repository.create.assert_called_once_with(self._expected_catalogue_item_in)
+        self.mock_catalogue_item_repository.create.assert_called_once_with(
+            self._expected_catalogue_item_in, session=self.mock_session
+        )
 
         assert self._created_catalogue_item == self._expected_catalogue_item_out
 
@@ -1252,7 +1262,7 @@ class ValidateDSL(CatalogueItemServiceDSL):
 
     _catalogue_category_out: Optional[CatalogueCategoryOut]
     _catalogue_item_data: dict
-    _validation_response: ValidationResponseSchema
+    _validation_result: ValidationResultSchema
 
     def mock_validate(
         self,
@@ -1315,7 +1325,11 @@ class ValidateDSL(CatalogueItemServiceDSL):
         """Calls the `CatalogueItemService` `validate` method with the appropriate data from a prior call to
         `mock_validate`."""
 
-        self._validation_response = self.catalogue_item_service.validate(self._catalogue_item_data)
+        # Easier to mock a single validation than a whole list, so do proper testing with single, then have a test
+        # for multiple
+        self._validation_result = self.catalogue_item_service._validate(  # pylint:disable=protected-access
+            index=0, catalogue_item_data=self._catalogue_item_data
+        )
 
     def check_validate_success(
         self, expected_warnings: list[ValidationErrorSchema], expected_errors: list[ValidationErrorSchema]
@@ -1361,7 +1375,9 @@ class ValidateDSL(CatalogueItemServiceDSL):
                     ANY,
                 )
 
-        assert self._validation_response == ValidationResponseSchema(warnings=expected_warnings, errors=expected_errors)
+        assert self._validation_result == ValidationResultSchema(
+            index=0, warnings=expected_warnings, errors=expected_errors
+        )
 
 
 class TestValidate(ValidateDSL):
@@ -1566,3 +1582,22 @@ class TestValidate(ValidateDSL):
                 )
             ],
         )
+
+
+class TestBulkValidate(CatalogueItemServiceDSL):
+    """Tests for bulk validating catalogue items."""
+
+    def test_bulk_validate(self):
+        """Test bulk validate correctly returns a list of validation results for the individual catalogue items."""
+        mock_catalogue_items = [{"name": "1"}, {"name": "2"}, {"name": "3"}]
+        mock_results = [
+            ValidationResultSchema(index=index, warnings=[], errors=[]) for index in range(0, len(mock_catalogue_items))
+        ]
+        mock_validate = MagicMock(side_effect=mock_results)
+
+        with patch.object(self.catalogue_item_service, "_validate", mock_validate):
+            result = self.catalogue_item_service.bulk_validate(mock_catalogue_items)
+        assert mock_validate.call_args_list == [
+            call(index, mock_catalogue_item) for index, mock_catalogue_item in enumerate(mock_catalogue_items)
+        ]
+        assert result == BulkValidationResultSchema(results=mock_results)

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -384,6 +384,31 @@ class TestCreate(CreateDSL):
         )
 
 
+class TestBulkCreate(CatalogueItemServiceDSL):
+    """Tests for bulk creating catalogue items."""
+
+    def test_bulk_create(self):
+        """Test bulk create correctly creates a list of catalogue items."""
+        mock_session = MagicMock()
+        context_manager = MagicMock()
+        context_manager.__enter__.return_value = mock_session
+        mock_catalogue_items = [MagicMock(), MagicMock()]
+        mock_created_item_outs = [MagicMock() for _ in range(0, len(mock_catalogue_items))]
+        self.catalogue_item_service.create = MagicMock(side_effect=mock_created_item_outs)
+
+        with patch(
+            "inventory_management_system_api.services.catalogue_item.start_session_transaction",
+            return_value=context_manager,
+        ) as mock_start_session_transaction:
+            created_catalogue_items = self.catalogue_item_service.bulk_create(mock_catalogue_items)
+
+        mock_start_session_transaction.assert_called_once_with("creating bulk catalogue items")
+        assert self.catalogue_item_service.create.call_args_list == [
+            call(catalogue_item, session=mock_session) for catalogue_item in mock_catalogue_items
+        ]
+        assert created_catalogue_items == mock_created_item_outs
+
+
 class GetDSL(CatalogueItemServiceDSL):
     """Base class for `get` tests."""
 

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -1368,7 +1368,7 @@ class ValidateDSL(CatalogueItemServiceDSL):
                     pass
 
             if self._catalogue_category_out:
-                self.wrapped_utils.validate_properties.assert_called_once_with(
+                self.wrapped_utils.process_properties.assert_called_once_with(
                     # Use ANY for errors as its mutable and changes after running to include the actual errors
                     self._catalogue_category_out.properties,
                     property_schemas,

--- a/test/unit/services/test_catalogue_item.py
+++ b/test/unit/services/test_catalogue_item.py
@@ -25,6 +25,7 @@ from test.mock_data import (
     CATALOGUE_ITEM_OUT_DATA_NOT_OBSOLETE_NO_PROPERTIES,
     MANUFACTURER_IN_DATA_A,
     MANUFACTURER_OUT_DATA_A,
+    PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE,
     PROPERTY_DATA_NUMBER_NON_MANDATORY_WITH_MM_UNIT_42,
 )
 from test.unit.services.conftest import BaseCatalogueServiceDSL, ServiceTestHelpers
@@ -1282,8 +1283,8 @@ class TestDelete(DeleteDSL):
         )
 
 
-class ValidateDSL(CatalogueItemServiceDSL):
-    """Base class for `validate` tests."""
+class ValidateCreateDSL(CatalogueItemServiceDSL):
+    """Base class for `validate_create` tests."""
 
     _catalogue_category_out: Optional[CatalogueCategoryOut]
     _catalogue_item_data: dict
@@ -1405,7 +1406,7 @@ class ValidateDSL(CatalogueItemServiceDSL):
         )
 
 
-class TestValidateCreate(ValidateDSL):
+class TestValidateCreate(ValidateCreateDSL):
     """Tests for validating catalogue item data for creation."""
 
     def test_validate_create_with_all_properties(self):
@@ -1457,8 +1458,14 @@ class TestValidateCreate(ValidateDSL):
 
         catalogue_item_data = {
             **{"name": 42, "days_to_replace": False},
-            "catalogue_category_id": str(CATALOGUE_CATEGORY_OUT_DATA_LEAF_NO_PARENT_NO_PROPERTIES["_id"]),
-            "manufacturer_id": str(MANUFACTURER_OUT_DATA_A["_id"]),
+            "catalogue_category_id": False,
+            "manufacturer_id": 26,
+            "properties": [
+                # Avoid mandatory property error - not trying to test here
+                PROPERTY_DATA_BOOLEAN_MANDATORY_TRUE,
+                # ID gets added based on name, so use unknown so ID is missing
+                {"name": "unknown"},
+            ],
         }
         self.mock_validate_create(
             catalogue_item_data,
@@ -1469,18 +1476,27 @@ class TestValidateCreate(ValidateDSL):
         self.check_validate_create_success(
             expected_warnings=[],
             expected_errors=[
+                ValidationErrorSchema(
+                    type="string_type",
+                    loc=["catalogue_category_id"],
+                    msg="Input should be a valid string",
+                    input=False,
+                ),
+                ValidationErrorSchema(
+                    type="string_type", loc=["manufacturer_id"], msg="Input should be a valid string", input=26
+                ),
                 ValidationErrorSchema(type="string_type", loc=["name"], msg="Input should be a valid string", input=42),
                 ValidationErrorSchema(
-                    type="missing",
-                    loc=["cost_gbp"],
-                    msg="Field required",
-                    input=catalogue_item_data,
+                    type="missing", loc=["cost_gbp"], msg="Field required", input=self._catalogue_item_data
+                ),
+                ValidationErrorSchema(
+                    type="missing", loc=["is_obsolete"], msg="Field required", input=self._catalogue_item_data
                 ),
                 ValidationErrorSchema(
                     type="missing",
-                    loc=["is_obsolete"],
+                    loc=["properties", 1, "id"],
                     msg="Field required",
-                    input=catalogue_item_data,
+                    input={"name": "unknown"},
                 ),
             ],
         )

--- a/test/unit/services/test_utils.py
+++ b/test/unit/services/test_utils.py
@@ -333,9 +333,9 @@ class TestProcessProperties:
         )
 
 
-class TestValidateProperties:
+class TestProcessPropertiesWithErrorCollection:
     """
-    Tests for the `validate_properties` method.
+    Tests for the `process_properties` method but while collecting errors.
     """
 
     def assert_errors_equal(self, actual_errors: list[InitErrorDetails], expected_errors: list[dict[str, Any]]) -> None:
@@ -355,20 +355,20 @@ class TestValidateProperties:
         converted_errors = [converted_error.model_dump() for converted_error in converted_errors]
         assert converted_errors == expected_errors
 
-    def test_validate_properties(self):
+    def test_process_properties(self):
         """
-        Test `validate_properties` works correctly.
+        Test `process_properties` works correctly.
         """
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, SUPPLIED_PROPERTIES, errors)
+        utils.process_properties(DEFINED_PROPERTIES, SUPPLIED_PROPERTIES, errors)
         self.assert_errors_equal(errors, [])
 
-    def test_validate_properties_with_missing_mandatory_properties(self):
+    def test_process_properties_with_missing_mandatory_properties(self):
         """
-        Test `validate_properties` works correctly with missing mandatory properties.
+        Test `process_properties` works correctly with missing mandatory properties.
         """
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, [SUPPLIED_PROPERTIES[0]], errors)
+        utils.process_properties(DEFINED_PROPERTIES, [SUPPLIED_PROPERTIES[0]], errors)
 
         self.assert_errors_equal(
             errors,
@@ -385,30 +385,30 @@ class TestValidateProperties:
             ],
         )
 
-    def test_validate_properties_with_missing_non_mandatory_properties(self):
+    def test_process_properties_with_missing_non_mandatory_properties(self):
         """
-        Test `validate_properties` works correctly with missing non-mandatory properties.
+        Test `process_properties` works correctly with missing non-mandatory properties.
         """
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, SUPPLIED_PROPERTIES[1:4], errors)
+        utils.process_properties(DEFINED_PROPERTIES, SUPPLIED_PROPERTIES[1:4], errors)
         self.assert_errors_equal(errors, [])
 
-    def test_validate_properties_with_undefined_properties(self):
+    def test_process_properties_with_undefined_properties(self):
         """
-        Test `validate_properties` works correctly with supplied properties that have not been defined.
+        Test `process_properties` works correctly with supplied properties that have not been defined.
         """
         supplied_properties = SUPPLIED_PROPERTIES + [PropertyPostSchema(id=str(ObjectId()), name="Property F", value=1)]
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(errors, [])
 
-    def test_validate_properties_with_none_non_mandatory_properties(self):
+    def test_process_properties_with_none_non_mandatory_properties(self):
         """
-        Test `validate_properties` works correctly when explicitly giving a value of None
+        Test `process_properties` works correctly when explicitly giving a value of None
         for non-mandatory properties.
         """
         errors = []
-        utils.validate_properties(
+        utils.process_properties(
             DEFINED_PROPERTIES,
             [
                 PropertyPostSchema(
@@ -430,25 +430,25 @@ class TestValidateProperties:
         )
         self.assert_errors_equal(errors, [])
 
-    def test_validate_properties_with_supplied_properties_and_no_defined_properties(self):
+    def test_process_properties_with_supplied_properties_and_no_defined_properties(self):
         """
-        Test `validate_properties` works correctly with supplied properties but no defined properties.
-        """
-        errors = []
-        utils.validate_properties([], SUPPLIED_PROPERTIES, errors)
-        self.assert_errors_equal(errors, [])
-
-    def test_validate_properties_without_properties(self):
-        """
-        Test `validate_properties` works correctly without defined and supplied properties.
+        Test `process_properties` works correctly with supplied properties but no defined properties.
         """
         errors = []
-        utils.validate_properties([], [], errors)
+        utils.process_properties([], SUPPLIED_PROPERTIES, errors)
         self.assert_errors_equal(errors, [])
 
-    def test_validate_properties_with_invalid_value_type_for_string_property(self):
+    def test_process_properties_without_properties(self):
         """
-        Test `validate_properties` works correctly with invalid value type for a string catalogue item
+        Test `process_properties` works correctly without defined and supplied properties.
+        """
+        errors = []
+        utils.process_properties([], [], errors)
+        self.assert_errors_equal(errors, [])
+
+    def test_process_properties_with_invalid_value_type_for_string_property(self):
+        """
+        Test `process_properties` works correctly with invalid value type for a string catalogue item
         property.
         """
         supplied_properties = [
@@ -460,7 +460,7 @@ class TestValidateProperties:
         ]
 
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(
             errors,
             [
@@ -478,9 +478,9 @@ class TestValidateProperties:
             ],
         )
 
-    def test_validate_properties_with_invalid_value_type_for_number_property(self):
+    def test_process_properties_with_invalid_value_type_for_number_property(self):
         """
-        Test `validate_properties` works correctly with invalid value type for a number catalogue item
+        Test `process_properties` works correctly with invalid value type for a number catalogue item
         property.
         """
         supplied_properties = [
@@ -492,7 +492,7 @@ class TestValidateProperties:
         ]
 
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(
             errors,
             [
@@ -510,9 +510,9 @@ class TestValidateProperties:
             ],
         )
 
-    def test_validate_properties_with_invalid_value_type_for_boolean_property(self):
+    def test_process_properties_with_invalid_value_type_for_boolean_property(self):
         """
-        Test `validate_properties` works correctly with invalid value type for a boolean catalogue item
+        Test `process_properties` works correctly with invalid value type for a boolean catalogue item
         property.
         """
         supplied_properties = [
@@ -524,7 +524,7 @@ class TestValidateProperties:
         ]
 
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(
             errors,
             [
@@ -542,9 +542,9 @@ class TestValidateProperties:
             ],
         )
 
-    def test_validate_properties_with_invalid_value_type_for_mandatory_property(self):
+    def test_process_properties_with_invalid_value_type_for_mandatory_property(self):
         """
-        Test `validate_properties` works correctly with a None value given for a mandatory property.
+        Test `process_properties` works correctly with a None value given for a mandatory property.
         """
         supplied_properties = [
             PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
@@ -555,7 +555,7 @@ class TestValidateProperties:
         ]
 
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
 
         self.assert_errors_equal(
             errors,
@@ -573,9 +573,9 @@ class TestValidateProperties:
             ],
         )
 
-    def test_validate_properties_with_invalid_allowed_value_list_number(self):
+    def test_process_properties_with_invalid_allowed_value_list_number(self):
         """
-        Test `validate_properties` works correctly when given an invalid value for a number property with a specific
+        Test `process_properties` works correctly when given an invalid value for a number property with a specific
         list of allowed values
         """
         supplied_properties = [
@@ -587,7 +587,7 @@ class TestValidateProperties:
         ]
 
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(
             errors,
             [
@@ -605,9 +605,9 @@ class TestValidateProperties:
             ],
         )
 
-    def test_validate_properties_with_invalid_allowed_value_list_string(self):
+    def test_process_properties_with_invalid_allowed_value_list_string(self):
         """
-        Test `validate_properties` works correctly when given an invalid value for a string property with a specific
+        Test `process_properties` works correctly when given an invalid value for a string property with a specific
         list of allowed values
         """
         supplied_properties = [
@@ -619,7 +619,7 @@ class TestValidateProperties:
         ]
 
         errors = []
-        utils.validate_properties(DEFINED_PROPERTIES, supplied_properties, errors)
+        utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(
             errors,
             [

--- a/test/unit/services/test_utils.py
+++ b/test/unit/services/test_utils.py
@@ -145,7 +145,7 @@ class TestProcessProperties:
         """
         Test `process_properties` works correctly with supplied properties that have not been defined.
         """
-        supplied_properties = SUPPLIED_PROPERTIES + [PropertyPostSchema(id=str(ObjectId()), name="Property F", value=1)]
+        supplied_properties = SUPPLIED_PROPERTIES + [PropertyPostSchema(id=str(ObjectId()), value=1)]
         result = utils.process_properties(DEFINED_PROPERTIES, supplied_properties)
         assert result == EXPECTED_PROCESSED_PROPERTIES
 
@@ -158,19 +158,16 @@ class TestProcessProperties:
             DEFINED_PROPERTIES,
             [
                 PropertyPostSchema(
-                    id=DEFINED_PROPERTIES[0].id, name="Property A", value=None, unit_id=DEFINED_PROPERTIES[0].unit_id
+                    id=DEFINED_PROPERTIES[0].id,
+                    value=None,
                 ),
-                PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
                 PropertyPostSchema(
                     id=DEFINED_PROPERTIES[2].id,
-                    name="Property C",
                     value="20x15x10",
-                    unit_id=DEFINED_PROPERTIES[2].unit_id,
                 ),
-                PropertyPostSchema(
-                    id=DEFINED_PROPERTIES[3].id, name="Property D", value=2, unit_id=DEFINED_PROPERTIES[3].unit_id
-                ),
-                PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value=None),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value=None),
             ],
         )
         assert result == [
@@ -219,11 +216,11 @@ class TestProcessProperties:
         property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value=True),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value=True),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         with pytest.raises(InvalidPropertyTypeError) as exc:

--- a/test/unit/services/test_utils.py
+++ b/test/unit/services/test_utils.py
@@ -48,13 +48,11 @@ DEFINED_PROPERTIES = [
 ]
 
 SUPPLIED_PROPERTIES = [
-    PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20, unit_id=DEFINED_PROPERTIES[0].unit_id),
-    PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-    PropertyPostSchema(
-        id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10", unit_id=DEFINED_PROPERTIES[2].unit_id
-    ),
-    PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2, unit_id=DEFINED_PROPERTIES[3].unit_id),
-    PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+    PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+    PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+    PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+    PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+    PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
 ]
 
 EXPECTED_PROCESSED_PROPERTIES = [
@@ -241,11 +239,11 @@ class TestProcessProperties:
         property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value="20"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value="20"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         with pytest.raises(InvalidPropertyTypeError) as exc:
@@ -261,11 +259,11 @@ class TestProcessProperties:
         property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value="False"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value="False"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         with pytest.raises(InvalidPropertyTypeError) as exc:
@@ -280,11 +278,11 @@ class TestProcessProperties:
         Test `process_properties` works correctly with a None value given for a mandatory property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value=None),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value=None),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         with pytest.raises(InvalidPropertyTypeError) as exc:
@@ -298,11 +296,11 @@ class TestProcessProperties:
         of allowed values
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=10),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=10),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         with pytest.raises(InvalidPropertyTypeError) as exc:
@@ -318,11 +316,11 @@ class TestProcessProperties:
         list of allowed values
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=4),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="invalid"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=4),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="invalid"),
         ]
 
         with pytest.raises(InvalidPropertyTypeError) as exc:
@@ -397,7 +395,7 @@ class TestProcessPropertiesWithErrorCollection:
         """
         Test `process_properties` works correctly with supplied properties that have not been defined.
         """
-        supplied_properties = SUPPLIED_PROPERTIES + [PropertyPostSchema(id=str(ObjectId()), name="Property F", value=1)]
+        supplied_properties = SUPPLIED_PROPERTIES + [PropertyPostSchema(id=str(ObjectId()), value=1)]
         errors = []
         utils.process_properties(DEFINED_PROPERTIES, supplied_properties, errors)
         self.assert_errors_equal(errors, [])
@@ -411,20 +409,14 @@ class TestProcessPropertiesWithErrorCollection:
         utils.process_properties(
             DEFINED_PROPERTIES,
             [
-                PropertyPostSchema(
-                    id=DEFINED_PROPERTIES[0].id, name="Property A", value=None, unit_id=DEFINED_PROPERTIES[0].unit_id
-                ),
-                PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=None),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
                 PropertyPostSchema(
                     id=DEFINED_PROPERTIES[2].id,
-                    name="Property C",
                     value="20x15x10",
-                    unit_id=DEFINED_PROPERTIES[2].unit_id,
                 ),
-                PropertyPostSchema(
-                    id=DEFINED_PROPERTIES[3].id, name="Property D", value=2, unit_id=DEFINED_PROPERTIES[3].unit_id
-                ),
-                PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value=None),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+                PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value=None),
             ],
             errors,
         )
@@ -452,11 +444,11 @@ class TestProcessPropertiesWithErrorCollection:
         property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value=True),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value=True),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         errors = []
@@ -484,11 +476,11 @@ class TestProcessPropertiesWithErrorCollection:
         property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value="20"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value="20"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         errors = []
@@ -516,11 +508,11 @@ class TestProcessPropertiesWithErrorCollection:
         property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value="False"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value="False"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         errors = []
@@ -547,11 +539,11 @@ class TestProcessPropertiesWithErrorCollection:
         Test `process_properties` works correctly with a None value given for a mandatory property.
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value=None),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=2),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value=None),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=2),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         errors = []
@@ -579,11 +571,11 @@ class TestProcessPropertiesWithErrorCollection:
         list of allowed values
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=10),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="red"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=10),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="red"),
         ]
 
         errors = []
@@ -611,11 +603,11 @@ class TestProcessPropertiesWithErrorCollection:
         list of allowed values
         """
         supplied_properties = [
-            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, name="Property A", value=20),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, name="Property B", value=False),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, name="Property C", value="20x15x10"),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, name="Property D", value=4),
-            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, name="Property E", value="invalid"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[0].id, value=20),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[1].id, value=False),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[2].id, value="20x15x10"),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[3].id, value=4),
+            PropertyPostSchema(id=DEFINED_PROPERTIES[4].id, value="invalid"),
         ]
 
         errors = []


### PR DESCRIPTION
## Description

Adds a POST `/catalogue-items/bulk` endpoint taking a list of catalogue items and creating them all at once in a transaction. This endpoint fails fast resulting in it being harder to determine which item specifically caused an error e.g. if a manufactuerer is not found, it will fail but it wont say on which item. This is made up for by the validate endpoint that all validation errors it finds.

## Other changes
- Changes `/catalogue-items/validate` to `/catalogue-items/bulk-validate`. This is the same as before, but now takes a list so more than one catalogue item can be validated in a single request.

## Notes

- The implementation is done as the simplest implementation possible reusing existing validation logic that is already part of the creation request. The most optimal solution would instead to process the group of catalouge items and then do an insert many, having done all fail fast validation before hand, but that is a much larger change and seemed unecessary at this point for a one off new feature. (It would also effect history)
- E2E tests only test some of the creation logic e.g. There are various ways a `InvalidPropertyTypeError` can occur, but its only testing one as it just needs to check the catch/raise logic in the router. The standard create tests are otherwise testing the rest of the logic as the existing `create` methods are being used in the `bulk_create` anyway.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking

Closes #764
