### PR TITLE
Revert "Update uv-build requirement from <0.12.0,>=0.11.13 to >=0.11.23,<0.12.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ exclude-newer = "7 days"
 inventory-management-system-api = { workspace = true }
 
 [build-system]
-requires = ["uv_build>=0.11.23,<0.12.0"]
+requires = ["uv_build>=0.11.13,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
## Description
Reverts https://github.com/ral-facilities/inventory-management-system-api/pull/790 because the version to which it was bumped is not 7 days older, see comment [here](https://github.com/ral-facilities/inventory-management-system-api/pull/790#issuecomment-4781072568) for more.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage