### PR TITLE
Add `.python-version` file to `Dockerfile` stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock .python-version README.md ./
 
 ########################################################################################################################
 # Stage for local development


### PR DESCRIPTION
## Description
Adds the `.python-version‎` file which was missing from the `Dockerfile` stages. This now results in an the image failing to build if a if a different base python version image is used to that in the file. 

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #794 