### PR TITLE
Replace invalid action error with NonLeafCatalogueCategoryError

### DIFF
--- a/inventory_management_system_api/routers/v1/catalogue_category.py
+++ b/inventory_management_system_api/routers/v1/catalogue_category.py
@@ -25,6 +25,7 @@ from inventory_management_system_api.core.exceptions import (
     LeafCatalogueCategoryError,
     MissingRecordError,
     WriteConflictError,
+    NonLeafCatalogueCategoryError,
 )
 from inventory_management_system_api.schemas.breadcrumbs import BreadcrumbsGetSchema
 from inventory_management_system_api.schemas.catalogue_category import (
@@ -275,6 +276,10 @@ def create_property(
         message = str(exc)
         logger.exception(message)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message) from exc
+    except NonLeafCatalogueCategoryError as exc:
+        message = str(exc)
+        logger.exception(message)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=message) from exc
 
 
 @router.patch(

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -8,7 +8,7 @@ from typing import Annotated, Optional
 from fastapi import Depends
 
 from inventory_management_system_api.core.database import start_session_transaction
-from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
+from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError, NonLeafCatalogueCategoryError
 from inventory_management_system_api.models.catalogue_category import (
     AllowedValues,
     CatalogueCategoryPropertyIn,
@@ -67,7 +67,7 @@ class CatalogueCategoryPropertyService:
         :param catalogue_category_property: Property to add (with additional info on how to perform the migration if
                                         necessary)
         :raises InvalidActionError: If attempting to add a mandatory property without a default_value being specified
-                                    or if the catalogue category is not a leaf
+        :raises NonLeafCatalogueCategoryError: If the catalogue category is not a leaf
         :raises MissingRecordError: If the catalogue category doesn't exist
         :return: The created property as defined at the catalogue category level
         """
@@ -84,7 +84,7 @@ class CatalogueCategoryPropertyService:
 
         # Must be a leaf catalogue category in order to have properties
         if not stored_catalogue_category.is_leaf:
-            raise InvalidActionError("Cannot add a property to a non-leaf catalogue category")
+            raise NonLeafCatalogueCategoryError("Cannot add a property to a non-leaf catalogue category")
 
         # Ensure the property is actually valid
         utils.check_duplicate_property_names(stored_catalogue_category.properties + [catalogue_category_property])

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -8,7 +8,11 @@ from typing import Annotated, Optional
 from fastapi import Depends
 
 from inventory_management_system_api.core.database import start_session_transaction
-from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError, NonLeafCatalogueCategoryError
+from inventory_management_system_api.core.exceptions import (
+    InvalidActionError,
+    MissingRecordError,
+    NonLeafCatalogueCategoryError,
+)
 from inventory_management_system_api.models.catalogue_category import (
     AllowedValues,
     CatalogueCategoryPropertyIn,

--- a/inventory_management_system_api/services/catalogue_category_property.py
+++ b/inventory_management_system_api/services/catalogue_category_property.py
@@ -71,7 +71,7 @@ class CatalogueCategoryPropertyService:
         :param catalogue_category_property: Property to add (with additional info on how to perform the migration if
                                         necessary)
         :raises InvalidActionError: If attempting to add a mandatory property without a default_value being specified
-        :raises NonLeafCatalogueCategoryError: If the catalogue category is not a leaf
+        :raises NonLeafCatalogueCategoryError: If the catalogue category is not a leaf category.
         :raises MissingRecordError: If the catalogue category doesn't exist
         :return: The created property as defined at the catalogue category level
         """

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -26,7 +26,11 @@ import pytest
 from bson import ObjectId
 
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
-from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError, NonLeafCatalogueCategoryError
+from inventory_management_system_api.core.exceptions import (
+    InvalidActionError,
+    MissingRecordError,
+    NonLeafCatalogueCategoryError,
+)
 from inventory_management_system_api.models.catalogue_category import (
     CatalogueCategoryIn,
     CatalogueCategoryOut,

--- a/test/unit/services/test_catalogue_category_property.py
+++ b/test/unit/services/test_catalogue_category_property.py
@@ -26,7 +26,7 @@ import pytest
 from bson import ObjectId
 
 from inventory_management_system_api.core.custom_object_id import CustomObjectId
-from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError
+from inventory_management_system_api.core.exceptions import InvalidActionError, MissingRecordError, NonLeafCatalogueCategoryError
 from inventory_management_system_api.models.catalogue_category import (
     CatalogueCategoryIn,
     CatalogueCategoryOut,
@@ -340,7 +340,7 @@ class TestCreate(CreateDSL):
             CATALOGUE_CATEGORY_PROPERTY_DATA_NUMBER_NON_MANDATORY,
             catalogue_category_in_data=CATALOGUE_CATEGORY_IN_DATA_NON_LEAF_NO_PARENT_NO_PROPERTIES_A,
         )
-        self.call_create_expecting_error(InvalidActionError)
+        self.call_create_expecting_error(NonLeafCatalogueCategoryError)
         self.check_create_failed_with_exception("Cannot add a property to a non-leaf catalogue category")
 
 


### PR DESCRIPTION
## Description
I changed a logic error where it produced the wrong type of error, it should have produced a NonLeafCatalogueCategoryError but instead it outputted and InvalidActionError to the correct error which is NonLeafCatalogueCategoryError.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

Detail testing
- [x] Get the list of Catalogue Categories in the swagger docs
- [x] Choose a non leaf Catalogue Category (where `is_leaf` is false) 
- [x] Copy the ID of this Catalogue Categoory
- [x] Go to the properties endpoint
- [x] Add the non-leaf ID and remove the Allowed values field (if you do not want to submit any data to test)
- [x] Submit and the error should be `422: Cannot add a property to a non-leaf catalogue category`  

## Agile board tracking

closes #381 
